### PR TITLE
Harden scripted installs with external Docker env staging and runtime preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The repository also contains the local-only HTTP and Docker components required 
     installs the MSIX, starts the `openclaw-core` and `openclaw-agent`
     compose stack, and writes a single-record install manifest for later
     rollback
+  - operator-managed Docker env files stay outside `artifacts/publish/<version>`
+    and can be supplied with `-DockerEnvFilePath` and `-AnthropicEnvFilePath`
   - `Uninstall.ps1` reads the install record and reverses the install
 - Supports a complete local solution path beyond the bridge transport:
   - `OpenClaw.HostAdapter` on Windows, `OpenClaw.Core` in Docker Desktop, and the `openclaw-agent` assistant service
@@ -317,6 +319,10 @@ Validate the full container path (container health, endpoints, HostAdapter reach
 ```powershell
 pwsh -NoProfile -File scripts/Invoke-OpenClawContainerPathValidation.ps1 -PassThru
 ```
+
+When `-CoreBaseUrl` is omitted, the validation script reads
+`OPENCLAW_HTTP_PORT` from `-EnvFilePath` (default `./.env`). For example,
+`OPENCLAW_HTTP_PORT=8081` validates Core at `http://127.0.0.1:8081`.
 
 The dashboard at `http://127.0.0.1:${OPENCLAW_AGENT_PORT:-18789}/` authenticates against the `OPENCLAW_GATEWAY_TOKEN` in `.env` produced by the onboarding script. Open the URL after the container is healthy; the dashboard reads the token without an operator paste step.
 

--- a/docs/mailbridge-runbook.md
+++ b/docs/mailbridge-runbook.md
@@ -450,6 +450,11 @@ Validate the container path. The validation script runs the same endpoint checks
 .\scripts\Invoke-OpenClawContainerPathValidation.ps1
 ```
 
+When `-CoreBaseUrl` is omitted, the validation script reads
+`OPENCLAW_HTTP_PORT` from `-EnvFilePath` (default `./.env`). If `.env`
+contains `OPENCLAW_HTTP_PORT=8081`, the Core probes target
+`http://127.0.0.1:8081`.
+
 Expected behavior:
 
 - `OverallResult` is `Expected` only when every container and endpoint check returns the expected response.
@@ -478,6 +483,71 @@ If the HostAdapter or Docker path is unavailable, continue using:
 ```
 
 The Windows bridge and client remain the canonical fallback path for troubleshooting.
+
+## Install Path D: Scripted Bundle Install
+
+Use this path for a bundle produced by `scripts/Publish.ps1`. The bundle root
+under `artifacts/publish/<version>/` is manifest-controlled. Do not add
+machine-local files such as `docker/.env` or `docker/secrets/.env.anthropic` to
+that directory.
+
+Prepare version-neutral operator configuration outside the publish bundle:
+
+```powershell
+$operatorConfig = Join-Path $env:LOCALAPPDATA 'OpenClaw\operator-config'
+New-Item -ItemType Directory -Force -Path (Join-Path $operatorConfig 'secrets') | Out-Null
+Copy-Item .\artifacts\publish\1.0.0.3\docker\.env.example (Join-Path $operatorConfig '.env') -Force
+notepad (Join-Path $operatorConfig '.env')
+notepad (Join-Path $operatorConfig 'secrets\.env.anthropic')
+```
+
+Configuration requirements:
+
+- The operator `.env` file must contain the same Docker settings normally used
+  by compose, including `OPENCLAW_GATEWAY_TOKEN` after onboarding.
+- The Anthropic env file must contain `ANTHROPIC_API_KEY=<real key>`.
+- Keep these files out of `artifacts/publish/<version>/`; the installer copies
+  them into the installed Docker directory after manifest verification.
+- When Docker is enabled, `Install.ps1` fails before MSIX installation if the
+  installed Docker directory does not have `secrets/.env.anthropic`.
+
+Before installing, confirm that both operator-managed files exist:
+
+```powershell
+Test-Path (Join-Path $operatorConfig '.env')
+Test-Path (Join-Path $operatorConfig 'secrets\.env.anthropic')
+```
+
+Both commands must return `True`. If either returns `False`, create or correct
+the missing file before running `Install.ps1`.
+
+Run the installer from the bundle directory and pass the operator-managed files:
+
+```powershell
+$bundle = 'C:\Users\DanMoisan\repos\open-claw-bridge\artifacts\publish\1.0.0.5'
+Set-Location $bundle
+.\Install.ps1 `
+  -DockerEnvFilePath (Join-Path $operatorConfig '.env') `
+  -AnthropicEnvFilePath (Join-Path $operatorConfig 'secrets\.env.anthropic')
+```
+
+If a prior attempt failed after creating `%LOCALAPPDATA%\OpenClaw\<version>\`,
+rerun the installer with `-Force` and the same env-file parameters:
+
+```powershell
+.\Install.ps1 -Force `
+  -DockerEnvFilePath (Join-Path $operatorConfig '.env') `
+  -AnthropicEnvFilePath (Join-Path $operatorConfig 'secrets\.env.anthropic')
+```
+
+If the Docker stage is intentionally deferred, run:
+
+```powershell
+.\Install.ps1 -SkipDocker
+```
+
+Then place the operator env files under
+`%LOCALAPPDATA%\OpenClaw\<version>\docker\` before starting compose manually.
 
 ## OpenClaw Agent (Required)
 
@@ -514,6 +584,10 @@ Run the aggregated validation script. It performs container inspection, `/health
 ```powershell
 pwsh -NoProfile -File scripts/Invoke-OpenClawContainerPathValidation.ps1 -PassThru
 ```
+
+When `-CoreBaseUrl` is omitted, the script derives the Core probe URL from
+`OPENCLAW_HTTP_PORT` in the selected `.env`; `OPENCLAW_HTTP_PORT=8081`
+resolves to `http://127.0.0.1:8081`.
 
 `OverallResult: Expected` means every probe passed. `OverallResult: Unexpected` will list the specific failing probes in `SupportingDiagnostics`.
 
@@ -589,5 +663,6 @@ Record these checks separately after the scripted suites pass:
 | Safe mode seems to hide sender or preview fields | Bridge is operating as designed | Keep `safe` mode if privacy is required, or switch to `enhanced` only after operator approval. |
 | `No prior install recorded` when running `Uninstall.ps1` | `%LOCALAPPDATA%\OpenClaw\install-record.json` is absent | Confirm that an install was performed via `Install.ps1`. If the install was performed via Path A or Path B, use the matching uninstall path instead (`uninstall-mailbridge.ps1` for Path A; `Get-AppxPackage ... | Remove-AppxPackage` for Path B). |
 | `Docker Desktop is not running or not installed. Start Docker Desktop and retry, or pass -SkipDocker to skip the container stage.` when running `Install.ps1` | `docker info` returned a non-zero exit code | Start Docker Desktop and rerun `Install.ps1`. If a docker-free install is acceptable, pass `-SkipDocker`; `Uninstall.ps1` later honors the recorded `skipDocker = true` and skips the compose-down step. |
-| `Manifest integrity check failed for bundle '<path>'. Discrepancies: ...` when running `Install.ps1` | One or more files under the bundle root do not match `manifest.json` by size or SHA-256, or on-disk files are absent from the manifest | Re-publish the bundle with `scripts\Publish.ps1` and retry. No destination folder is created when manifest integrity fails, so the host is left in a clean pre-install state. |
+| `Required Docker secret file not found at '<path>\docker\secrets\.env.anthropic'...` when running `Install.ps1` | Docker installation was requested, but the Anthropic env file was not supplied to the installed Docker directory | Keep the secret outside the publish bundle and rerun `Install.ps1` with `-AnthropicEnvFilePath <operator-config>\secrets\.env.anthropic`, or pass `-SkipDocker` and stage Docker configuration manually before starting compose. |
+| `Manifest integrity check failed for bundle '<path>'. Discrepancies: ...` when running `Install.ps1` | One or more files under the bundle root do not match `manifest.json` by size or SHA-256, or on-disk files are absent from the manifest. This includes manually added files such as `docker/.env` or `docker/secrets/.env.anthropic`. | Remove machine-local files from `artifacts/publish/<version>/`. Keep operator env files outside the bundle and pass them with `Install.ps1 -DockerEnvFilePath ... -AnthropicEnvFilePath ...`, or re-publish the bundle with `scripts\Publish.ps1` if packaged files were changed. No destination folder is created when manifest integrity fails. |
 | `manifest.json not found at '<path>\manifest.json'. Ensure Install.ps1 is executed from a bundle directory produced by Publish.ps1...` when running `Install.ps1` | The script resolved the bundle root from `$PSScriptRoot` (or `-SourcePath`) but no `manifest.json` sits at that root | Ensure the script is being run from the bundle directory produced by `Publish.ps1` (i.e. `cd artifacts/publish/<version>; .\Install.ps1`), not from the repo's `scripts/` directory. Pass `-SourcePath` only to override for dev/test scenarios. |

--- a/scripts/Install.Helpers.psm1
+++ b/scripts/Install.Helpers.psm1
@@ -242,6 +242,7 @@ function Invoke-MsixRemove {
     [CmdletBinding(SupportsShouldProcess = $true)]
     param(
         [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [string]$PackageFullName
     )
 
@@ -250,8 +251,9 @@ function Invoke-MsixRemove {
         return
     }
 
-    if ($PSCmdlet.ShouldProcess($PackageFullName, 'Remove-AppxPackage')) {
-        Remove-AppxPackage -Package $PackageFullName
+    $targetPackageFullName = if ([string]::IsNullOrWhiteSpace($PackageFullName)) { $pkg.PackageFullName } else { $PackageFullName }
+    if ($PSCmdlet.ShouldProcess($targetPackageFullName, 'Remove-AppxPackage')) {
+        Remove-AppxPackage -Package $targetPackageFullName
     }
 }
 
@@ -367,7 +369,7 @@ function Wait-ComposeHealthy {
     }
     $failing = $lastState.Keys |
         Where-Object { $lastState[$_].State -ne 'running' -or (-not [string]::IsNullOrEmpty($lastState[$_].Health) -and $lastState[$_].Health -ne 'healthy') } |
-        Select-Object -First 1
+            Select-Object -First 1
     if (-not $failing) {
         $failing = 'openclaw-core'
     }

--- a/scripts/Install.ps1
+++ b/scripts/Install.ps1
@@ -42,6 +42,17 @@
     install record captures skipDocker = true so Uninstall.ps1 mirrors the
     skip.
 
+.PARAMETER DockerEnvFilePath
+    Optional operator-managed Docker .env file to copy into the installed
+    docker directory after bundle manifest validation. Do not place this file
+    inside artifacts/publish/<version>; that directory is manifest-controlled.
+
+.PARAMETER AnthropicEnvFilePath
+    Optional operator-managed Anthropic env file to copy to
+    docker/secrets/.env.anthropic in the installed docker directory after
+    bundle manifest validation. Do not place this file inside
+    artifacts/publish/<version>; that directory is manifest-controlled.
+
 .PARAMETER Force
     Performs a full uninstall-then-install against any prior install of the
     same version (compose down, remove MSIX, remove destination folder,
@@ -56,6 +67,11 @@
 .EXAMPLE
     .\Install.ps1 -SkipDocker
     Installs only the MSIX; records skipDocker = true.
+
+.EXAMPLE
+    .\Install.ps1 -DockerEnvFilePath "$env:LOCALAPPDATA\OpenClaw\operator-config\.env" -AnthropicEnvFilePath "$env:LOCALAPPDATA\OpenClaw\operator-config\secrets\.env.anthropic"
+    Installs the bundle and stages operator-managed Docker env files from a
+    version-neutral local configuration directory.
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
@@ -64,6 +80,10 @@ param(
     [switch]$AllowUnsigned,
 
     [switch]$SkipDocker,
+
+    [string]$DockerEnvFilePath,
+
+    [string]$AnthropicEnvFilePath,
 
     [switch]$Force
 )
@@ -84,6 +104,192 @@ if (-not (Get-Command -Name 'Test-IsElevatedAdmin' -ErrorAction SilentlyContinue
     }
 }
 
+function Assert-OptionalInputFile {
+    [CmdletBinding()]
+    param(
+        [AllowEmptyString()]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ParameterName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "The file supplied by -$ParameterName was not found at '$Path'. Keep operator env files outside artifacts/publish/<version> and pass their local paths to Install.ps1."
+    }
+}
+
+function Copy-OperatorDockerConfiguration {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DestDockerDir,
+
+        [AllowEmptyString()]
+        [string]$DockerEnvFilePath,
+
+        [AllowEmptyString()]
+        [string]$AnthropicEnvFilePath
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($DockerEnvFilePath)) {
+        $destEnv = Join-Path $DestDockerDir '.env'
+        Write-Information "[install:env] Copying operator Docker env file to $destEnv" -InformationAction Continue
+        Copy-Item -LiteralPath $DockerEnvFilePath -Destination $destEnv -Force
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($AnthropicEnvFilePath)) {
+        $destSecretsDir = Join-Path $DestDockerDir 'secrets'
+        $destAnthropicEnv = Join-Path $destSecretsDir '.env.anthropic'
+        Write-Information "[install:env] Copying operator Anthropic env file to $destAnthropicEnv" -InformationAction Continue
+        $null = New-Item -ItemType Directory -Path $destSecretsDir -Force
+        Copy-Item -LiteralPath $AnthropicEnvFilePath -Destination $destAnthropicEnv -Force
+    }
+}
+
+function Assert-DockerRuntimeInput {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DestDockerDir
+    )
+
+    $anthropicEnvPath = Join-Path $DestDockerDir 'secrets/.env.anthropic'
+    if (-not (Test-Path -LiteralPath $anthropicEnvPath)) {
+        throw "Required Docker secret file not found at '$anthropicEnvPath'. Keep the file outside artifacts/publish/<version> and pass -AnthropicEnvFilePath to Install.ps1, or pass -SkipDocker and stage Docker configuration before starting compose manually."
+    }
+}
+
+function Get-InstallEnvFileMap {
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$EnvFilePath
+    )
+
+    $map = @{}
+    if (-not (Test-Path -LiteralPath $EnvFilePath)) {
+        return $map
+    }
+
+    $lines = @(Get-Content -LiteralPath $EnvFilePath)
+    foreach ($line in $lines) {
+        if ($null -eq $line) {
+            continue
+        }
+
+        $trimmed = $line.Trim()
+        if ($trimmed.Length -eq 0 -or $trimmed.StartsWith('#')) {
+            continue
+        }
+
+        $equalsIndex = $trimmed.IndexOf('=')
+        if ($equalsIndex -lt 1) {
+            continue
+        }
+
+        $key = $trimmed.Substring(0, $equalsIndex).Trim()
+        $value = $trimmed.Substring($equalsIndex + 1).Trim().Trim([char[]]@('"', "'"))
+        $map[$key] = $value
+    }
+
+    return $map
+}
+
+function Get-InstallEndpointUri {
+    [CmdletBinding()]
+    [OutputType([uri])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [uri]$BaseUri,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $builder = [UriBuilder]::new($BaseUri)
+    $basePath = $builder.Path.TrimEnd('/')
+    $relativePath = $Path.TrimStart('/')
+    $builder.Path = if ([string]::IsNullOrWhiteSpace($basePath)) {
+        $relativePath
+    } else {
+        '{0}/{1}' -f $basePath, $relativePath
+    }
+
+    return $builder.Uri
+}
+
+function Get-HostAdapterPreflightUri {
+    [CmdletBinding()]
+    [OutputType([uri])]
+    param(
+        [hashtable]$EnvMap
+    )
+
+    $baseUrl = 'http://host.docker.internal:4319/v1'
+    if ($EnvMap -and $EnvMap.ContainsKey('OpenClaw__HostAdapter__BaseUrl') -and -not [string]::IsNullOrWhiteSpace([string]$EnvMap['OpenClaw__HostAdapter__BaseUrl'])) {
+        $baseUrl = [string]$EnvMap['OpenClaw__HostAdapter__BaseUrl']
+    }
+
+    try {
+        $builder = [UriBuilder]::new([uri]$baseUrl)
+    } catch {
+        throw "OpenClaw__HostAdapter__BaseUrl in the installed docker .env is not a valid URI: '$baseUrl'."
+    }
+
+    if ($builder.Host -eq 'host.docker.internal') {
+        $builder.Host = '127.0.0.1'
+    }
+
+    return Get-InstallEndpointUri -BaseUri $builder.Uri -Path '/status'
+}
+
+function Assert-HostAdapterRuntimePreflight {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DestDockerDir
+    )
+
+    $envFilePath = Join-Path $DestDockerDir '.env'
+    $envMap = Get-InstallEnvFileMap -EnvFilePath $envFilePath
+    $tokenFilePath = 'C:\ProgramData\OpenClaw\HostAdapter\adapter.token'
+    if ($envMap.ContainsKey('HOSTADAPTER_TOKEN_FILE') -and -not [string]::IsNullOrWhiteSpace([string]$envMap['HOSTADAPTER_TOKEN_FILE'])) {
+        $tokenFilePath = [Environment]::ExpandEnvironmentVariables([string]$envMap['HOSTADAPTER_TOKEN_FILE'])
+    }
+
+    if (-not (Test-Path -LiteralPath $tokenFilePath)) {
+        throw "HostAdapter preflight failed before starting Docker. Token file not found at '$tokenFilePath'. Provision the HostAdapter token file, start OpenClaw.HostAdapter and OpenClaw.MailBridge, then retry; or pass -SkipDocker to skip the container stage."
+    }
+
+    $token = (Get-Content -LiteralPath $tokenFilePath -Raw).Trim()
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        throw "HostAdapter preflight failed before starting Docker. Token file '$tokenFilePath' is empty. Provision a non-empty HostAdapter token, start OpenClaw.HostAdapter and OpenClaw.MailBridge, then retry; or pass -SkipDocker to skip the container stage."
+    }
+
+    $statusUri = Get-HostAdapterPreflightUri -EnvMap $envMap
+    try {
+        $response = Invoke-WebRequest `
+            -Uri $statusUri `
+            -Method Get `
+            -Headers @{ Authorization = "Bearer $token" } `
+            -UseBasicParsing `
+            -SkipHttpErrorCheck `
+            -TimeoutSec 10
+    } catch {
+        throw "HostAdapter preflight failed before starting Docker. GET $statusUri was unreachable: $($_.Exception.Message). Start OpenClaw.HostAdapter and OpenClaw.MailBridge, then retry; or pass -SkipDocker to skip the container stage."
+    }
+
+    if ([int]$response.StatusCode -ne 200) {
+        throw "HostAdapter preflight failed before starting Docker. GET $statusUri returned HTTP $($response.StatusCode). Confirm OpenClaw.HostAdapter is running, the token is valid, and OpenClaw.MailBridge is running, then retry; or pass -SkipDocker to skip the container stage."
+    }
+}
+
 # --- Main (only runs when executed directly, not when dot-sourced for tests) ---
 if ($MyInvocation.InvocationName -ne '.') {
 
@@ -94,6 +300,9 @@ if ($MyInvocation.InvocationName -ne '.') {
             throw '-AllowUnsigned requires the current PowerShell session to run as administrator when the MSIX contains executable content. Relaunch PowerShell as administrator and retry, or install the signing certificate to Cert:\LocalMachine\TrustedPeople and omit -AllowUnsigned. See https://learn.microsoft.com/en-us/windows/msix/package/unsigned-package for details.'
         }
     }
