### PR TITLE
(docs(orchestrator)): capture OpenClaw.Core namespace-only agent rule

### DIFF
--- a/.claude/agent-memory/orchestrator/MEMORY.md
+++ b/.claude/agent-memory/orchestrator/MEMORY.md
@@ -2,3 +2,4 @@
 
 - [Surface consequential decisions](feedback_surface-consequential-decisions.md) — get operator confirmation on irreversible harness/scope/CI-gate forks; batch low-risk defaults.
 - [Harness governance](project_harness-governance.md) — harness is now version-controlled (Issue #66/PR #68); `.claude/rules/*` is canonical; AGENTS.md + .github/instructions match it.
+- [Core agent = namespace not project](project_core-agent-namespace-not-project.md) — new logic for OpenClaw.Core folds into a namespace, not a new project (arch rule 6); enforce with namespace NetArchTest.

--- a/.claude/agent-memory/orchestrator/project_core-agent-namespace-not-project.md
+++ b/.claude/agent-memory/orchestrator/project_core-agent-namespace-not-project.md
@@ -1,0 +1,12 @@
+---
+name: core-agent-namespace-not-project
+description: New agent/deterministic logic for OpenClaw.Core must live in a namespace inside OpenClaw.Core, not a new project — architecture-boundaries rule 6.
+metadata:
+  type: project
+---
+
+New deterministic/agent logic that `OpenClaw.Core` must consume belongs in a **namespace inside the existing `OpenClaw.Core` project** (e.g. `OpenClaw.Core.Agent`), not a new `OpenClaw.Core.Agent` *project*.
+
+**Why:** `.claude/rules/architecture-boundaries.md` rule 6 restricts `OpenClaw.Core` to depend **only on `OpenClaw.HostAdapter.Contracts`**. A new project would force a `OpenClaw.Core -> OpenClaw.Core.Agent` ProjectReference, which is a PR-blocking architecture violation. Policy under `.claude/rules/**` must not be edited to work around it. On issue #70 the research/spec adopted a new-project default (OR-1) and the plan failed preflight on exactly this; the fix was fold-in + a namespace-scoped `NetArchTest.Rules` assertion (in the existing `OpenClaw.Core.Tests`) to enforce the contract-parity invariant that the pure logic references no `OpenClaw.MailBridge`/`OpenClaw.HostAdapter`/COM types.
+
+**How to apply:** When scoping work that puts new logic behind a seam consumed by `OpenClaw.Core`, instruct the planner up front to fold into `OpenClaw.Core` under a dedicated namespace and enforce isolation with a namespace-scoped architecture test — do not create a sibling project. This avoids a wasted plan→preflight→revise cycle. The 500-line limit is per-file, so many small files in one project is fine. See [[harness-governance]].


### PR DESCRIPTION
- Add an orchestrator memory entry linking the new OpenClaw.Core namespace guidance
- Record that new deterministic agent logic must stay within OpenClaw.Core rather than a sibling project
- Document the architecture-boundary rationale and NetArchTest enforcement guidance to avoid #70-style preflight rework

Refs: #70