+
+    Assert-OptionalInputFile -Path $DockerEnvFilePath -ParameterName 'DockerEnvFilePath'
+    Assert-OptionalInputFile -Path $AnthropicEnvFilePath -ParameterName 'AnthropicEnvFilePath'
 
     # Stage 1: bundle selection. Bundle root = -SourcePath (defaults to
     # $PSScriptRoot, the directory this script lives in after it has been
@@ -139,6 +348,8 @@ if ($MyInvocation.InvocationName -ne '.') {
             catch { Write-Information "[install:force-uninstall] remove-record tolerated failure: $($_.Exception.Message)" -InformationAction Continue }
         }
         elseif (Test-Path -LiteralPath $DestinationPath) {
+            try { Invoke-MsixRemove -PackageFullName '' }
+            catch { Write-Information "[install:force-uninstall] destination-only msix-remove tolerated failure: $($_.Exception.Message)" -InformationAction Continue }
             try { Remove-Item -LiteralPath $DestinationPath -Recurse -Force }
             catch { Write-Information "[install:force-uninstall] remove-destination tolerated failure: $($_.Exception.Message)" -InformationAction Continue }
         }
@@ -159,6 +370,10 @@ if ($MyInvocation.InvocationName -ne '.') {
     $DestDockerDir = Join-Path $DestinationPath 'docker'
     Write-Information '[install:env] Provisioning .env when absent' -InformationAction Continue
     Initialize-DotEnv -DestDockerDir $DestDockerDir
+    Copy-OperatorDockerConfiguration -DestDockerDir $DestDockerDir -DockerEnvFilePath $DockerEnvFilePath -AnthropicEnvFilePath $AnthropicEnvFilePath
+    if (-not $SkipDocker) {
+        Assert-DockerRuntimeInput -DestDockerDir $DestDockerDir
+    }
 
     # Stage 7: MSIX install + capture.
     $MsixPath = Join-Path $BundleRoot "msix/OpenClaw.MailBridge_${ResolvedVersion}_x64.msix"
@@ -173,6 +388,8 @@ if ($MyInvocation.InvocationName -ne '.') {
     # Stage 8: compose up + health poll (skipped when -SkipDocker).
     $ComposeFilePath = Join-Path $DestDockerDir 'docker-compose.yml'
     if (-not $SkipDocker) {
+        Write-Information '[install:hostadapter-check] Verifying HostAdapter and MailBridge readiness before compose up' -InformationAction Continue
+        Assert-HostAdapterRuntimePreflight -DestDockerDir $DestDockerDir
         Write-Information '[install:docker] Starting compose stack' -InformationAction Continue
         Invoke-ComposeUp -DestDockerDir $DestDockerDir -ComposeFilePath $ComposeFilePath
         Wait-ComposeHealthy -ComposeFilePath $ComposeFilePath

--- a/scripts/Invoke-OpenClawContainerPathValidation.ps1
+++ b/scripts/Invoke-OpenClawContainerPathValidation.ps1
@@ -19,10 +19,16 @@ and the four new probes introduced by issue #38) live in the
 Relative path on the openclaw-agent gateway used by the DashboardAuth probe.
 Default: `/auth/verify`. Operators can override when their upstream gateway
 exposes the auth-verify endpoint at a non-default path.
+
+.PARAMETER CoreBaseUrl
+Base URL for OpenClaw.Core endpoint probes. When omitted, the script reads
+`OPENCLAW_HTTP_PORT` from `-EnvFilePath` and uses `http://127.0.0.1:<port>`.
+If the env file or port setting is absent, the fallback is
+`http://127.0.0.1:8080`.
 #>
 [CmdletBinding()]
 param(
-    [uri]$CoreBaseUrl = 'http://127.0.0.1:8080',
+    [uri]$CoreBaseUrl,
     [uri]$AgentBaseUrl = 'http://127.0.0.1:18789',
     [string]$CoreContainerName = 'openclaw-core',
     [string]$AgentContainerName = 'openclaw-agent',
@@ -42,6 +48,28 @@ $moduleManifest = Join-Path $PSScriptRoot 'powershell/modules/OpenClawContainerV
 # inside the module's scope; re-importing with -Force would invalidate those mocks.
 if (-not (Get-Module -Name OpenClawContainerValidation)) {
     Import-Module -Name $moduleManifest -ErrorAction Stop
+}
+
+function Get-OpenClawCoreBaseUrl {
+    [CmdletBinding()]
+    [OutputType([uri])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$EnvFilePath
+    )
+
+    $envMap = Get-OpenClawEnvFileMap -EnvFilePath $EnvFilePath
+    $portValue = '8080'
+    if ($envMap.ContainsKey('OPENCLAW_HTTP_PORT') -and -not [string]::IsNullOrWhiteSpace([string]$envMap['OPENCLAW_HTTP_PORT'])) {
+        $portValue = ([string]$envMap['OPENCLAW_HTTP_PORT']).Trim().Trim([char[]]@('"', "'"))
+    }
+
+    $port = 0
+    if (-not [int]::TryParse($portValue, [ref]$port) -or $port -lt 1 -or $port -gt 65535) {
+        throw "OPENCLAW_HTTP_PORT in '$EnvFilePath' must be an integer from 1 through 65535. Actual value: '$portValue'."
+    }
+
+    return [uri]("http://127.0.0.1:{0}" -f $port)
 }
 
 function Invoke-OpenClawDockerEngineValidation {
@@ -214,6 +242,10 @@ function Invoke-OpenClawAgentDashboardEndpointValidation {
         -ExpectedCondition 'HTTP 200 with a non-empty response body' `
         -Request $request -IsExpected $isExpected -Summary $summary `
         -Details @{ hasBody = $hasBody }
+}
+
+if ($null -eq $CoreBaseUrl) {
+    $CoreBaseUrl = Get-OpenClawCoreBaseUrl -EnvFilePath $EnvFilePath
 }
 
 $live = Invoke-OpenClawLiveEndpointValidation -Uri (Get-OpenClawEndpointUri -BaseUri $CoreBaseUrl -Path '/health/live') -TimeoutSeconds $TimeoutSeconds

--- a/scripts/powershell/modules/OpenClawContainerValidation/OpenClawContainerValidation.psm1
+++ b/scripts/powershell/modules/OpenClawContainerValidation/OpenClawContainerValidation.psm1
@@ -272,7 +272,7 @@ function Invoke-OpenClawHostAdapterInContainerProbe {
         [Parameter(Mandatory = $true)][string]$DockerExecutablePath,
         [Parameter(Mandatory = $true)][string]$AgentContainerName
     )
-    $shellCommand = 'curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $(cat /run/openclaw/hostadapter.token)" http://host.docker.internal:4319/v1/status'
+    $shellCommand = 'TOKEN=$(tr -d "\r\n" < /run/openclaw/hostadapter.token); curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $TOKEN" http://host.docker.internal:4319/v1/status'
     $command = Invoke-OpenClawDockerCommand -ExecutablePath $DockerExecutablePath -CommandArguments @(
         'compose', 'exec', '-T', $AgentContainerName, 'sh', '-c', $shellCommand
     )

--- a/tests/scripts/Install.Helpers.Tests.ps1
+++ b/tests/scripts/Install.Helpers.Tests.ps1
@@ -251,6 +251,12 @@ Describe 'Install.Helpers.psm1' {
             Should -Invoke -ModuleName Install.Helpers -CommandName Remove-AppxPackage -Times 0 -Exactly
         }
 
+        It 'uses the installed package full name when the supplied package full name is empty' {
+            Mock -ModuleName Install.Helpers Get-AppxPackage { [pscustomobject]@{ PackageFullName = 'OpenClaw.MailBridge_1.2.3.0_x64__abc' } }
+            Invoke-MsixRemove -PackageFullName ''
+            Should -Invoke -ModuleName Install.Helpers -CommandName Remove-AppxPackage -Times 1 -Exactly -ParameterFilter { $Package -eq 'OpenClaw.MailBridge_1.2.3.0_x64__abc' }
+        }
+
         It '-WhatIf produces no Remove-AppxPackage call' {
             Mock -ModuleName Install.Helpers Get-AppxPackage { [pscustomobject]@{ PackageFullName = 'x' } }
             Invoke-MsixRemove -PackageFullName 'x' -WhatIf

--- a/tests/scripts/Install.Tests.ps1
+++ b/tests/scripts/Install.Tests.ps1
@@ -72,10 +72,14 @@ Describe 'scripts/Install.ps1' {
 
         # Filesystem shims. Test-Path default: MSIX exists; prior-install does NOT.
         Mock New-Item { [void]$global:InstallTestCalls.Add('New-Item') }
+        Mock Copy-Item { [void]$global:InstallTestCalls.Add('Copy-Item') }
         Mock Remove-Item { [void]$global:InstallTestCalls.Add('Remove-Item') }
+        Mock Get-Content { 'test-hostadapter-token' }
+        Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 200; Headers = @{}; Content = '{}' } }
         Mock Test-Path {
             param($LiteralPath)
             if ($LiteralPath -like '*install-record.json') { return $false }
+            if ($LiteralPath -like '*TestAppData*OpenClaw*docker*secrets*.env.anthropic') { return $true }
             # Any destination under LOCALAPPDATA\OpenClaw\<leaf> must default to absent so
             # tests that supply -SourcePath or -Version do not trip the prior-install guard.
             if ($LiteralPath -like '*TestAppData*OpenClaw\*') { return $false }
@@ -90,11 +94,22 @@ Describe 'scripts/Install.ps1' {
 
     AfterEach {
         Remove-Item -Path 'Function:\global:Test-IsElevatedAdmin' -ErrorAction SilentlyContinue
+        Remove-Variable -Name CapturedHostAdapterPreflightUri -Scope Global -ErrorAction SilentlyContinue
+        Remove-Variable -Name CapturedHostAdapterPreflightAuthorization -Scope Global -ErrorAction SilentlyContinue
     }
 
     Context 'parameter binding' {
         It 'accepts the refinement parameter set with defaults' {
             { & $script:ScriptPath -WhatIf } | Should -Not -Throw
+        }
+
+        It 'accepts operator Docker env file parameters' {
+            {
+                & $script:ScriptPath `
+                    -DockerEnvFilePath 'C:\operator\.env' `
+                    -AnthropicEnvFilePath 'C:\operator\secrets\.env.anthropic' `
+                    -WhatIf
+            } | Should -Not -Throw
         }
 
         It '-SourcePath overrides the default $PSScriptRoot' {
@@ -154,6 +169,122 @@ Describe 'scripts/Install.ps1' {
                 'Write-InstallRecord'
             )
             ($helperOrder -join ',') | Should -Be ($expected -join ',')
+        }
+    }
+
+    Context 'operator Docker env file staging' {
+        It 'copies supplied operator env files after .env initialization and before MSIX install' {
+            & $script:ScriptPath `
+                -DockerEnvFilePath 'C:\operator\.env' `
+                -AnthropicEnvFilePath 'C:\operator\secrets\.env.anthropic' | Out-Null
+
+            $idxInitialize = $global:InstallTestCalls.IndexOf('Initialize-DotEnv')
+            $idxCopy = $global:InstallTestCalls.IndexOf('Copy-Item')
+            $idxMsix = $global:InstallTestCalls.IndexOf('Invoke-MsixInstall')
+
+            $idxInitialize | Should -BeGreaterOrEqual 0
+            $idxCopy | Should -BeGreaterThan $idxInitialize
+            $idxMsix | Should -BeGreaterThan $idxCopy
+            Should -Invoke -CommandName Copy-Item -Times 1 -Exactly -ParameterFilter { $LiteralPath -eq 'C:\operator\.env' -and $Destination -like '*\docker\.env' -and $Force }
+            Should -Invoke -CommandName Copy-Item -Times 1 -Exactly -ParameterFilter { $LiteralPath -eq 'C:\operator\secrets\.env.anthropic' -and $Destination -like '*\docker\secrets\.env.anthropic' -and $Force }
+        }
+
+        It 'throws before manifest validation when a supplied operator env file is absent' {
+            Mock Test-Path {
+                param($LiteralPath)
+                if ($LiteralPath -eq 'C:\missing\.env') { return $false }
+                if ($LiteralPath -like '*install-record.json') { return $false }
+                if ($LiteralPath -like '*TestAppData*OpenClaw*docker*secrets*.env.anthropic') { return $true }
+                if ($LiteralPath -like '*TestAppData*OpenClaw\*') { return $false }
+                if ($LiteralPath -like '*TestAppData*OpenClaw/*') { return $false }
+                $true
+            }
+
+            { & $script:ScriptPath -DockerEnvFilePath 'C:\missing\.env' } |
+                Should -Throw -ExpectedMessage '*-DockerEnvFilePath*not found*outside artifacts/publish*'
+
+            $global:InstallTestCalls -contains 'Get-ManifestVersion' | Should -BeFalse
+            $global:InstallTestCalls -contains 'Test-ManifestIntegrity' | Should -BeFalse
+        }
+    }
+
+    Context 'Docker runtime input preflight' {
+        It 'throws before MSIX install when Docker is enabled and the Anthropic env file is absent' {
+            Mock Test-Path {
+                param($LiteralPath)
+                if ($LiteralPath -like '*install-record.json') { return $false }
+                if ($LiteralPath -like '*TestAppData*OpenClaw*docker*secrets*.env.anthropic') { return $false }
+                if ($LiteralPath -like '*TestAppData*OpenClaw\*') { return $false }
+                if ($LiteralPath -like '*TestAppData*OpenClaw/*') { return $false }
+                $true
+            }
+
+            { & $script:ScriptPath } |
+                Should -Throw -ExpectedMessage '*Required Docker secret file not found*-AnthropicEnvFilePath*-SkipDocker*'
+
+            $global:InstallTestCalls -contains 'Invoke-MsixInstall' | Should -BeFalse
+            $global:InstallTestCalls -contains 'Invoke-ComposeUp' | Should -BeFalse
+        }
+
+        It 'throws before compose up when the HostAdapter status probe is not ready' {
+            Mock Invoke-WebRequest { [pscustomobject]@{ StatusCode = 503; Headers = @{}; Content = '{}' } }
+
+            { & $script:ScriptPath } |
+                Should -Throw -ExpectedMessage '*HostAdapter preflight failed before starting Docker*HTTP 503*OpenClaw.MailBridge*'
+
+            $global:InstallTestCalls -contains 'Invoke-MsixInstall' | Should -BeTrue
+            $global:InstallTestCalls -contains 'Invoke-ComposeUp' | Should -BeFalse
+            $global:InstallTestCalls -contains 'Wait-ComposeHealthy' | Should -BeFalse
+        }
+
+        It 'probes the host-loopback HostAdapter status URI before compose up' {
+            $global:CapturedHostAdapterPreflightUri = $null
+            Mock Invoke-WebRequest {
+                param([uri]$Uri)
+                $global:CapturedHostAdapterPreflightUri = [string]$Uri
+                [pscustomobject]@{ StatusCode = 200; Headers = @{}; Content = '{}' }
+            }
+
+            & $script:ScriptPath | Out-Null
+
+            $global:CapturedHostAdapterPreflightUri | Should -Be 'http://127.0.0.1:4319/v1/status'
+            $global:InstallTestCalls -contains 'Invoke-ComposeUp' | Should -BeTrue
+        }
+
+        It 'uses installed docker env HostAdapter settings for the preflight' {
+            $global:CapturedHostAdapterPreflightUri = $null
+            $global:CapturedHostAdapterPreflightAuthorization = $null
+            Mock Test-Path {
+                param($LiteralPath)
+                if ($LiteralPath -like '*install-record.json') { return $false }
+                if ($LiteralPath -like '*TestAppData*OpenClaw*docker*.env') { return $true }
+                if ($LiteralPath -like '*TestAppData*OpenClaw*docker*secrets*.env.anthropic') { return $true }
+                if ($LiteralPath -eq 'C:\tokens\adapter.token') { return $true }
+                if ($LiteralPath -like '*TestAppData*OpenClaw\*') { return $false }
+                if ($LiteralPath -like '*TestAppData*OpenClaw/*') { return $false }
+                $true
+            }
+            Mock Get-Content {
+                param($LiteralPath)
+                if ($LiteralPath -like '*docker*.env') {
+                    return @(
+                        'OpenClaw__HostAdapter__BaseUrl=http://host.docker.internal:5319/v1',
+                        'HOSTADAPTER_TOKEN_FILE=C:\tokens\adapter.token'
+                    )
+                }
+                return 'custom-token'
+            }
+            Mock Invoke-WebRequest {
+                param([uri]$Uri, [hashtable]$Headers)
+                $global:CapturedHostAdapterPreflightUri = [string]$Uri
+                $global:CapturedHostAdapterPreflightAuthorization = [string]$Headers.Authorization
+                [pscustomobject]@{ StatusCode = 200; Headers = @{}; Content = '{}' }
+            }
+
+            & $script:ScriptPath | Out-Null
+
+            $global:CapturedHostAdapterPreflightUri | Should -Be 'http://127.0.0.1:5319/v1/status'
+            $global:CapturedHostAdapterPreflightAuthorization | Should -Be 'Bearer custom-token'
         }
     }
 
@@ -219,13 +350,14 @@ Describe 'scripts/Install.ps1' {
             $global:InstallTestCalls -contains 'Copy-BundleContents' | Should -BeTrue
         }
 
-        It '-Force with destination-only (no record file) removes the destination' {
+        It '-Force with destination-only (no record file) removes MSIX and destination' {
             Mock Test-Path {
                 param($LiteralPath)
                 if ($LiteralPath -like '*install-record.json') { return $false }
                 $true
             }
             & $script:ScriptPath -Force | Out-Null
+            $global:InstallTestCalls -contains 'Invoke-MsixRemove' | Should -BeTrue
             $global:InstallTestCalls -contains 'Remove-Item' | Should -BeTrue
         }
     }

--- a/tests/scripts/Invoke-OpenClawContainerPathValidation.HostAdapter.Tests.ps1
+++ b/tests/scripts/Invoke-OpenClawContainerPathValidation.HostAdapter.Tests.ps1
@@ -72,6 +72,9 @@ Describe 'Invoke-OpenClawContainerPathValidation.ps1 (HostAdapterInContainer pro
         $probe = $result.SupportingDiagnostics | Where-Object { $_.Name -eq 'HostAdapterInContainer' }
         $probe | Should -Not -BeNullOrEmpty
         $probe.IsExpected | Should -BeTrue
+        $execRequest = @($script:DockerRequests | Where-Object { $_ -like '*compose exec*' })[0]
+        $execRequest | Should -Match 'tr -d'
+        $execRequest | Should -Match 'hostadapter\.token'
     }
 
     It 'HostAdapterInContainer probe reports Unexpected when docker exec returns non-200' -Tag 'ExpectFail-Phase5' {

--- a/tests/scripts/Invoke-OpenClawContainerPathValidation.Tests.ps1
+++ b/tests/scripts/Invoke-OpenClawContainerPathValidation.Tests.ps1
@@ -104,6 +104,63 @@ Describe 'Invoke-OpenClawContainerPathValidation.ps1' {
         @($script:DockerRequests) | Should -Contain 'container inspect openclaw-agent'
     }
 
+    It 'derives the default CoreBaseUrl from OPENCLAW_HTTP_PORT in the selected env file' {
+        $requestedUris = $script:RequestedUris
+        Mock -ModuleName OpenClawContainerValidation Get-Content { return @('OPENCLAW_HTTP_PORT=8081', 'OPENCLAW_GATEWAY_TOKEN=valid-token-abc') } -ParameterFilter { (($Path -and $Path -match '\.env$') -or ($LiteralPath -and $LiteralPath -match '\.env$')) }
+        Mock -ModuleName OpenClawContainerValidation Test-Path { return $true }
+        Mock -ModuleName OpenClawContainerValidation Invoke-WebRequest {
+            param(
+                [uri]$Uri,
+                [string]$Method,
+                [int]$TimeoutSec,
+                [switch]$UseBasicParsing,
+                [switch]$SkipHttpErrorCheck,
+                $Headers,
+                $Body
+            )
+
+            $null = @($Method, $TimeoutSec, $UseBasicParsing, $SkipHttpErrorCheck, $Headers, $Body)
+            $requestedUris.Add([string]$Uri)
+            $content = switch ($Uri.AbsolutePath) {
+                '/health/live' { '{"status":"live"}' }
+                '/health/ready' { '{"status":"ready","sqliteReady":true,"hostAdapterReachable":true}' }
+                '/api/status' { '{"sqliteReady":true,"hostAdapterReachable":true,"cacheItemCounts":{"messages":0,"meetingRequests":0,"events":0},"bridgeFreshness":{"cacheStale":false}}' }
+                '/' { '<html><body>OpenClaw Gateway Dashboard</body></html>' }
+                '/readyz' { 'ready' }
+                '/auth/verify' { '{"ok":true}' }
+                default { throw "Unexpected URI: $Uri" }
+            }
+
+            return [pscustomobject]@{
+                StatusCode = 200
+                Headers    = @{ 'Content-Type' = 'application/json' }
+                Content    = $content
+            }
+        }
+        $dockerRequests = $script:DockerRequests
+        Set-Item -Path Function:\Global:Invoke-FakeDocker -Value ({
+                [CmdletBinding()]
+                param([Parameter(ValueFromRemainingArguments = $true)][object[]]$Arguments)
+                $commandLine = $Arguments -join ' '
+                $dockerRequests.Add($commandLine)
+                $global:LASTEXITCODE = 0
+                switch -Regex ($commandLine) {
+                    '^version --format' { '25.0.0'; return }
+                    'container inspect openclaw-core' { '[{"Name":"/openclaw-core","Config":{"Image":"openclaw/core:pre-mvp"},"State":{"Status":"running","Running":true,"Health":{"Status":"healthy"}}}]'; return }
+                    'container inspect openclaw-agent' { '[{"Name":"/openclaw-agent","Config":{"Image":"openclaw/agent:pre-mvp"},"State":{"Status":"running","Running":true,"Health":{"Status":"healthy"}}}]'; return }
+                    'compose exec' { '200'; return }
+                    default { $global:LASTEXITCODE = 1; "Unexpected: $commandLine" }
+                }
+            }.GetNewClosure())
+
+        $result = & $script:ScriptPath -DockerPath 'Invoke-FakeDocker' -EnvFilePath 'C:\operator\.env' -PassThru
+
+        $result.CoreBaseUrl | Should -Be 'http://127.0.0.1:8081/'
+        @($requestedUris) | Should -Contain 'http://127.0.0.1:8081/health/live'
+        @($requestedUris) | Should -Contain 'http://127.0.0.1:8081/health/ready'
+        @($requestedUris) | Should -Contain 'http://127.0.0.1:8081/api/status'
+    }
+
     It 'returns unexpected when readiness diagnostics report a degraded dependency' {
         Mock -ModuleName OpenClawContainerValidation Get-Content { return @('OPENCLAW_GATEWAY_TOKEN=valid-token-abc') } -ParameterFilter { (($Path -and $Path -match '\.env$') -or ($LiteralPath -and $LiteralPath -match '\.env$')) }
         Mock -ModuleName OpenClawContainerValidation Test-Path { return $true }


### PR DESCRIPTION
# Harden scripted installs with external Docker env staging and runtime preflight checks

## Summary

- Keep operator-managed Docker `.env` and Anthropic secret files outside manifest-controlled publish bundles, then copy them into the installed docker directory during scripted install.
- Add early install-time checks for missing Docker runtime inputs and HostAdapter readiness before the compose startup step.
- Make forced reinstall cleanup tolerate destination-only recovery cases by removing an installed MSIX even when no prior install record exists.
- Update container-path validation to derive the default Core probe URL from `OPENCLAW_HTTP_PORT` when `CoreBaseUrl` is not supplied.
- Trim newline characters from the in-container HostAdapter token before the curl-based status probe runs.
- Expand PowerShell regression coverage for the install flow and container validation behavior.
- Document the revised install workflow and validation expectations in the runbook and README.

## Why

The branch and commit history indicate this PR addresses an install-path bug in the scripted bundle workflow. The changed installer and validation scripts suggest two related failure modes: operator-specific Docker configuration should not live inside the manifest-controlled publish bundle, and Docker startup should fail earlier with clearer checks when required runtime inputs or HostAdapter readiness are missing. The validation updates and documentation changes align the troubleshooting path with the deployed runtime configuration by using the configured HTTP port instead of a fixed default when `CoreBaseUrl` is omitted.

## What Changed

- Core behavior / architecture
  - Extended `scripts/Install.ps1` to accept external Docker env file inputs, copy them into the installed docker layout, validate required Docker runtime files, and preflight HostAdapter reachability before compose startup.
  - Updated `scripts/Install.Helpers.psm1` so MSIX removal can fall back to the installed package full name when the supplied value is empty, which supports force-reinstall cleanup.
  - Updated `scripts/Invoke-OpenClawContainerPathValidation.ps1` to resolve the default Core base URL from `OPENCLAW_HTTP_PORT`.
  - Updated `scripts/powershell/modules/OpenClawContainerValidation/OpenClawContainerValidation.psm1` to strip CR/LF characters from the in-container HostAdapter token before invoking curl.

- Tests
  - Added and expanded PowerShell tests covering external env-file staging, missing runtime-input failures, HostAdapter preflight behavior, force-reinstall cleanup, Core URL derivation from env settings, and the in-container HostAdapter probe command shape.

- Docs / operational guidance
  - Updated `docs/mailbridge-runbook.md` with the external operator-config install path, failure guidance, and the revised container validation behavior.
  - Updated `README.md` to note that operator-managed Docker env files stay outside publish bundles and that Core validation can derive its base URL from `OPENCLAW_HTTP_PORT`.

## Architecture / How It Fits Together

The publish bundle remains a manifest-controlled artifact, while operator-specific Docker configuration is treated as machine-local input that is staged into the installed docker directory only after bundle validation. Once staged, the installer now verifies the Docker secret file and checks HostAdapter readiness before starting the compose stack. The container validation script uses the selected env file to determine the Core endpoint port, which keeps runtime probes aligned with the installed Docker configuration. Together, these changes separate immutable packaged content from operator-managed secrets and reduce late-stage install failures.

## Verification

### Completed

- Not verified in this PR (no tool outputs recorded in `pr_context.summary.txt`).

### Recommended

- `pwsh -NoProfile -File scripts/Install.ps1 -DockerEnvFilePath <operator-env-path> -AnthropicEnvFilePath <operator-anthropic-env-path>`
- `pwsh -NoProfile -File scripts/Install.ps1 -SkipDocker`
- `pwsh -NoProfile -File scripts/Invoke-OpenClawContainerPathValidation.ps1 -PassThru`

## Backward Compatibility / Migration Notes

- Docker-enabled scripted installs now expect operator-managed env files to remain outside `artifacts/publish/<version>/` and to be supplied explicitly to `Install.ps1`.
- If those files are not supplied for a Docker-enabled install, the installer now fails early instead of continuing into later startup stages.
- Operators who intentionally defer Docker setup can continue to use `-SkipDocker`.
- Container-path validation now honors `OPENCLAW_HTTP_PORT` when `CoreBaseUrl` is omitted, which may change the default probe target compared with earlier behavior.

## Risks and Mitigations

- Risk: Stricter preflight checks may block installs that previously failed later in the process.
  - Mitigation: The installer now surfaces these conditions earlier and the runbook documents the expected operator-managed inputs and fallback `-SkipDocker` path.
- Risk: Incorrect operator env-file paths could prevent install progress.
  - Mitigation: The installer adds explicit validation for optional input-file parameters before bundle processing.
- Risk: Runtime probing behavior changes when env-file port settings differ from the historical default.
  - Mitigation: The validation logic and documentation now align on deriving the Core base URL from `OPENCLAW_HTTP_PORT`.

## Review Guide

- Review `scripts/Install.ps1` first for the new install flow: external env-file staging, runtime input validation, and HostAdapter preflight sequencing.
- Review `scripts/Install.Helpers.psm1` next for the force-reinstall MSIX cleanup adjustment.
- Review `scripts/Invoke-OpenClawContainerPathValidation.ps1` and `scripts/powershell/modules/OpenClawContainerValidation/OpenClawContainerValidation.psm1` for the probe-behavior changes.
- Review the PowerShell test updates to confirm the intended failure and success cases are covered.
- Review `docs/mailbridge-runbook.md` and `README.md` last to confirm the operator guidance matches the script behavior.

## Follow-ups

- Add canonical verification evidence to future PR context captures so installer and validation runs can be recorded under completed verification.
- Consider whether additional automation is needed to streamline operator-managed Docker configuration setup outside the publish bundle.

## GitHub Auto-close

- None (no verified closing issues listed; fill “Author-asserted autoclose issues” in PR Intent to enable auto-close)

## Related issues / PRs

- None.