### PR TITLE
feat(hostadapter)!: evolve HTTP surface to Graph-shaped endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Validate the local-only path:
 
 ```powershell
 $token = (Get-Content 'C:\ProgramData\OpenClaw\HostAdapter\adapter.token' -Raw).Trim()
-curl.exe -H "Authorization: Bearer $token" http://127.0.0.1:4319/v1/status
+curl.exe -H "Authorization: Bearer $token" http://127.0.0.1:4319/status
 curl.exe http://127.0.0.1:8081/health/ready
 curl.exe http://127.0.0.1:8081/api/status
 ```
@@ -368,14 +368,16 @@ Key behavior:
 - `list-calendar --start <utc> --end <utc> --limit <n>`
 - `get-event --id <bridgeId>`
 
-The HostAdapter preserves this contract exactly and exposes it through:
+The HostAdapter preserves this contract exactly and exposes it through a Microsoft Graph-shaped HTTP surface. The `{id}` path segment is the configured mailbox identifier (`HostAdapterOptions.MailboxId`, default `me`):
 
-- `GET /v1/status`
-- `GET /v1/messages`
-- `GET /v1/messages/{bridgeId}`
-- `GET /v1/meeting-requests`
-- `GET /v1/calendar`
-- `GET /v1/events/{bridgeId}`
+- `GET /status`
+- `GET /users/{id}/messages` (`?$filter=receivedDateTime ge <iso8601>&$top=<n>`)
+- `GET /users/{id}/messages/{messageId}`
+- `GET /users/{id}/messages` (`?$filter=meetingMessageType ne null&$top=<n>` for meeting requests)
+- `GET /users/{id}/calendarView` (`?startDateTime=<iso8601>&endDateTime=<iso8601>&$top=<n>`)
+- `GET /users/{id}/events/{eventId}`
+
+> Breaking change (adapter version `1.0.0`): the earlier bespoke `/v1/*` routes (`/v1/status`, `/v1/messages`, `/v1/meeting-requests`, `/v1/calendar`, `/v1/events/{bridgeId}`) were replaced by the Graph-shaped surface above. Request and response envelope shapes are unchanged. Meeting requests are served by the `/users/{id}/messages` route filtered on `meetingMessageType`. Clients configure the adapter base URL without a `/v1/` segment (for example `http://127.0.0.1:4319/`).
 
 ## Additional Documentation
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,7 +9,7 @@ The MailBridge exposes a local JSON-RPC API over Windows Named Pipes. An OpenCla
 
 The repository also includes an additive HTTP-and-container path:
 
-- `OpenClaw.HostAdapter` runs on Windows and translates authenticated HTTP requests such as `GET /v1/status` into the same six `OpenClaw.MailBridge.Client` commands.
+- `OpenClaw.HostAdapter` runs on Windows and translates authenticated, Microsoft Graph-shaped HTTP requests such as `GET /status` and `GET /users/{id}/messages` into the same six `OpenClaw.MailBridge.Client` commands.
 - `OpenClaw.Core` runs locally in Docker, calls the HostAdapter through `host.docker.internal`, and serves cache-backed UI and internal API responses.
 - The six-command `OpenClaw.MailBridge.Client` contract remains unchanged and is still the canonical transport seam.
 
@@ -34,16 +34,18 @@ The pipe is ACL-restricted to the current interactive user, BUILTIN\Administrato
 
 ## Additive HostAdapter HTTP Surface
 
-`OpenClaw.HostAdapter` is the only approved network seam for the containerized path. It wraps the existing DTOs in `ApiEnvelope<T>` responses and preserves the current CLI contract by shelling out to `OpenClaw.MailBridge.Client` with allowlisted arguments.
+`OpenClaw.HostAdapter` is the only approved network seam for the containerized path. It wraps the existing DTOs in `ApiEnvelope<T>` responses and preserves the current CLI contract by shelling out to `OpenClaw.MailBridge.Client` with allowlisted arguments. As of adapter version `1.0.0`, the surface is Microsoft Graph-shaped: the `{id}` path segment is the configured mailbox identifier (`HostAdapterOptions.MailboxId`, default `me`).
 
 | Route | Backing `OpenClaw.MailBridge.Client` command | Response shape |
 |---|---|---|
-| `GET /v1/status` | `status` | `ApiEnvelope<BridgeStatusDto>` |
-| `GET /v1/messages?since=<utc>&limit=<n>` | `list-messages --since <utc> --limit <n>` | `ApiEnvelope<ItemsResponse<MessageDto>>` |
-| `GET /v1/messages/{bridgeId}` | `get-message --id <bridgeId>` | `ApiEnvelope<MessageDto>` |
-| `GET /v1/meeting-requests?since=<utc>&limit=<n>` | `list-meeting-requests --since <utc> --limit <n>` | `ApiEnvelope<ItemsResponse<MessageDto>>` |
-| `GET /v1/calendar?start=<utc>&end=<utc>&limit=<n>` | `list-calendar --start <utc> --end <utc> --limit <n>` | `ApiEnvelope<ItemsResponse<EventDto>>` |
-| `GET /v1/events/{bridgeId}` | `get-event --id <bridgeId>` | `ApiEnvelope<EventDto>` |
+| `GET /status` | `status` | `ApiEnvelope<BridgeStatusDto>` |
+| `GET /users/{id}/messages?$filter=receivedDateTime ge <utc>&$top=<n>` | `list-messages --since <utc> --limit <n>` | `ApiEnvelope<ItemsResponse<MessageDto>>` |
+| `GET /users/{id}/messages/{messageId}` | `get-message --id <bridgeId>` | `ApiEnvelope<MessageDto>` |
+| `GET /users/{id}/messages?$filter=meetingMessageType ne null&$top=<n>` | `list-meeting-requests --since <utc> --limit <n>` | `ApiEnvelope<ItemsResponse<MessageDto>>` |
+| `GET /users/{id}/calendarView?startDateTime=<utc>&endDateTime=<utc>&$top=<n>` | `list-calendar --start <utc> --end <utc> --limit <n>` | `ApiEnvelope<ItemsResponse<EventDto>>` |
+| `GET /users/{id}/events/{eventId}` | `get-event --id <bridgeId>` | `ApiEnvelope<EventDto>` |
+
+> Breaking change (adapter version `1.0.0`): the earlier bespoke `/v1/*` routes were replaced by the Graph-shaped surface above. Request and response envelope shapes are unchanged. Meeting requests are served by the `/users/{id}/messages` route filtered on `meetingMessageType`. The `OpenClaw.Core` adapter base URL no longer carries a `/v1/` segment.
 
 Requests use `Authorization: Bearer <token>` and may include `X-Request-Id`. The additive `OpenClaw.Core` container path reaches this HTTP surface through `host.docker.internal`.
 

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/code-review.2026-06-12T23-30.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/code-review.2026-06-12T23-30.md
@@ -1,0 +1,108 @@
+# Code Review: evolve-hostadapter-graph-surface (#76)
+
+**Review Date:** 2026-06-12
+**Reviewer:** feature-review agent
+**Feature Folder:** `docs/features/active/evolve-hostadapter-graph-surface-76`
+**Feature Folder Selection Rule:** Folder suffix `-76` matches the issue number in the branch context; it holds the only material scoping-doc changes in the branch diff.
+**Base Branch:** `main` (`3041d083691cd77b2b2e888580fc9f2ab8bc611f`)
+**Head Branch:** `open-claw-bridge-wt-2026-06-12-22-19` (`e3bc4506e1ebce0080e057306b91ffbbb77fd945`)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+This change replaces the HostAdapter bespoke `/v1/*` HTTP route table with a Microsoft Graph-shaped surface and updates the in-repo typed client and T2 contract documentation to match. The six bespoke routes become five Graph-shaped routes: `/status` (operational probe, kept), `/users/{id}/messages` (with `$filter=receivedDateTime ge {iso}` and `$top`), `/users/{id}/messages/{messageId}`, `/users/{id}/calendarView` (with `startDateTime`/`endDateTime`/`$top`), and `/users/{id}/events/{eventId}`. The meeting-requests capability is retained (decision D1) but reachable as a messages-filtered query: the messages handler branches on a `meetingMessageType ne null` predicate in `$filter`, dispatching to `BuildListMeetingRequests` when present and `BuildListMessages` otherwise. The change is path-and-query only; DTOs and envelopes are byte-for-byte unchanged.
+
+The implementation is coherent and low-risk. Independent verification confirmed: build clean (0 warnings / 0 errors with analyzers, nullable, and warnings-as-errors); CSharpier format clean (149 files); HostAdapter.Tests 74/74 and Core.Tests 178/178 passing; no new `ProjectReference` edges; T2 `IHostAdapterClient` signatures unchanged with `ListMeetingRequestsAsync` retained; adapter version reports `1.0.0`; no `/v1/` route strings remain in `src/OpenClaw.HostAdapter`.
+
+**What changed:**
+Production: `Program.cs` (route reshaping + single messages handler with branch dispatch), `HostAdapterRequestValidation.cs` (new `$filter` lower-bound extraction and meeting-requests predicate detection; error-message renames to `$top`/`startDateTime`/`endDateTime`), `HostAdapterOptions.cs` (new `MailboxId`; `FormatAdapterVersion` to render 3-component `1.0.0`), `OpenClaw.HostAdapter.csproj` (`<Version>1.0.0</Version>`), `IHostAdapterClient.cs` (XML-doc only), `HostAdapterHttpClient.cs` (six Graph-shaped relative paths from `MailboxId`), `CoreOptions.cs` (`BaseUrl` default drops `/v1/`; `MailboxId` mirror). Tests: 8 updated + 1 new version test.
+
+**Top 3 risks:**
+1. The `{id}` route segment is captured by each handler but not used server-side: the adapter does not validate or route on the mailbox identifier, so `/users/anyone/messages` resolves the same data as `/users/me/messages`. This matches the spec's stated intent (Graph-portability of request construction; `"me"` is non-identifying), but it means the `{id}` is presentational only and could mislead a caller into assuming per-mailbox isolation.
+2. CSharpier formatting was verified with global 1.3.0 rather than the pinned 0.16.0 dotnet-tool (which could not be restored), so format-clean under the pinned formatter is not directly proven.
+3. The `$filter` parser is substring/prefix-based (`receivedDateTime ge `, `meetingMessageType ne null`, split on ` and `), which is sufficient for the shapes the typed client emits but is not a general OData parser; an externally-constructed `$filter` with different ordering or casing of clauses could parse unexpectedly. Behavior is bounded by the existing downstream timestamp validation.
+
+**PR readiness recommendation:** **Go** — The change is correct, well-tested, and policy-compliant; the residual items are Minor/Info and non-blocking.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `src/OpenClaw.HostAdapter/Program.cs` | `/users/{id}/...` handlers | The `id` route parameter is bound but unused in every handler body; the mailbox identity is not validated or routed on server-side. | Confirm this is intended (spec says it is). Optionally add a brief comment that `{id}` is accepted for Graph route-shape parity and is not used to scope data in the local adapter. | Prevents a future reader from assuming per-mailbox authorization/isolation that does not exist. | Diff inspection; spec.md "Security/privacy considerations" states `{id}` defaults to non-identifying `"me"`. |
+| Minor | `src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs` | `ExtractReceivedDateTimeLowerBound`, `FilterSelectsMeetingRequests` | `$filter` is parsed by substring/prefix matching and ` and ` splitting, not a general OData parser. | Acceptable for the controlled client. If external callers will craft `$filter` directly, document the supported predicate grammar or add targeted tests for clause-ordering variants. | A non-canonical `$filter` shape could parse to an unexpected lower bound or miss the meeting-requests branch. | Diff inspection of the two helpers. |
+| Minor | `src/OpenClaw.HostAdapter/*` (build/format) | toolchain | Formatting verified with global CSharpier 1.3.0; pinned 0.16.0 dotnet-tool unavailable in worktree. | Repair `dotnet tool restore` or update the tool pin to the installed major version, then re-run `csharpier check`. | A major-version formatter difference can in principle yield different formatting; the pinned formatter was not the one exercised. | `dotnet csharpier --version` -> "Run dotnet tool restore"; `csharpier --version` -> 1.3.0. |
+| Info | `artifacts/pr_context.summary.txt` | "Changed files overview" | Summary reports "Core logic changes: 0 files" though seven `src/**` C# files changed with logic. | None for this PR; the audit used the direct branch diff. Consider investigating the context-generator classifier. | Avoids future reviewers under-scoping based on the summary. | `git diff --stat 3041d08..e3bc450` shows 7 src + 9 test C# files. |
+| Info | `src/OpenClaw.HostAdapter/HostAdapterOptions.cs` | `FormatAdapterVersion` | Two defensive branches (`version is null`, `version.Build < 0`) are unreachable for the loaded assembly. | Keep as defensive guards; no action needed. | Documents why changed-code branch coverage is 79.41% rather than higher; intentional. | `evidence/qa-gates/coverage-delta.2026-06-12T23-17.md`. |
+
+No Blocker or Major findings.
+
+---
+
+## Implementation Audit
+
+### C# implementation audit
+
+#### What changed well
+
+- The messages and meeting-requests endpoints were unified into a single `/users/{id}/messages` handler that branches on the `$filter` predicate, eliminating a duplicated ~70-line endpoint while preserving both behaviors (Program.cs net reduction). This is the simplest design that satisfies D1 and the Graph route shape.
+- The Core-side `MailboxId` was added as a mirror in `CoreOptions.cs` rather than by taking a `ProjectReference` on `OpenClaw.HostAdapter`, honoring the architecture boundary (design note N2). The mirror is documented in an XML-doc summary.
+- Route parameters were renamed from the generic `bridgeId` to `messageId`/`eventId`, matching Graph segment names and improving local readability.
+- `FormatAdapterVersion` correctly addresses the assembly-version 4-component vs `meta.adapterVersion` 3-component mismatch so the AC's exact `1.0.0` value is produced; the helper is covered by a dedicated test.
+
+#### Type safety and API notes
+
+- Nullable analysis is clean under warnings-as-errors; `FormatAdapterVersion(Version?)` handles null explicitly. No `dynamic` introduced. The T2 `IHostAdapterClient` public surface is unchanged (signatures identical; only XML-doc text changed), so the breaking change is in the wire/HTTP contract, correctly signaled by the major version bump rather than by a source-level signature break.
+
+#### Error handling and logging
+
+- Request validation continues to return explicit `ApiError`/`ApiEnvelope<T>` failures with messages that now name the Graph-shaped parameters (`$top`, `startDateTime`/`endDateTime`, `receivedDateTime`). An absent `$filter` predicate yields empty `StringValues`, which deterministically surfaces the existing required-parameter error downstream — documented in the helper summary and consistent with fail-fast/explicit error policy. No logging regression; `RequestLoggingMiddleware` is retained.
+
+---
+
+## Test Quality Audit
+
+The verification evidence is strong and was independently reconfirmed rather than accepted from the executor artifacts alone.
+
+### Reviewed test and QA artifacts
+
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterMappingTests.cs` — adds explicit branch-dispatch tests asserting the process-runner invocation sequence (`status` then `list-meeting-requests` vs `list-messages`), which verifies the new `$filter`-based fork at the integration boundary, not just the URL string.
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterValidationTests.cs` — updated to assert error messages cite the Graph-shaped parameter names; preserves the over-`MaxLimit` and equal-window negative cases.
+- `tests/OpenClaw.Core.Tests/HostAdapterHttpClientTests.cs` — asserts each method emits the Graph-shaped path with `/users/me/...` (proving `MailboxId` sourcing) and the renamed query parameters; default-limit case now asserts `$top=100`.
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterVersionTests.cs` (new) — asserts `DefaultAdapterVersion == "1.0.0"`, with a comment explaining why the in-process factory's `"test-version"` override makes the assembly-derived value the correct assertion target.
+- `evidence/qa-gates/coverage-delta.2026-06-12T23-17.md` — changed-code 98.85% line / 79.41% branch; cross-checked against cobertura package rates (HostAdapter 97.08%/86.30%, Core 98.58%/90.32%).
+- `evidence/qa-gates/contract-compat.2026-06-12T23-17.md` and `architecture-check.2026-06-12T23-17.md` — independently re-verified (member parity; no new project edges).
+
+### Quality assessment prompts
+
+- **Determinism:** In-memory `FakeHttpHandler` and enqueued process-runner responses; fixed timestamp literals; no wall-clock waits or sleeps in changed tests.
+- **Isolation:** Each test targets one route/parameter/branch behavior; failures localize cleanly.
+- **Speed:** ~1.18 s combined for 252 tests (observed).
+- **Diagnostics:** FluentAssertions messages name the exact expected token or invocation sequence.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | Diff inspection; only route strings, options, and version. No tokens/keys added. |
+| No unsafe subprocess or command construction | ✅ PASS | Command building is unchanged; dispatch selects between existing `BuildListMessages`/`BuildListMeetingRequests`. No shell/string command injection surface added. |
+| Input validation at boundaries | ✅ PASS | Graph-shaped parameters validated (`$filter` receivedDateTime bound, `startDateTime`/`endDateTime`, `$top` against `MaxLimit`); bridge-id segments escaped via `Uri.EscapeDataString` on the client and validated server-side. |
+| Error handling remains explicit | ✅ PASS | `ApiError`/`ApiEnvelope<T>` failures with specific messages; no broad catch added. |
+| Configuration / path handling is safe | ✅ PASS | `MailboxId` is URL-escaped (`Uri.EscapeDataString`) when rendered into the path on the client; defaults to non-identifying `"me"`. |
+
+---
+
+## Research Log
+
+No external research was required. All evidence derives from the branch diff, the repository toolchain (CSharpier, dotnet build/test), the cobertura coverage reports, and the feature-folder evidence artifacts.
+
+---
+
+## Verdict
+
+The change is ready for normal PR flow. It is a focused, well-tested, path-and-query reshaping of the HostAdapter HTTP surface to Graph-shaped routes with a correctly signaled `1.0.0` breaking-change version, a configurable `MailboxId`, retained meeting-requests capability (D1), unchanged DTO/envelope schema, and unchanged architecture boundaries. Toolchain and tests are green under independent re-verification, and changed-code coverage meets the uniform thresholds. The three Minor and two Info findings are non-blocking; the most useful optional follow-ups are repairing the CSharpier tool pin and adding a one-line comment clarifying that the `{id}` segment is presentational in the local adapter. This conclusion is consistent with the Go recommendation above.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-build.2026-06-12T22-30.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-build.2026-06-12T22-30.md
@@ -1,0 +1,9 @@
+# Baseline — Build / Analyzers
+
+Timestamp: 2026-06-12T22-30
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). All 9 projects (6 src, 3 test) restored and compiled cleanly with .NET analyzers and code-style enforcement enabled.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-format.2026-06-12T22-30.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-format.2026-06-12T22-30.md
@@ -1,0 +1,11 @@
+# Baseline — Formatting
+
+Timestamp: 2026-06-12T22-30
+
+Command: `csharpier check .`
+
+Note on command form: The plan references `dotnet csharpier . --check`. The repo-local dotnet-tool manifest form is unavailable in this worktree (the resolving manifest `C:\Users\DanMoisan\repos\dotnet-tools.json` pins csharpier 0.16.0 whose command id is `dotnet-csharpier`, not `csharpier`, so `dotnet tool restore` fails). The globally installed CSharpier 1.3.0 is used instead via the `csharpier` command, which is the policy-sanctioned equivalent per `.claude/rules/csharp.md` ("Command: `csharpier .` (or `dotnet csharpier .` when installed as a dotnet tool)"). CSharpier 1.x replaces `--check` with the `check` subcommand.
+
+EXIT_CODE: 0
+
+Output Summary: PASS. Checked 148 files in 424ms; no files require reformatting. Baseline formatting is clean.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-test.2026-06-12T22-30.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-test.2026-06-12T22-30.md
@@ -1,0 +1,22 @@
+# Baseline — Test + Coverage
+
+Timestamp: 2026-06-12T22-30
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+
+EXIT_CODE: 0
+
+Output Summary:
+- Result: PASS. All test projects green.
+- Totals: 425 passed, 0 failed, 3 skipped (platform-gated COM test + 2 publish-output tests).
+  - OpenClaw.HostAdapter.Tests: 71 passed, 0 failed, 0 skipped.
+  - OpenClaw.Core.Tests: 178 passed, 0 failed, 0 skipped.
+  - OpenClaw.MailBridge.Tests: 176 passed, 0 failed, 3 skipped.
+- Assembly-level coverage headline (cobertura, whole assembly — the no-regression reference for the touched projects):
+  - OpenClaw.HostAdapter.Tests cobertura: line-rate 0.8499 (84.99%), branch-rate 0.6288 (62.88%).
+  - OpenClaw.Core.Tests cobertura: line-rate 0.8932 (89.32%), branch-rate 0.7758 (77.58%).
+- Note: cobertura `coverage` element rates are whole-assembly aggregates. The repository coverage gate (line >= 85% / branch >= 75%) and the no-regression rule apply to changed code; changed-code coverage is computed in P3-T5 against these baseline figures.
+
+Coverage attachment paths:
+- tests/OpenClaw.HostAdapter.Tests/TestResults/e8dc7a2e-5085-4b24-b5c2-f6fec564fa30/coverage.cobertura.xml
+- tests/OpenClaw.Core.Tests/TestResults/2c39c1a6-8dbb-49a3-a07c-fec09ee0608d/coverage.cobertura.xml

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-typecheck.2026-06-12T22-30.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-typecheck.2026-06-12T22-30.md
@@ -1,0 +1,9 @@
+# Baseline — Nullable Type-Check
+
+Timestamp: 2026-06-12T22-30
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded with warnings-as-errors. 0 Warning(s), 0 Error(s). No nullable-flow warnings; baseline nullable type-state is clean.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/other/phase0-instructions-read.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/other/phase0-instructions-read.md
@@ -1,0 +1,29 @@
+# Phase 0 — Policy Instructions Read
+
+Timestamp: 2026-06-12T22-30
+
+Policy Order:
+1. `.claude/skills/policy-compliance-order/SKILL.md` (policy reading order)
+2. `CLAUDE.md` / project standing instructions (loaded into context)
+3. `.claude/rules/general-code-change.md` (cross-language code change policy)
+4. `.claude/rules/general-unit-test.md` (cross-language unit test policy)
+5. `.claude/rules/csharp.md` (C#-specific toolchain and coding standards)
+6. `.claude/rules/quality-tiers.md` (T1–T4 module rigor tiers and gate matrix)
+7. `.claude/rules/architecture-boundaries.md` (project dependency and COM confinement rules)
+
+Files Read:
+- `.claude/skills/policy-compliance-order/SKILL.md`
+- `CLAUDE.md` (and the `.claude/rules/*` content surfaced in standing instructions: benchmark-baselines.md, ci-workflows.md, general-code-change.md, general-unit-test.md, quality-tiers.md, tonality.md)
+- `.claude/rules/general-code-change.md`
+- `.claude/rules/general-unit-test.md`
+- `.claude/rules/csharp.md`
+- `.claude/rules/quality-tiers.md`
+- `.claude/rules/architecture-boundaries.md`
+
+Key constraints carried into execution:
+- Mandatory C# toolchain loop: format (CSharpier) -> build/analyzers -> nullable type-check -> architecture -> test+coverage. Restart from step 1 on any failure or auto-fix.
+- File size limit: no production/test file may exceed 500 lines.
+- Coverage gates (uniform T1–T4): line >= 85%, branch >= 75%; no regression on changed lines.
+- Architecture boundaries: no new ProjectReference edges; Core -> HostAdapter.Contracts only; HostAdapter -> HostAdapter.Contracts + MailBridge.Contracts; no COM crossing.
+- Evidence written only under `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/<kind>/`.
+- Tonality: professional, factual, evidence-first; no humor/hyperbole.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/ac-mapping.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/ac-mapping.2026-06-12T23-17.md
@@ -1,0 +1,17 @@
+# Acceptance Criteria to Evidence Mapping
+
+Timestamp: 2026-06-12T23-17
+
+AC source of record: `docs/features/active/evolve-hostadapter-graph-surface-76/user-story.md` (7 criteria). All 7 boxes checked after evidence confirmed PASS.
+
+| AC | Criterion (abbreviated) | Verifying evidence | Verdict |
+|---|---|---|---|
+| AC1 | Graph-shaped routes; no `/v1/*` except `/status` | `evidence/qa-gates/route-surface-check.2026-06-12T23-17.md` (zero `/v1/`, 5 Graph routes + /status); `HostAdapterEndpointTests`, `HostAdapterAuthTests`, `HostAdapterValidationTests`, `HostAdapterMappingTests`, `HostAdapterEnvelopeTests` (all pass) | PASS |
+| AC2 | `IHostAdapterClient`/`HostAdapterHttpClient` call Graph endpoints, envelope-wrapped; `ListMeetingRequestsAsync` retained | `evidence/qa-gates/contract-compat.2026-06-12T23-17.md`; `HostAdapterHttpClientTests` (Graph-path assertions pass) | PASS |
+| AC3 | `OpenClawOptions.HostAdapter.BaseUrl` default has no `/v1/` | P2-T1 (`src/OpenClaw.Core/CoreOptions.cs` default `http://host.docker.internal:4319/`); `HostAdapterHttpClientTests` base-url + `GetStatusAsync_SendsGetRequestToStatusPath` (`/status`) pass | PASS |
+| AC4 | Adapter version reports `1.0.0` via `meta.adapterVersion` | P1-T10 (`<Version>1.0.0</Version>` in csproj); P1-T18 `HostAdapterVersionTests` (`DefaultAdapterVersion == "1.0.0"`, pass); `evidence/qa-gates/contract-compat.2026-06-12T23-17.md` | PASS |
+| AC5 | `MailboxId` default `"me"` configurable on `HostAdapterOptions`; renders `{id}` | Adapter: P1-T1/P1-T2 (`HostAdapterOptions.MailboxId`, post-configure normalize). Core: P2-T2/P2-T3 (`CoreOptions.HostAdapterOptions.MailboxId`, `HostAdapterHttpClient` sources `{id}`). `/users/me/...` assertions in `HostAdapterHttpClientTests` pass | PASS |
+| AC6 | Existing contract/endpoint tests pass against new routes, not weakened | `evidence/qa-gates/phase1-test`, `phase2-test`, `final-test.2026-06-12T23-17.md` (428 passed, 0 failed); assertions retained at equal strength | PASS |
+| AC7 | Line >= 85%, branch >= 75% on changed code; no regression | `evidence/qa-gates/coverage-delta.2026-06-12T23-17.md` (changed-code lines 98.85%, branches 79.41%; no changed-line regression) | PASS |
+
+All 7 acceptance criteria are checked off in `user-story.md`.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/architecture-check.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/architecture-check.2026-06-12T23-17.md
@@ -1,0 +1,28 @@
+# Architecture Boundary Verification
+
+Timestamp: 2026-06-12T23-17
+
+Command: `rg 'ProjectReference Include="[^"]*"' src --glob *.csproj`
+
+EXIT_CODE: 0
+
+## Inspected ProjectReference edges
+
+| Project | References | Allowed by rule |
+|---|---|---|
+| OpenClaw.MailBridge.Contracts | (none) | Rule 1 (leaf) |
+| OpenClaw.MailBridge | OpenClaw.MailBridge.Contracts | Rule 2 |
+| OpenClaw.MailBridge.Client | OpenClaw.MailBridge.Contracts | Rule 3 |
+| OpenClaw.HostAdapter.Contracts | OpenClaw.MailBridge.Contracts | Rule 4 |
+| OpenClaw.HostAdapter | OpenClaw.HostAdapter.Contracts, OpenClaw.MailBridge.Contracts | Rule 5 |
+| OpenClaw.Core | OpenClaw.HostAdapter.Contracts | Rule 6 |
+
+## Verdict
+
+- No new `ProjectReference` edge was introduced by this feature. The only `.csproj` modification was adding `<Version>1.0.0</Version>` to `OpenClaw.HostAdapter.csproj` (no reference change).
+- `OpenClaw.Core` references only `OpenClaw.HostAdapter.Contracts` (design note N2 honored: the Core-side `MailboxId` mirror was added in `OpenClaw.Core/CoreOptions.cs`, NOT by referencing `OpenClaw.HostAdapter`).
+- `OpenClaw.HostAdapter` references only `OpenClaw.HostAdapter.Contracts` + `OpenClaw.MailBridge.Contracts`.
+- `OpenClaw.HostAdapter.Contracts` references only `OpenClaw.MailBridge.Contracts`.
+- No COM boundary crossed: no new Outlook COM/`Marshal`/`Microsoft.Office.Interop.Outlook` usage was added to any web project; the changes are HTTP route strings, query-parameter parsing, options, and version.
+
+Result: PASS. Architecture boundaries unchanged; no violations.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/contract-compat.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/contract-compat.2026-06-12T23-17.md
@@ -1,0 +1,48 @@
+# Contract / Schema Compatibility Check (T2 IHostAdapterClient)
+
+Timestamp: 2026-06-12T23-17
+
+This is a breaking change to the HostAdapter HTTP surface and the `IHostAdapterClient` T2 contract (path-and-query reshaping to Microsoft Graph-shaped routes). Per `.claude/rules/quality-tiers.md`, a T1/T2 contract breaking change requires a major version bump and a compatibility check.
+
+## IHostAdapterClient member parity (C# signatures unchanged)
+
+`git diff HEAD src/OpenClaw.HostAdapter.Contracts/IHostAdapterClient.cs` shows only XML-doc (`///`) lines changed; no signature line was added or removed. All six members are retained with identical signatures:
+
+| Member | Signature retained | Notes |
+|---|---|---|
+| `GetStatusAsync(requestId, ct)` | yes | -> `ApiEnvelope<BridgeStatusDto>` |
+| `ListMessagesAsync(sinceUtc, limit, requestId, ct)` | yes | -> `ApiEnvelope<ItemsResponse<MessageDto>>` |
+| `GetMessageAsync(bridgeId, requestId, ct)` | yes | -> `ApiEnvelope<MessageDto>` |
+| `ListMeetingRequestsAsync(sinceUtc, limit, requestId, ct)` | yes | RETAINED per D1; -> `ApiEnvelope<ItemsResponse<MessageDto>>` |
+| `ListCalendarWindowAsync(startUtc, endUtc, limit, requestId, ct)` | yes | -> `ApiEnvelope<ItemsResponse<EventDto>>` |
+| `GetEventAsync(bridgeId, requestId, ct)` | yes | -> `ApiEnvelope<EventDto>` |
+
+## HostAdapterHttpClient implementation parity
+
+`src/OpenClaw.Core/HostAdapterHttpClient.cs` implements every interface member and emits the Graph-shaped wire routes:
+
+- `GetStatusAsync` -> `status`
+- `ListMessagesAsync` -> `users/{id}/messages?$filter=receivedDateTime ge {iso}&$top={limit}`
+- `GetMessageAsync` -> `users/{id}/messages/{escaped messageId}`
+- `ListMeetingRequestsAsync` -> `users/{id}/messages?$filter=meetingMessageType ne null and receivedDateTime ge {iso}&$top={limit}`
+- `ListCalendarWindowAsync` -> `users/{id}/calendarView?startDateTime={iso}&endDateTime={iso}&$top={limit}`
+- `GetEventAsync` -> `users/{id}/events/{escaped eventId}`
+
+The `{id}` segment is sourced from `options.HostAdapter.MailboxId` (default `"me"`). Verified by the updated `HostAdapterHttpClientTests.cs` (Core.Tests, all passing).
+
+## DTO / envelope schema unchanged
+
+`git diff --name-only HEAD` contains no `ApiEnvelope`, `ItemsResponse`, `MessageDto`, `EventDto`, `ApiMeta`, `ApiError`, or `BridgeStatusDto` file. These contract types are byte-for-byte unchanged. This is a path-and-query change only.
+
+## Adapter version (major bump)
+
+`<Version>1.0.0</Version>` is declared in `src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj`. `HostAdapterOptions.DefaultAdapterVersion` resolves to `1.0.0` (the getter formats the assembly version to the three-component major.minor.patch form). Verified by `HostAdapterVersionTests.DefaultAdapterVersion_should_report_1_0_0_from_the_assembly_version` (passing). This is the first major bump, signalling the breaking HTTP surface change reported through `meta.adapterVersion`.
+
+## In-repo caller compilation and tests
+
+All in-repo callers compile and pass:
+- `HostAdapterHttpClient` (Core) — implements the interface; Core.Tests pass.
+- `HostAdapterSchedulingService` (Core) — calls only `GetMessageAsync`, `GetEventAsync`, `ListCalendarWindowAsync` with unchanged signatures; no functional edit required (design note N3); `HostAdapterSchedulingServiceTests` pass.
+- `MessagePollingWorker` and its tests — `ListMeetingRequestsAsync`/`ListMessagesAsync` mock setups remain valid (signatures unchanged); tests pass.
+
+Result: PASS. Member parity confirmed, implementation confirmed, DTO/envelope unchanged, version 1.0.0 confirmed, all callers compile and pass.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/coverage-delta.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/coverage-delta.2026-06-12T23-17.md
@@ -1,0 +1,41 @@
+# Coverage Delta and Threshold Verification
+
+Timestamp: 2026-06-12T23-17
+
+Inputs:
+- Baseline: `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-test.2026-06-12T22-30.md`
+- Post-change: `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-test.2026-06-12T23-17.md`
+
+## Whole-assembly coverage (no-regression reference)
+
+| Assembly | Baseline line% | Post line% | Baseline branch% | Post branch% |
+|---|---|---|---|---|
+| OpenClaw.HostAdapter | 84.99% | 84.62% | 62.88% | 62.37% |
+| OpenClaw.Core | 89.32% | 89.36% | 77.58% | 77.58% |
+
+Note: The whole-assembly HostAdapter figures are dominated by pre-existing Program.cs endpoint guard branches and are below the 85%/75% bar at the assembly level both before and after this change; they are unchanged in character by this work. The repository gate is line >= 85% / branch >= 75% on **changed code**, with no regression on changed lines. The changed-code measurement below is the gate surface.
+
+## Changed-code coverage (the gate surface)
+
+Per-file coverage computed from the post-change cobertura reports for the production files modified by this feature (deduplicating compiler-generated class entries by source line, reading `condition-coverage` for branches):
+
+| Changed production file | Lines | Line% | Branches | Branch% |
+|---|---|---|---|---|
+| OpenClaw.HostAdapter/Program.cs | 329/329 | 100.0% | 4/4 | 100.0% |
+| OpenClaw.HostAdapter/HostAdapterRequestValidation.cs | 114/118 | 96.6% | 21/26 | 80.8% |
+| OpenClaw.HostAdapter/HostAdapterOptions.cs | 19/21 | 90.5% | 2/4 | 50.0% |
+| OpenClaw.Core/HostAdapterHttpClient.cs | 55/55 | 100.0% | 0/0 | n/a (no branches) |
+| OpenClaw.Core/CoreOptions.cs | n/a | n/a | n/a | no coverable sequence points (auto-property defaults) |
+| **Changed-code aggregate** | **517/523** | **98.85%** | **27/34** | **79.41%** |
+
+## Threshold verdict
+
+- Changed-code line coverage: 98.85% >= 85% — PASS.
+- Changed-code branch coverage: 79.41% >= 75% — PASS.
+- No regression on changed lines: the changed/new lines in Program.cs, HostAdapterHttpClient.cs (both 100%), HostAdapterRequestValidation.cs (96.6% line), and the new MailboxId/version members are at or above their prior coverage; the parameter-name string changes and route templates are exercised by the updated and added tests. PASS.
+
+Residual note (non-blocking): HostAdapterOptions.cs branch coverage (2/4) reflects two defensive branches in the new `FormatAdapterVersion` helper (the `version is null` fallback and the `version.Build < 0` guard) that the loaded assembly cannot reach at runtime (the real assembly version is non-null with Build >= 0). These are intentional defensive guards; the aggregate changed-code branch coverage (79.41%) remains above the 75% threshold.
+
+## Outcome
+
+PASS. Both changed-code thresholds are met and no changed line regressed.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-build.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-build.2026-06-12T23-17.md
@@ -1,0 +1,9 @@
+# Final QA Gate: Build / Analyzers
+
+Timestamp: 2026-06-12T23-17
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). Zero analyzer errors across all 9 projects with code-style enforcement enabled.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-format.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-format.2026-06-12T23-17.md
@@ -1,0 +1,9 @@
+# Final QA Gate: Formatting
+
+Timestamp: 2026-06-12T23-17
+
+Command: `csharpier check .` (CSharpier 1.3.0 global tool; dotnet-tool form unavailable in this worktree per baseline-format note)
+
+EXIT_CODE: 0
+
+Output Summary: PASS. Checked 149 files; no files require reformatting. No files reformatted, loop not restarted.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-test.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-test.2026-06-12T23-17.md
@@ -1,0 +1,22 @@
+# Final QA Gate: Test + Coverage
+
+Timestamp: 2026-06-12T23-17
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+
+EXIT_CODE: 0
+
+Output Summary:
+- Result: PASS in a single clean toolchain pass.
+- Totals: 428 passed, 0 failed, 3 skipped.
+  - OpenClaw.HostAdapter.Tests: 74 passed.
+  - OpenClaw.Core.Tests: 178 passed.
+  - OpenClaw.MailBridge.Tests: 176 passed, 3 skipped (platform-gated COM + 2 publish-output).
+- Whole-assembly coverage headline (cobertura):
+  - OpenClaw.HostAdapter assembly: line-rate 0.8462 (84.62%), branch-rate 0.6237 (62.37%).
+  - OpenClaw.Core assembly: line-rate 0.8936 (89.36%), branch-rate 0.7758 (77.58%).
+- Changed-code coverage (the gate surface; see coverage-delta artifact): aggregate lines 517/523 = 98.85%, branches 27/34 = 79.41%. Both above the line >= 85% / branch >= 75% thresholds.
+
+Coverage attachment paths:
+- tests/OpenClaw.HostAdapter.Tests/TestResults/8d218b5b-4811-4254-a89b-8c263055367c/coverage.cobertura.xml
+- tests/OpenClaw.Core.Tests/TestResults/93de4c82-c23c-4300-93ab-8aa779dbcf9e/coverage.cobertura.xml

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-typecheck.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-typecheck.2026-06-12T23-17.md
@@ -1,0 +1,9 @@
+# Final QA Gate: Nullable Type-Check
+
+Timestamp: 2026-06-12T23-17
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded with warnings-as-errors. 0 Warning(s), 0 Error(s). No nullable-flow or other warnings.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase1-build.2026-06-12T23-11.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase1-build.2026-06-12T23-11.md
@@ -1,0 +1,9 @@
+# Phase 1 — QA Gate: Build / Analyzers
+
+Timestamp: 2026-06-12T23-11
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). All 9 projects compiled with analyzers and code-style enforcement enabled after the Phase 1 HostAdapter route, validation, options, version, and contract-doc changes.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase1-format.2026-06-12T23-11.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase1-format.2026-06-12T23-11.md
@@ -1,0 +1,9 @@
+# Phase 1 — QA Gate: Formatting
+
+Timestamp: 2026-06-12T23-11
+
+Command: `csharpier format .` then `csharpier check .` (CSharpier 1.3.0 global tool; see baseline-format note on the dotnet-tool form being unavailable in this worktree)
+
+EXIT_CODE: 0
+
+Output Summary: PASS. Formatted 149 files; subsequent `csharpier check .` reports all 149 files already conform (idempotent). No outstanding formatting differences.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase1-test.2026-06-12T23-11.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase1-test.2026-06-12T23-11.md
@@ -1,0 +1,21 @@
+# Phase 1 — QA Gate: Test + Coverage
+
+Timestamp: 2026-06-12T23-11
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+
+EXIT_CODE: 0
+
+Output Summary:
+- Result: PASS in a single clean toolchain pass (format -> build -> typecheck -> test).
+- Totals: 428 passed, 0 failed, 3 skipped.
+  - OpenClaw.HostAdapter.Tests: 74 passed (71 prior + 2 new meeting-requests/plain-messages dispatch tests + 1 new DefaultAdapterVersion test).
+  - OpenClaw.Core.Tests: 178 passed (unchanged in Phase 1).
+  - OpenClaw.MailBridge.Tests: 176 passed, 3 skipped (platform/publish-output).
+- Coverage headline (cobertura, whole assembly):
+  - OpenClaw.HostAdapter.Tests: line-rate 0.8462 (84.62%), branch-rate 0.6237 (62.37%).
+  - OpenClaw.Core.Tests: line-rate 0.8932 (89.32%), branch-rate 0.7758 (77.58%).
+- Note: whole-assembly cobertura rates include code outside the changed surface. The repository gate (line >= 85% / branch >= 75%) and no-regression rule apply to changed code; the changed-code delta is computed in P3-T5. The HostAdapter assembly rate moved 84.99% -> 84.62% (line) and 62.88% -> 62.37% (branch) from baseline, attributable to added but not-yet-fully-exercised branch arms (verified per-file in P3-T5).
+- New HostAdapter.Tests added: meeting-requests dispatch (meetingMessageType ne null), plain-messages dispatch, DefaultAdapterVersion == "1.0.0".
+
+Coverage attachment path: tests/OpenClaw.HostAdapter.Tests/TestResults/f0fe595f-e5c7-4a1b-a1a1-fbe68cdf4eac/coverage.cobertura.xml

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase1-typecheck.2026-06-12T23-11.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase1-typecheck.2026-06-12T23-11.md
@@ -1,0 +1,9 @@
+# Phase 1 — QA Gate: Nullable Type-Check
+
+Timestamp: 2026-06-12T23-11
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded with warnings-as-errors. 0 Warning(s), 0 Error(s). No nullable-flow regressions introduced by the Phase 1 changes.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase2-build.2026-06-12T23-15.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase2-build.2026-06-12T23-15.md
@@ -1,0 +1,9 @@
+# Phase 2 — QA Gate: Build / Analyzers
+
+Timestamp: 2026-06-12T23-15
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). All projects compiled with analyzers and code-style enforcement after the Core BaseUrl default, MailboxId mirror, and HostAdapterHttpClient Graph-shaped relative-path changes.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase2-format.2026-06-12T23-15.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase2-format.2026-06-12T23-15.md
@@ -1,0 +1,9 @@
+# Phase 2 — QA Gate: Formatting
+
+Timestamp: 2026-06-12T23-15
+
+Command: `csharpier format .` then `csharpier check .` (CSharpier 1.3.0 global tool)
+
+EXIT_CODE: 0
+
+Output Summary: PASS. Formatted 149 files; `csharpier check .` confirms all 149 files conform. No outstanding formatting differences after the Phase 2 Core changes.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase2-test.2026-06-12T23-15.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase2-test.2026-06-12T23-15.md
@@ -1,0 +1,22 @@
+# Phase 2 — QA Gate: Test + Coverage
+
+Timestamp: 2026-06-12T23-15
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+
+EXIT_CODE: 0
+
+Output Summary:
+- Result: PASS in a single clean toolchain pass (format -> build -> typecheck -> test).
+- Totals: 428 passed, 0 failed, 3 skipped.
+  - OpenClaw.HostAdapter.Tests: 74 passed.
+  - OpenClaw.Core.Tests: 178 passed (HostAdapterHttpClient tests updated to assert Graph-shaped paths, new base URL, $filter/$top/startDateTime/endDateTime/meetingMessageType, and users/me/{...} segments).
+  - OpenClaw.MailBridge.Tests: 176 passed, 3 skipped.
+- Coverage headline (cobertura, whole assembly):
+  - OpenClaw.Core.Tests: line-rate 0.8936 (89.36%), branch-rate 0.7758 (77.58%).
+  - OpenClaw.HostAdapter.Tests: line-rate 0.8462 (84.62%), branch-rate 0.6237 (62.37%).
+- Note: whole-assembly rates; changed-code delta computed in P3-T5. Core line rate moved 89.32% -> 89.36% from baseline (no regression). MailboxId mirror and Graph-shaped paths are exercised by the updated client tests.
+
+Coverage attachment paths:
+- tests/OpenClaw.Core.Tests/TestResults/1cd9a520-86a3-4c38-970e-b4562820cebe/coverage.cobertura.xml
+- tests/OpenClaw.HostAdapter.Tests/TestResults/939b880f-995c-4c88-96e3-a430109c4b46/coverage.cobertura.xml

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase2-typecheck.2026-06-12T23-15.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/phase2-typecheck.2026-06-12T23-15.md
@@ -1,0 +1,9 @@
+# Phase 2 — QA Gate: Nullable Type-Check
+
+Timestamp: 2026-06-12T23-15
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded with warnings-as-errors. 0 Warning(s), 0 Error(s). No nullable-flow regressions from the Phase 2 Core changes.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/route-surface-check.2026-06-12T23-17.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/route-surface-check.2026-06-12T23-17.md
@@ -1,0 +1,27 @@
+# Route Surface Check
+
+Timestamp: 2026-06-12T23-17
+
+Command: `grep -c '"/v1/' src/OpenClaw.HostAdapter/Program.cs` and `grep -A1 'app.MapGet' src/OpenClaw.HostAdapter/Program.cs`
+
+EXIT_CODE: 0
+
+## /v1/ template scan
+
+Zero matches for the `"/v1/` literal in `src/OpenClaw.HostAdapter/Program.cs`. No bespoke `/v1/*` route template remains.
+
+## Route inventory (post-change)
+
+The HostAdapter registers exactly five GET routes:
+
+1. `GET /status` — operational probe (sole non-`/users/{id}/...` route; no Graph equivalent).
+2. `GET /users/{id}/messages` — single handler with two branches:
+   - plain messages: dispatches `BuildListMessages` when `$filter` has no `meetingMessageType ne null` predicate.
+   - meeting-requests: dispatches `BuildListMeetingRequests` when `$filter` contains `meetingMessageType ne null` (design note N1; verified by the two new dispatch tests in `HostAdapterMappingTests.cs`).
+3. `GET /users/{id}/messages/{messageId}` — single message.
+4. `GET /users/{id}/calendarView` — calendar window (`startDateTime`/`endDateTime`/`$top`).
+5. `GET /users/{id}/events/{eventId}` — single event.
+
+## Verdict
+
+PASS. No `/v1/` template remains; `/status` is the only non-Graph route; all other routes are Graph-shaped `/users/{id}/...` forms.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/feature-audit.2026-06-12T23-30.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/feature-audit.2026-06-12T23-30.md
@@ -1,0 +1,99 @@
+# Feature Audit: evolve-hostadapter-graph-surface (#76)
+
+**Audit Date:** 2026-06-12
+**Feature Folder:** `docs/features/active/evolve-hostadapter-graph-surface-76`
+**Base Branch:** `main` (`3041d083691cd77b2b2e888580fc9f2ab8bc611f`)
+**Head Branch:** `open-claw-bridge-wt-2026-06-12-22-19` (`e3bc4506e1ebce0080e057306b91ffbbb77fd945`)
+**Work Mode:** `full-feature`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `3041d083691cd77b2b2e888580fc9f2ab8bc611f`)
+- **Head branch/commit:** `open-claw-bridge-wt-2026-06-12-22-19` (commit `e3bc4506e1ebce0080e057306b91ffbbb77fd945`)
+- **Merge base:** `3041d083691cd77b2b2e888580fc9f2ab8bc611f` (identical to base tip)
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/**`
+  - Additional evidence: direct `git diff 3041d08..e3bc450`, independent build/test/coverage runs
+- **Feature folder used:** `docs/features/active/evolve-hostadapter-graph-surface-76`
+- **Requirements source:** `user-story.md` (authoritative checkbox ACs) and `spec.md` (Definition of Done prose).
+- **Work mode resolution note:** `issue.md` is absent from the feature folder. Per the work-mode contract, a missing/malformed marker fails closed to `full-feature`; the orchestrator prompt also explicitly specified `full-feature`. `full-feature` resolves AC sources to `spec.md` and `user-story.md`. The checkbox acceptance criteria live under `## Acceptance Criteria` in `user-story.md`.
+- **Scope note:** Audit scope is the full branch diff vs the resolved base, not any plan/task subset. The PR-context summary's "Core logic changes: 0 files" classification was rejected as inaccurate (seven `src/**` C# files changed); the audit used the direct branch diff. No caller scope-narrowing instruction was present.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `docs/features/active/evolve-hostadapter-graph-surface-76/user-story.md` — primary (checkbox ACs)
+- `docs/features/active/evolve-hostadapter-graph-surface-76/spec.md` — secondary (prose Definition of Done; not a separate checkbox AC set)
+
+### Acceptance criteria (from user-story.md `## Acceptance Criteria`)
+
+1. HostAdapter exposes the Graph-shaped routes (`/users/{id}/messages`, `/users/{id}/messages/{messageId}`, `/users/{id}/calendarView`, `/users/{id}/events/{eventId}`, and meeting-requests as a messages-filtered query on `meetingMessageType`) and no longer serves the `/v1/*` bespoke routes (the `/status` operational probe excepted).
+2. `IHostAdapterClient` and `HostAdapterHttpClient` call the Graph-shaped endpoints and receive envelope-wrapped (`ApiEnvelope<T>`) results, with `ListMeetingRequestsAsync` retained on the interface.
+3. `OpenClawOptions.HostAdapter.BaseUrl` default no longer contains `/v1/`.
+4. The adapter version reports `1.0.0` (via `meta.adapterVersion`) to signal the breaking change.
+5. `MailboxId` (default `"me"`) is configurable on `HostAdapterOptions` and is used to render the `{id}` path segment.
+6. Existing contract/endpoint tests pass against the new routes (HostAdapter.Tests and Core.Tests updated, not weakened).
+7. Line coverage >= 85% and branch coverage >= 75% on changed code; no coverage regression on changed lines.
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | Graph-shaped routes served; no `/v1/*` (except `/status`) | PASS | `src/OpenClaw.HostAdapter/Program.cs` registers `/status`, `/users/{id}/messages`, `/users/{id}/messages/{messageId}`, `/users/{id}/calendarView`, `/users/{id}/events/{eventId}`; the messages handler branches on the `meetingMessageType ne null` `$filter` predicate to the meeting-requests command. No `/v1/` string remains in `src/OpenClaw.HostAdapter`. | `grep -rn '"/v1/' src/OpenClaw.HostAdapter/` (no matches); `grep -n 'MapGet' src/OpenClaw.HostAdapter/Program.cs` (5 routes) | Meeting-requests is a filtered messages query, matching the spec mapping. |
+| 2 | Client calls Graph endpoints; envelope-wrapped; `ListMeetingRequestsAsync` retained | PASS | `HostAdapterHttpClient.cs` emits the six Graph-shaped relative paths returning `ApiEnvelope<...>`; `IHostAdapterClient` retains all six members including `ListMeetingRequestsAsync` (XML-doc only changed). `HostAdapterHttpClientTests` assert `/users/me/...` paths and renamed params; all pass. | `dotnet test tests/OpenClaw.Core.Tests/...` (178/178); diff of `IHostAdapterClient.cs` (signatures unchanged) | Contract-compat evidence corroborates member parity. |
+| 3 | `BaseUrl` default no longer contains `/v1/` | PASS | `CoreOptions.cs`: `BaseUrl` default changed to `http://host.docker.internal:4319/`. Test factory and client tests updated to the `/v1/`-less base URL. | diff of `src/OpenClaw.Core/CoreOptions.cs` | D6 honored. |
+| 4 | Adapter version reports `1.0.0` via `meta.adapterVersion` | PASS | `OpenClaw.HostAdapter.csproj` declares `<Version>1.0.0</Version>`; `FormatAdapterVersion` renders the 3-component `1.0.0`; `HostAdapterVersionTests.DefaultAdapterVersion_should_report_1_0_0...` asserts `"1.0.0"` and passes. | `grep -n 'Version' src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj`; `dotnet test tests/OpenClaw.HostAdapter.Tests/...` | The in-process test factory overrides the envelope version to `"test-version"`, so the assembly-derived value is asserted directly (documented in the test). |
+| 5 | `MailboxId` (default `"me"`) configurable and renders `{id}` | PASS | `HostAdapterOptions.cs` adds `MailboxId` (default `"me"`) with `Program.cs` post-configure normalization; `HostAdapterHttpClient.cs` sources `{id}` from `options.HostAdapter.MailboxId` (URL-escaped). Client tests assert `/users/me/...`. | diff of `HostAdapterOptions.cs`, `HostAdapterHttpClient.cs`; `dotnet test tests/OpenClaw.Core.Tests/...` | Server-side the `{id}` segment is presentational (not used to scope data); see code-review Minor finding. |
+| 6 | Existing contract/endpoint tests pass against new routes; updated not weakened | PASS | All affected tests updated to Graph-shaped routes and pass: HostAdapter.Tests 74/74, Core.Tests 178/178. New tests strengthen coverage (branch dispatch, version). No tests removed or skipped. | `dotnet test tests/OpenClaw.HostAdapter.Tests/...` (74/74); `dotnet test tests/OpenClaw.Core.Tests/...` (178/178) | Updated assertions verify stronger Graph-shaped shapes. |
+| 7 | Changed-code line >= 85% / branch >= 75%; no regression on changed lines | PASS | Changed-code aggregate 98.85% line / 79.41% branch; package cobertura HostAdapter 97.08% line / 86.30% branch, Core 98.58% line / 90.32% branch; no changed line regressed. | inspected `evidence/qa-gates/coverage-delta.2026-06-12T23-17.md`; cobertura under `tests/**/TestResults/*/coverage.cobertura.xml` | Two unreachable defensive branches in `FormatAdapterVersion` explain residual branch headroom; aggregate above threshold. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+**Criteria summary:**
+- **PASS:** 7 criteria
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 0 criteria
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. None.
+
+**Recommended follow-up verification steps:**
+
+1. Repair or re-pin the CSharpier dotnet-tool so formatting is verified under the pinned version (non-blocking; code-review Minor finding).
+2. Optionally add a one-line comment in `Program.cs` noting the `{id}` segment is accepted for Graph route-shape parity and is not used to scope data in the local adapter.
+
+---
+
+## Acceptance Criteria Check-off
+
+Per the acceptance-criteria tracking rules, all seven criteria are evaluated PASS. In `user-story.md` they were already recorded as `[x]` by the executor during delivery; this audit confirms each PASS against independent evidence and leaves the existing checked state intact. No additional source-file edit was required (the boxes are already checked and the evaluation confirms them).
+
+### AC Status Summary
+
+- Source: `docs/features/active/evolve-hostadapter-graph-surface-76/user-story.md`
+- Total AC items: 7
+- Checked off (delivered): 7
+- Remaining (unchecked): 0
+- Items remaining: None.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `user-story.md` | 7 | 7 | 0 | Checkbox-backed; all PASS and confirmed; already checked at delivery. |
+| `spec.md` | 0 | 0 | 0 | Prose Definition of Done; not a separate checkbox AC set. Behavior covered by the seven user-story criteria above. |
+
+No new source-file checkbox change was made because all seven authoritative criteria were already checked `[x]` and this audit's independent evaluation confirms each as PASS.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/plan.2026-06-12T22-21.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/plan.2026-06-12T22-21.md
@@ -1,0 +1,277 @@
+# evolve-hostadapter-graph-surface - Plan
+
+- **Issue:** #76
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-12T22-21
+- **Status:** Draft
+- **Version:** 1.0
+- **Work Mode:** full-feature
+
+## Required References
+
+- Policy reading order: `.claude/skills/policy-compliance-order/SKILL.md`
+- General code change policy: `.claude/rules/general-code-change.md`
+- General unit test policy: `.claude/rules/general-unit-test.md`
+- C# code standards: `.claude/rules/csharp.md`
+- Quality tiers / gate matrix: `.claude/rules/quality-tiers.md`
+- Architecture boundaries: `.claude/rules/architecture-boundaries.md`
+- Evidence and timestamp conventions: `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Authoritative Inputs
+
+- Spec: `docs/features/active/evolve-hostadapter-graph-surface-76/spec.md`
+- User story / AC source of record: `docs/features/active/evolve-hostadapter-graph-surface-76/user-story.md`
+- Research: `artifacts/research/issue-76-graph-surface.md`
+
+## Locked Design Decisions (operator-confirmed; do not re-open)
+
+- D1: KEEP `ListMeetingRequestsAsync`; only its wire route changes to the Graph-shaped messages-filtered form. Do not touch the bridge RPC chain, `MessagePollingWorker`, or Core UI.
+- D2: Add `MailboxId` to `src/OpenClaw.HostAdapter/HostAdapterOptions.cs`, default `"me"`; the `{id}` path segment is sourced from it.
+- D3: single event `GET /users/{id}/events/{eventId}`.
+- D4: messages list `GET /users/{id}/messages?$filter=receivedDateTime ge {iso}&$top={limit}`; single message `/users/{id}/messages/{messageId}`; calendar `GET /users/{id}/calendarView?startDateTime={iso}&endDateTime={iso}&$top={limit}`. Status stays `GET /status`.
+- D5: add `<Version>1.0.0</Version>` to `src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj`.
+- D6: `OpenClawOptions.HostAdapter.BaseUrl` default -> `http://host.docker.internal:4319/` in `src/OpenClaw.Core/CoreOptions.cs`.
+- Envelope/DTOs unchanged.
+
+## Design Notes Captured During Planning (must be honored by the executor)
+
+- N1 (route collision): the messages list and the meeting-requests list both resolve to the route template `/users/{id}/messages` and differ only by `$filter` content. ASP.NET Core minimal APIs cannot register two handlers with the same `{HTTP method, route template}`. Therefore `Program.cs` MUST register **one** `GET /users/{id}/messages` handler that inspects the `$filter` value: when the filter contains the `meetingMessageType ne null` predicate it dispatches `commandBuilder.BuildListMeetingRequests(...)`; otherwise it dispatches `commandBuilder.BuildListMessages(...)`. The receivedDateTime lower bound and `$top` are parsed the same way in both branches. The `ListMeetingRequestsAsync` interface method and the `BuildListMeetingRequests` command chain are unchanged per D1.
+- N2 (Core-side MailboxId): `OpenClaw.Core` must render `/users/{id}/...` paths. Per architecture-boundaries Rule 6, Core must not reference `OpenClaw.HostAdapter` (the web project that owns `HostAdapterOptions.MailboxId`). The minimal approach is to add a `MailboxId` property (default `"me"`) to the Core-side `HostAdapterOptions` in `src/OpenClaw.Core/CoreOptions.cs` and read it in `HostAdapterHttpClient`. This keeps the constant configurable and consistent with the adapter default without crossing a project boundary. (A hardcoded `"me"` constant is the fallback if a config property is judged out of scope; the config property is the recommended choice and is what this plan specifies.)
+- N3 (signatures unchanged): `IHostAdapterClient` method signatures keep the same C# shape (`sinceUtc`, `limit`, `bridgeId`, `startUtc`/`endUtc`, `requestId`, `cancellationToken`). Only XML-doc text and the implementation's emitted wire strings change. `HostAdapterSchedulingService` calls only `GetMessageAsync`, `GetEventAsync`, and `ListCalendarWindowAsync`; with signatures unchanged this file is review-only (no functional edit expected).
+- N4 (validation parameter names): `HostAdapterRequestValidation` currently reads `since`/`start`/`end`/`limit` by name and emits diagnostics that quote those names. After the change it reads the receivedDateTime lower bound parsed from `$filter`, `startDateTime`, `endDateTime`, and `$top`, and the diagnostic message strings must quote the new parameter names. All existing validation semantics (UTC round-trip parse with zero offset, limit `>0` and `<= MaxLimit` bounds, window `end > start`, required-parameter errors) are preserved.
+- N5 (file size): `src/OpenClaw.HostAdapter/Program.cs` is 465 lines today. Consolidating the two `/messages` handlers into one (N1) reduces duplicated handler bodies, but the `/users/{id}/...` rewrites add an `id` route parameter and `$filter` parsing. The executor MUST verify `Program.cs` stays `< 500` lines after the edit; if it would exceed 500, extract the messages-handler body into a small internal helper in a new file rather than letting the route file grow past the limit.
+- N6 (status route): `/v1/status` becomes `/status` only. It is the sole non-Graph route and keeps its handler body unchanged apart from the template string.
+
+## Evidence Locations (canonical; non-overridable)
+
+All evidence artifacts for this feature are written under:
+`docs/features/active/evolve-hostadapter-graph-surface-76/evidence/<kind>/`
+
+- Baseline: `.../evidence/baseline/`
+- QA gates: `.../evidence/qa-gates/`
+- Regression testing: `.../evidence/regression-testing/`
+- Other: `.../evidence/other/`
+
+Writing evidence to `artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`, or any other non-canonical path is a policy violation. If any caller instruction supplies such a path, reject it, substitute the canonical path, and record `EVIDENCE_LOCATION_OVERRIDE_REJECTED: <supplied> replaced with <canonical>`.
+
+Timestamp format for all artifacts: `yyyy-MM-ddTHH-mm` (ISO-8601).
+
+## Toolchain Command Reference (C#)
+
+- Format: `dotnet csharpier .`
+- Build / lint (analyzers + code style): `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+- Type check (nullable as errors): `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+- Test + coverage: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+- Architecture: verify no new `ProjectReference` edges in `*.csproj`; Core depends only on `OpenClaw.HostAdapter.Contracts`; HostAdapter depends only on `OpenClaw.HostAdapter.Contracts` + `OpenClaw.MailBridge.Contracts`.
+
+---
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Baseline Capture and Policy Reading
+
+- [x] [P0-T1] Read the repository policy files in required order and record an evidence artifact.
+  - Files to read: `.claude/skills/policy-compliance-order/SKILL.md`, `CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/csharp.md`, `.claude/rules/quality-tiers.md`, `.claude/rules/architecture-boundaries.md`.
+  - Acceptance: artifact `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/other/phase0-instructions-read.md` exists and contains `Timestamp:`, `Policy Order:`, and the explicit list of files read.
+
+- [x] [P0-T2] Capture baseline formatting state.
+  - Command: `dotnet csharpier . --check`
+  - Acceptance: artifact `.../evidence/baseline/baseline-format.<timestamp>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` (pass/fail and any files needing formatting).
+
+- [x] [P0-T3] Capture baseline build/analyzer state.
+  - Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+  - Acceptance: artifact `.../evidence/baseline/baseline-build.<timestamp>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` (warning/error counts).
+
+- [x] [P0-T4] Capture baseline nullable type-check state.
+  - Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+  - Acceptance: artifact `.../evidence/baseline/baseline-typecheck.<timestamp>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+
+- [x] [P0-T5] Capture baseline test + coverage state for the full solution.
+  - Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+  - Acceptance: artifact `.../evidence/baseline/baseline-test.<timestamp>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` including numeric headline line-coverage % and branch-coverage % and total passed/failed counts. These numbers are the no-regression reference for Phase 3.
+
+### Phase 1 — HostAdapter Side: Graph-Shaped Routes, Validation, Options, Version (HostAdapter.Tests green)
+
+- [x] [P1-T1] Add the `MailboxId` option to `src/OpenClaw.HostAdapter/HostAdapterOptions.cs`.
+  - Change: add a public `string MailboxId { get; set; } = "me";` property (default `"me"`); follow the existing default-fallback pattern if normalized in `Program.cs` post-configure.
+  - Acceptance: `HostAdapterOptions` exposes `MailboxId` with default `"me"`; file compiles; file remains `< 500` lines.
+
+- [x] [P1-T2] Normalize `MailboxId` in the `Program.cs` options post-configure block.
+  - File: `src/OpenClaw.HostAdapter/Program.cs` (the `.PostConfigure` block).
+  - Change: set `options.MailboxId = string.IsNullOrWhiteSpace(options.MailboxId) ? "me" : options.MailboxId;`.
+  - Acceptance: an empty or whitespace `MailboxId` resolves to `"me"`; no other post-configure behavior changed.
+
+- [x] [P1-T3] Update `src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs` to read and quote the Graph-shaped parameter names.
+  - Change: parameter-name strings and diagnostic messages move from `since`/`start`/`end`/`limit` to the receivedDateTime lower bound (parsed from `$filter`), `startDateTime`, `endDateTime`, and `$top`. Preserve all parse/bounds/window semantics unchanged (UTC round-trip, zero offset, `>0`, `<= MaxLimit`, `end > start`, required-parameter error). The window error message updates from quoting `start`/`end` to `startDateTime`/`endDateTime`.
+  - Acceptance: validation helpers accept the new parameter names; error messages quote the new names; bounds/window semantics unchanged; file remains `< 500` lines.
+
+- [x] [P1-T4] Rewrite the status route in `src/OpenClaw.HostAdapter/Program.cs` from `/v1/status` to `/status`.
+  - Acceptance: `app.MapGet("/status", ...)` registered; handler body unchanged; no `/v1/status` template remains.
+
+- [x] [P1-T5] Rewrite the messages list and meeting-requests routes into a single `GET /users/{id}/messages` handler per design note N1.
+  - File: `src/OpenClaw.HostAdapter/Program.cs`.
+  - Change: register one `GET /users/{id}/messages` handler that parses the receivedDateTime lower bound from `$filter` and `$top`, then branches: if `$filter` contains the `meetingMessageType ne null` predicate, invoke `commandBuilder.BuildListMeetingRequests(sinceUtc, limit)`; otherwise invoke `commandBuilder.BuildListMessages(sinceUtc, limit)`. Remove the former `/v1/messages` and `/v1/meeting-requests` registrations.
+  - Acceptance: exactly one `/users/{id}/messages` route is registered; meeting-requests dispatch is selected by the `meetingMessageType ne null` predicate; `BuildListMessages` and `BuildListMeetingRequests` command chains are both reachable and unchanged; no `/v1/messages` or `/v1/meeting-requests` template remains.
+
+- [x] [P1-T6] Rewrite the single-message route to `GET /users/{id}/messages/{messageId}` in `src/OpenClaw.HostAdapter/Program.cs`.
+  - Change: template becomes `/users/{id}/messages/{messageId}`; the route value passed to `TryGetBridgeId`/`BuildGetMessage` is `messageId`. The `{id}` segment is not bridge-id validated.
+  - Acceptance: route registered at `/users/{id}/messages/{messageId}`; single-message lookup uses the `messageId` segment; no `/v1/messages/{bridgeId}` template remains.
+
+- [x] [P1-T7] Rewrite the calendar route to `GET /users/{id}/calendarView` with `startDateTime`/`endDateTime`/`$top` in `src/OpenClaw.HostAdapter/Program.cs`.
+  - Change: template becomes `/users/{id}/calendarView`; read `startDateTime`, `endDateTime`, `$top` from the query; preserve window validation and `BuildListCalendar(startUtc, endUtc, limit)` dispatch.
+  - Acceptance: route registered at `/users/{id}/calendarView`; query params are `startDateTime`/`endDateTime`/`$top`; no `/v1/calendar` template remains.
+
+- [x] [P1-T8] Rewrite the single-event route to `GET /users/{id}/events/{eventId}` in `src/OpenClaw.HostAdapter/Program.cs`.
+  - Change: template becomes `/users/{id}/events/{eventId}`; route value passed to `TryGetBridgeId`/`BuildGetEvent` is `eventId`.
+  - Acceptance: route registered at `/users/{id}/events/{eventId}`; no `/v1/events/{bridgeId}` template remains.
+
+- [x] [P1-T9] Verify `src/OpenClaw.HostAdapter/Program.cs` stays under 500 lines after the route rewrites (design note N5).
+  - Acceptance: `Program.cs` line count `< 500`. If `>= 500`, extract the messages-handler body into a small internal helper in a new file under `src/OpenClaw.HostAdapter/` and re-verify; record the count.
+
+- [x] [P1-T10] Add `<Version>1.0.0</Version>` to `src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj` (D5).
+  - Change: add `<Version>1.0.0</Version>` inside the existing `<PropertyGroup>`.
+  - Acceptance: the csproj declares `<Version>1.0.0</Version>`; `HostAdapterOptions.DefaultAdapterVersion` resolves to `1.0.0` from the assembly version.
+
+- [x] [P1-T11] Update XML-doc comments in `src/OpenClaw.HostAdapter.Contracts/IHostAdapterClient.cs` to describe the Graph-shaped routes (signatures unchanged per N3).
+  - Change: revise `<summary>`/`<param>` text on `ListMessagesAsync`, `GetMessageAsync`, `ListMeetingRequestsAsync`, `ListCalendarWindowAsync`, `GetEventAsync`, `GetStatusAsync` to reference the Graph-shaped routes. Do not remove, rename, or re-order any method or parameter.
+  - Acceptance: all six methods retain their current signatures; doc text references the Graph-shaped routes; `ListMeetingRequestsAsync` is retained.
+
+- [x] [P1-T12] Update `tests/OpenClaw.HostAdapter.Tests/HostAdapterEndpointTests.cs` route strings to the Graph-shaped paths.
+  - Change: `/v1/messages/{...}` -> `/users/me/messages/{...}`; `/v1/events/{...}` -> `/users/me/events/{...}`. Do not weaken assertions.
+  - Acceptance: tests reference Graph-shaped paths; assertions unchanged in strength.
+
+- [x] [P1-T13] Update `tests/OpenClaw.HostAdapter.Tests/HostAdapterAuthTests.cs` status route strings.
+  - Change: `/v1/status` -> `/status` at both call sites.
+  - Acceptance: tests reference `/status`; auth assertions unchanged.
+
+- [x] [P1-T14] Update `tests/OpenClaw.HostAdapter.Tests/HostAdapterMappingTests.cs` route and query-param strings.
+  - Change: `/v1/messages?since=...&limit=...` -> `/users/me/messages?$filter=receivedDateTime ge ...&$top=...`.
+  - Acceptance: tests reference the Graph-shaped messages route and parameters; mapping assertions unchanged.
+
+- [x] [P1-T15] Update `tests/OpenClaw.HostAdapter.Tests/HostAdapterValidationTests.cs` route and query-param strings, including the over-limit and window cases.
+  - Change: messages route/params to `$filter=receivedDateTime ge ...&$top=...`; calendar route to `/users/me/calendarView?startDateTime=...&endDateTime=...`; over-limit `$top` case preserved; expected error messages updated to quote the new parameter names.
+  - Acceptance: validation tests assert the same status codes and error semantics against the Graph-shaped parameter names; no assertion weakened.
+
+- [x] [P1-T16] Update `tests/OpenClaw.HostAdapter.Tests/HostAdapterEnvelopeTests.cs` status route string.
+  - Change: `/v1/status` -> `/status`.
+  - Acceptance: envelope test references `/status`; assertions unchanged.
+
+- [x] [P1-T17] Add a HostAdapter test asserting the meeting-requests dispatch on `/users/{id}/messages` with the `meetingMessageType ne null` filter predicate.
+  - File: `tests/OpenClaw.HostAdapter.Tests/HostAdapterMappingTests.cs` (or the most appropriate existing HostAdapter.Tests file that already exercises the messages route).
+  - Change: add a test issuing `GET /users/me/messages?$filter=meetingMessageType ne null and receivedDateTime ge {iso}&$top={n}` and asserting the meeting-requests command path is taken (distinct from the plain messages path), preserving the existing envelope shape.
+  - Acceptance: a test exists that verifies the meeting-requests branch is selected by the `meetingMessageType ne null` predicate and the plain-messages branch is selected without it.
+
+- [x] [P1-T18] Add or update a HostAdapter test asserting `meta.adapterVersion` reports `1.0.0` from the assembly version, OR document that the test factory overrides `AdapterVersion` to `"test-version"` and verify the version through `HostAdapterOptions.DefaultAdapterVersion` instead.
+  - File: `tests/OpenClaw.HostAdapter.Tests/` (the most appropriate existing file; `HostAdapterTestWebApplicationFactory.cs:49` sets `AdapterVersion = "test-version"`).
+  - Acceptance: a test confirms `HostAdapterOptions.DefaultAdapterVersion == "1.0.0"` (assembly-version-derived). If the in-process test version is overridden by the factory, the test asserts the `DefaultAdapterVersion` value directly, not the overridden envelope value.
+
+- [x] [P1-T19] Run the C# toolchain for the HostAdapter changes and record the QA-gate artifacts.
+  - Commands (in order; restart from format if any step changes files or fails): `dotnet csharpier .` ; `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` ; `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true` ; `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`.
+  - Acceptance: all four commands exit `0` in a single pass; artifacts `.../evidence/qa-gates/phase1-format.<timestamp>.md`, `phase1-build.<timestamp>.md`, `phase1-typecheck.<timestamp>.md`, `phase1-test.<timestamp>.md` each contain `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`; the test artifact records numeric line/branch coverage headline values. HostAdapter.Tests pass.
+
+### Phase 2 — Core Side: HTTP Client Paths, BaseUrl Default, MailboxId Mirror (Core.Tests green)
+
+- [x] [P2-T1] Change the `BaseUrl` default in `src/OpenClaw.Core/CoreOptions.cs` to drop `/v1/` (D6).
+  - Change: `BaseUrl` default from `http://host.docker.internal:4319/v1/` to `http://host.docker.internal:4319/`.
+  - Acceptance: the Core `HostAdapterOptions.BaseUrl` default no longer contains `/v1/`.
+
+- [x] [P2-T2] Add a `MailboxId` property (default `"me"`) to the Core-side `HostAdapterOptions` in `src/OpenClaw.Core/CoreOptions.cs` (design note N2).
+  - Change: add `public string MailboxId { get; set; } = "me";` to the Core `HostAdapterOptions` class.
+  - Acceptance: the Core-side `HostAdapterOptions` exposes `MailboxId` with default `"me"`; no new project reference is introduced.
+
+- [x] [P2-T3] Rewrite the six relative paths in `src/OpenClaw.Core/HostAdapterHttpClient.cs` to the Graph-shaped forms, sourcing the `{id}` segment from `options.HostAdapter.MailboxId`.
+  - Changes:
+    - `GetStatusAsync`: `"status"`.
+    - `ListMessagesAsync`: `$"users/{id}/messages?$filter=receivedDateTime ge {iso}&$top={limit}"` (URL-encode as needed).
+    - `GetMessageAsync`: `$"users/{id}/messages/{escapedMessageId}"`.
+    - `ListMeetingRequestsAsync`: `$"users/{id}/messages?$filter=meetingMessageType ne null and receivedDateTime ge {iso}&$top={limit}"`.
+    - `ListCalendarWindowAsync`: `$"users/{id}/calendarView?startDateTime={iso}&endDateTime={iso}&$top={limit}"`.
+    - `GetEventAsync`: `$"users/{id}/events/{escapedEventId}"`.
+  - The `{id}` value is `options.HostAdapter.MailboxId`. Preserve `Uri.EscapeDataString` on id/timestamp values consistent with current escaping.
+  - Acceptance: all six relative paths emit Graph-shaped forms with the `{id}` segment from `MailboxId`; method signatures unchanged; the meeting-requests path carries the `meetingMessageType ne null` predicate.
+
+- [x] [P2-T4] Review `src/OpenClaw.Core/Agent/Runtime/HostAdapterSchedulingService.cs` call sites against the revised `IHostAdapterClient` (design note N3).
+  - Acceptance: confirm the file calls only `GetMessageAsync`, `GetEventAsync`, `ListCalendarWindowAsync` with unchanged signatures; record that no functional edit is required (or apply the minimal edit if a call shape changed, with justification).
+
+- [x] [P2-T5] Update `tests/OpenClaw.Core.Tests/HostAdapterHttpClientTests.cs` base URL, path, and query-param assertions.
+  - Changes: base URL `http://localhost:4319/v1/` -> `http://localhost:4319/`; status path assertion `/v1/status` -> `/status`; messages path assertion to contain `users/me/messages` and `$filter=receivedDateTime` and `$top=`; meeting-requests assertion to contain `users/me/messages` and `meetingMessageType ne null`; calendar assertion to contain `calendarView`, `startDateTime=`, `endDateTime=`, `$top=`; single message/event paths to `users/me/messages/{...}` and `users/me/events/{...}`. Do not weaken assertions.
+  - Acceptance: client tests assert the Graph-shaped paths/parameters and the new base URL; `since=`/`start=`/`end=`/`limit=`/`meeting-requests`/`/v1/` substrings no longer asserted; assertion strength preserved.
+
+- [x] [P2-T6] Review and update `tests/OpenClaw.Core.Tests/MessagePollingWorkerTests.cs` and `tests/OpenClaw.Core.Tests/Agent/Runtime/HostAdapterSchedulingServiceTests.cs` mock setups.
+  - Acceptance: because `ListMeetingRequestsAsync` and all other signatures are retained, confirm the existing Moq setups remain valid; update any literal route/base-url strings if present; record that no mock signature change is required (or apply the minimal change with justification). Do not weaken assertions.
+
+- [x] [P2-T7] Scan `tests/OpenClaw.Core.Tests/` (including `tests/OpenClaw.Core.Tests/CoreTestWebApplicationFactory.cs`) for any remaining references to old route strings or the `/v1/` base URL and update them.
+  - Search targets: `/v1/`, `since=`, `start=`, `end=`, `limit=`, `meeting-requests`, `4319/v1/`.
+  - Acceptance: no Core test asserts a removed route string or the `/v1/` base URL except where intentionally testing rejection; any remaining occurrence is justified in the task record.
+
+- [x] [P2-T8] Update `tests/OpenClaw.Core.Tests/CoreTestWebApplicationFactory.cs` base URL from "http://127.0.0.1:4319/v1/" to "http://127.0.0.1:4319/" (D6 consistency).
+  - Acceptance: the Core test factory's HostAdapter BaseUrl configuration no longer contains /v1/; no other factory behavior changed.
+
+- [x] [P2-T9] Run the full C# toolchain for the Core changes and record the QA-gate artifacts.
+  - Commands (in order; restart from format if any step changes files or fails): `dotnet csharpier .` ; `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` ; `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true` ; `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`.
+  - Acceptance: all four commands exit `0` in a single pass; artifacts `.../evidence/qa-gates/phase2-format.<timestamp>.md`, `phase2-build.<timestamp>.md`, `phase2-typecheck.<timestamp>.md`, `phase2-test.<timestamp>.md` each contain `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`; the test artifact records numeric line/branch coverage headline values. Core.Tests pass.
+
+### Phase 3 — Full-Solution QA, Coverage Verification, Contract/Schema Check, AC Mapping
+
+- [x] [P3-T1] Run the full final-QA formatting gate.
+  - Command: `dotnet csharpier .`
+  - Acceptance: exit `0` with no files reformatted; artifact `.../evidence/qa-gates/final-format.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. If files are reformatted, restart the loop from this task.
+
+- [x] [P3-T2] Run the full final-QA build/analyzer gate.
+  - Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+  - Acceptance: exit `0` with 0 analyzer errors; artifact `.../evidence/qa-gates/final-build.<timestamp>.md` with the required fields and warning/error counts in `Output Summary:`.
+
+- [x] [P3-T3] Run the full final-QA nullable type-check gate.
+  - Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+  - Acceptance: exit `0`; artifact `.../evidence/qa-gates/final-typecheck.<timestamp>.md` with the required fields.
+
+- [x] [P3-T4] Run the full final-QA test + coverage gate for the whole solution.
+  - Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+  - Acceptance: exit `0`, all tests pass; artifact `.../evidence/qa-gates/final-test.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` including numeric post-change line-coverage % and branch-coverage % and total passed/failed counts.
+
+- [x] [P3-T5] Verify coverage thresholds and no-regression on changed code.
+  - Inputs: baseline coverage from `.../evidence/baseline/baseline-test.<timestamp>.md` (P0-T5) and post-change coverage from `.../evidence/qa-gates/final-test.<timestamp>.md` (P3-T4).
+  - Acceptance: artifact `.../evidence/qa-gates/coverage-delta.<timestamp>.md` records baseline line/branch %, post-change line/branch %, and changed-code coverage; confirms line coverage `>= 85%`, branch coverage `>= 75%`, and no regression on changed lines. If any threshold is unmet, the outcome is remediation-required, not PASS.
+
+- [x] [P3-T6] Verify architecture boundaries are unchanged.
+  - Check: no new `ProjectReference` edges in any `*.csproj`; `OpenClaw.Core` references only `OpenClaw.HostAdapter.Contracts`; `OpenClaw.HostAdapter` references only `OpenClaw.HostAdapter.Contracts` + `OpenClaw.MailBridge.Contracts`; `OpenClaw.HostAdapter.Contracts` references only `OpenClaw.MailBridge.Contracts`; no COM boundary crossed.
+  - Acceptance: artifact `.../evidence/qa-gates/architecture-check.<timestamp>.md` records the inspected `ProjectReference` sets and confirms no new edges.
+
+- [x] [P3-T7] Perform the contract/schema compatibility check for the T2 `IHostAdapterClient` breaking change.
+  - Check: confirm `IHostAdapterClient` retains all six members with unchanged C# signatures (including `ListMeetingRequestsAsync` per D1); confirm `HostAdapterHttpClient` implements every member and emits the Graph-shaped wire routes; confirm the envelope/DTO contracts (`ApiEnvelope<T>`, `ItemsResponse<T>`, `MessageDto`, `EventDto`, `ApiMeta`, `ApiError`, `BridgeStatusDto`) are byte-for-byte unchanged; confirm the adapter version is `1.0.0` (major bump signaling the breaking HTTP surface change).
+  - Acceptance: artifact `.../evidence/qa-gates/contract-compat.<timestamp>.md` records the member-by-member implementation confirmation, the unchanged-DTO confirmation, and the `1.0.0` version, and states that all in-repo callers (`HostAdapterHttpClient`, `HostAdapterSchedulingService`, polling workers) compile and pass.
+
+- [x] [P3-T8] Verify no `/v1/*` route (status excepted) is served by the HostAdapter.
+  - Check: grep `src/OpenClaw.HostAdapter/Program.cs` for `"/v1/`; confirm zero matches. Confirm `/status` is the only non-`/users/{id}/...` route.
+  - Acceptance: artifact `.../evidence/qa-gates/route-surface-check.<timestamp>.md` records the route inventory: `/status`, `/users/{id}/messages` (single handler, plain + meeting-requests branches), `/users/{id}/messages/{messageId}`, `/users/{id}/calendarView`, `/users/{id}/events/{eventId}`; and confirms no `/v1/` template remains.
+
+- [x] [P3-T9] Map each of the 7 acceptance criteria in `user-story.md` to the satisfying test(s)/evidence and check them off per the acceptance-criteria-tracking convention.
+  - Mapping (verify each against passing tests/evidence before checking the AC box in `user-story.md`):
+    - AC1 (Graph-shaped routes, no `/v1/*` except `/status`): P3-T8 route-surface-check + `HostAdapterEndpointTests.cs`, `HostAdapterAuthTests.cs`, `HostAdapterValidationTests.cs`, `HostAdapterMappingTests.cs`, `HostAdapterEnvelopeTests.cs`.
+    - AC2 (`IHostAdapterClient`/`HostAdapterHttpClient` call Graph endpoints, envelope-wrapped, `ListMeetingRequestsAsync` retained): P3-T7 contract-compat + `HostAdapterHttpClientTests.cs`.
+    - AC3 (`OpenClawOptions.HostAdapter.BaseUrl` default has no `/v1/`): P2-T1 + `HostAdapterHttpClientTests.cs` base-url assertion.
+    - AC4 (adapter version reports `1.0.0` via `meta.adapterVersion`): P1-T10, P1-T18 + contract-compat artifact.
+    - AC5 (`MailboxId` default `"me"` configurable on `HostAdapterOptions` and renders `{id}`): P1-T1/P1-T2 (adapter) and P2-T2/P2-T3 (Core client path) + the `/users/me/...` assertions in `HostAdapterHttpClientTests.cs`.
+    - AC6 (existing contract/endpoint tests pass against new routes, not weakened): P1-T19, P2-T9, P3-T4 final-test artifact (all tests pass).
+    - AC7 (line >= 85%, branch >= 75% on changed code, no regression): P3-T5 coverage-delta artifact.
+  - Acceptance: artifact `.../evidence/qa-gates/ac-mapping.<timestamp>.md` records the AC-to-evidence map with the verifying artifact path for each AC; all 7 boxes in `user-story.md` are checked only after their evidence is confirmed PASS.
+
+## Test Plan
+
+- Unit (MSTest + Moq + FluentAssertions): HostAdapter.Tests assert the new route templates, `$filter`/`$top`/`startDateTime`/`endDateTime` parameter handling, the meeting-requests branch selection, validation error messages, and `DefaultAdapterVersion == "1.0.0"`. Core.Tests assert the new base URL, Graph-shaped relative paths, and `MailboxId`-sourced `{id}` segment.
+- Core test-file scope: `tests/OpenClaw.Core.Tests/HostAdapterHttpClientTests.cs` (P2-T5), `tests/OpenClaw.Core.Tests/MessagePollingWorkerTests.cs` and `tests/OpenClaw.Core.Tests/Agent/Runtime/HostAdapterSchedulingServiceTests.cs` (P2-T6), and `tests/OpenClaw.Core.Tests/CoreTestWebApplicationFactory.cs` (P2-T8 base-URL update; also scanned in P2-T7).
+- Contract/schema: P3-T7 confirms `IHostAdapterClient` member parity, `HostAdapterHttpClient` implementation, unchanged DTO/envelope contracts, and the `1.0.0` major bump.
+- Integration: covered by the existing `WebApplicationFactory`-based HostAdapter endpoint tests exercised through the full `dotnet test` run in P3-T4.
+- Coverage evidence:
+  - Baseline: `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/baseline/baseline-test.<timestamp>.md`
+  - Post-change: `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/final-test.<timestamp>.md`
+  - Comparison: `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/coverage-delta.<timestamp>.md`
+
+## Open Questions / Notes
+
+- N1 route collision (single `/users/{id}/messages` handler branching on `$filter`) is the one non-obvious implementation decision; it is resolved in this plan and must be honored.
+- N2 Core-side `MailboxId`: a Core-side config mirror is specified to avoid crossing the architecture boundary into `OpenClaw.HostAdapter`. A hardcoded `"me"` constant is the only acceptable fallback if the config property is later judged out of scope.
+- File-size watch: `Program.cs` (currently 465 lines) is the only file near the 500-line limit; P1-T9 enforces the check.

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/policy-audit.2026-06-12T23-30.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/policy-audit.2026-06-12T23-30.md
@@ -1,0 +1,449 @@
+# Policy Compliance Audit: evolve-hostadapter-graph-surface (#76)
+
+**Audit Date:** 2026-06-12
+**Code Under Test:** Branch `open-claw-bridge-wt-2026-06-12-22-19` @ `e3bc4506e1ebce0080e057306b91ffbbb77fd945` vs base `main` @ `3041d083691cd77b2b2e888580fc9f2ab8bc611f` (merge base identical to base tip).
+
+Source files changed (C#):
+- `src/OpenClaw.Core/CoreOptions.cs`
+- `src/OpenClaw.Core/HostAdapterHttpClient.cs`
+- `src/OpenClaw.HostAdapter.Contracts/IHostAdapterClient.cs`
+- `src/OpenClaw.HostAdapter/HostAdapterOptions.cs`
+- `src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs`
+- `src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj`
+- `src/OpenClaw.HostAdapter/Program.cs`
+
+Test files changed (C#):
+- `tests/OpenClaw.Core.Tests/CoreTestWebApplicationFactory.cs`
+- `tests/OpenClaw.Core.Tests/HostAdapterHttpClientTests.cs`
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterAuthTests.cs`
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterEndpointTests.cs`
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterEnvelopeTests.cs`
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterMappingTests.cs`
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterStatusCacheTests.cs`
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterValidationTests.cs`
+- `tests/OpenClaw.HostAdapter.Tests/HostAdapterVersionTests.cs` (new)
+
+Docs/scoping changed: `spec.md`, `user-story.md`, `plan.2026-06-12T22-21.md`, and 22 evidence artifacts under the feature folder.
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| C# | 7 source + 9 test | 252 (74 HostAdapter + 178 Core) | ✅ 252 pass, 0 fail | HostAdapter 84.99% line / 62.88% branch (whole-assembly); Core 89.32% line / 77.58% branch | HostAdapter package 97.08% line / 86.30% branch; Core package 98.58% line / 90.32% branch | Changed-code 98.85% line / 79.41% branch |
+
+**Note:** Only C# (plus Markdown docs) has changed files in the branch diff. No Python, PowerShell, TypeScript, Bash, or JSON application code changed. Coverage verdicts for those languages are N/A because they have zero changed files on the branch.
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: `N/A - out of scope`
+- TypeScript post-change coverage artifact: `N/A - out of scope`
+- PowerShell baseline coverage artifact: `N/A - out of scope`
+- PowerShell post-change coverage artifact: `N/A - out of scope`
+- C# changed-code coverage artifact (executor analysis): `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/qa-gates/coverage-delta.2026-06-12T23-17.md`
+- C# raw cobertura (HostAdapter.Tests): `tests/OpenClaw.HostAdapter.Tests/TestResults/8d218b5b-4811-4254-a89b-8c263055367c/coverage.cobertura.xml` — package `OpenClaw.HostAdapter` line-rate 0.9708, branch-rate 0.863 (independently inspected).
+- C# raw cobertura (Core.Tests): `tests/OpenClaw.Core.Tests/TestResults/93de4c82-c23c-4300-93ab-8aa779dbcf9e/coverage.cobertura.xml` — package `OpenClaw.Core` line-rate 0.9858, branch-rate 0.9032 (independently inspected).
+- Per-language comparison summary: Section 1.2.1 below.
+
+**Coverage artifact path note:** The feature-review skill nominates `artifacts/csharp/coverage.xml` as the canonical C# coverage artifact path. That literal path is absent, but parseable cobertura reports exist under each test project's `TestResults/` directory and were inspected directly. This is a path-naming difference, not a missing-evidence condition; coverage verification was performed against the present cobertura reports and the executor coverage-delta artifact. Verdict therefore PASS, not the missing-artifact FAIL.
+
+**Non-negotiable verdict rule:** Numeric baseline and post-change C# coverage metrics are included above; changed-code coverage (98.85% line / 79.41% branch) is recorded.
+
+---
+
+## Executive Summary
+
+This change reshapes the `OpenClaw.HostAdapter` HTTP surface and the `IHostAdapterClient` T2 contract from a bespoke `/v1/*` route table to a Microsoft Graph-shaped surface (`/users/{id}/messages`, `/users/{id}/messages/{messageId}`, `/users/{id}/calendarView`, `/users/{id}/events/{eventId}`, and a messages-filtered meeting-requests form), retaining the `/status` operational probe. It is a path-and-query change: the DTO/envelope schema is unchanged. The adapter version is bumped to `1.0.0` to signal the breaking contract change, a configurable `MailboxId` (default `"me"`) sources the `{id}` segment, and the Core `BaseUrl` default drops `/v1/`.
+
+Independent verification confirmed the toolchain is clean: build with analyzers, nullable analysis, and warnings-as-errors produced 0 warnings / 0 errors; CSharpier reported no formatting changes across 149 files; the two affected test projects pass 252/252. Architecture boundaries are unchanged (no new `ProjectReference` edges). The T2 contract member parity holds (signatures unchanged; only XML-doc text changed), the implementation emits the Graph-shaped routes, and the version reports `1.0.0`. Changed-code coverage meets the uniform thresholds.
+
+**Policy documents evaluated:**
+- ✅ `.claude/rules/general-code-change.md`
+- ✅ `.claude/rules/general-unit-test.md`
+- ✅ `.claude/rules/quality-tiers.md` (T2 boundary, uniform coverage)
+- ✅ `.claude/rules/tonality.md`
+
+**Language-specific policies evaluated:**
+- ✅ C# (`.claude/rules/csharp.md`): CSharpier format, .NET analyzers, nullable type analysis, MSTest, architecture-boundary assertions, contract/schema compatibility.
+- N/A Python / PowerShell / Bash / JSON / TypeScript: no changed files on the branch.
+
+**Temporary artifacts cleanup:**
+- ✅ No temporary/one-time scripts were created during this review.
+- ✅ No throwaway scripts remain.
+
+---
+
+## Rejected Scope Narrowing
+
+The orchestrator prompt directed a full feature-vs-base audit and supplied locked design decisions and a toolchain note; it did not attempt to narrow audit scope to a plan/task/phase subset, to a subset of changed files, or to mark any in-scope language as out of scope. No scope-narrowing instruction was detected. No verbatim narrowing text is recorded because none was present.
+
+Separately, the PR-context summary (`artifacts/pr_context.summary.txt`, "Changed files overview") classifies the change as "Core logic changes: 0 files" and "Docs/templates/agents/tooling: 25 files". This classification is inaccurate: the branch diff includes seven `src/**` C# source files and nine test files with material logic changes. This audit does not narrow scope to the summary classification; it audits the full branch diff resolved directly from `git diff <merge-base>..<head>`. Recorded here for traceability; this is a context-artifact classification defect, not a caller narrowing instruction.
+
+---
+
+## Evidence Location Compliance
+
+- Branch diff scanned for files written under `artifacts/baselines/`, `artifacts/baseline/`, `artifacts/qa/`, `artifacts/qa-gates/`, `artifacts/evidence/`, `artifacts/coverage/`, `artifacts/regression-testing/`, or `artifacts/post-change/`.
+  - Command: `git diff --name-only 3041d08..e3bc450 | grep -E 'artifacts/(baselines?|qa|qa-gates|evidence|coverage|regression-testing|post-change)/'`
+  - Result: no matches. No forbidden evidence path was written by this branch.
+- All feature evidence is written under the canonical `docs/features/active/evolve-hostadapter-graph-surface-76/evidence/<kind>/` scheme (baseline, qa-gates, other).
+- `validate_evidence_locations.py` is not present in this repository; the scan was performed by direct path inspection of the branch diff instead. No violations found.
+
+Verdict: PASS. No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` events were required during this review.
+
+---
+
+## modified-workflow-needs-green-run
+
+- Branch diff scanned for paths under `.github/workflows/**`, `scripts/benchmarks/**`, `.github/actions/**`.
+  - Command: `git diff --name-only 3041d08..e3bc450 | grep -E '\.github/workflows/|scripts/benchmarks/|\.github/actions/'`
+  - Result: no matches.
+- The rule does not fire. No green-workflow-run evidence is required for this change. Verdict: PASS (rule not triggered).
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** - Tests run in any order | ✅ PASS | MSTest classes use per-test `WebApplicationFactory`/`HttpClient` instances disposed with `using`; no shared mutable static state across tests. Both projects ran to green in a single `dotnet test` pass. |
+| **Isolation** - Each test targets single behavior | ✅ PASS | Each added test targets one behavior: meeting-requests branch dispatch, plain-messages branch dispatch, and `DefaultAdapterVersion == "1.0.0"`. Updated tests assert one route/parameter shape each. |
+| **Fast Execution** | ✅ PASS | HostAdapter.Tests 379 ms / 74 tests; Core.Tests 800 ms / 178 tests (independently observed). |
+| **Determinism** | ✅ PASS | Tests use an in-memory `FakeHttpHandler` and an enqueued `ProcessRunner`; no wall-clock waits, no `Thread.Sleep`/`Task.Delay`, no network. Timestamps are fixed literals. |
+| **Readability & Maintainability** | ✅ PASS | Descriptive method names (e.g., `HostAdapter_should_dispatch_meeting_requests_branch_when_filter_contains_meeting_message_type_predicate`) and XML-doc summaries on updated tests. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | ✅ PASS | `evidence/baseline/baseline-test.2026-06-12T22-30.md`: HostAdapter 84.99% line / 62.88% branch (whole-assembly), Core 89.32% line / 77.58% branch. Command: `dotnet test ... --collect:"XPlat Code Coverage"`. |
+| **No Coverage Regression (changed lines)** | ✅ PASS | Changed/new lines in `Program.cs` and `HostAdapterHttpClient.cs` are at 100%; `HostAdapterRequestValidation.cs` 96.6% line; no changed line regressed. Source: `evidence/qa-gates/coverage-delta.2026-06-12T23-17.md`. |
+| **Changed-code line >= 85% / branch >= 75%** | ✅ PASS | Changed-code aggregate 98.85% line / 79.41% branch (uniform thresholds per `quality-tiers.md`). Package-level cobertura independently inspected: HostAdapter 97.08% line / 86.30% branch; Core 98.58% line / 90.32% branch. |
+| **Comprehensive Coverage** | ✅ PASS | New branch-selection logic (`FilterSelectsMeetingRequests`) covered by both meeting-requests and plain-messages dispatch tests; `$top`/`startDateTime`/`endDateTime` validation paths covered by updated validation tests; version helper covered by `HostAdapterVersionTests`. |
+| **Positive Flows** | ✅ PASS | Mapping tests issue valid Graph-shaped requests and assert 200 + correct branch dispatch. |
+| **Negative Flows** | ✅ PASS | Validation tests assert error messages now cite `receivedDateTime`, `startDateTime`/`endDateTime`, and `$top` for malformed/over-limit inputs. |
+| **Edge Cases** | ✅ PASS | Over-`MaxLimit` `$top=251`, equal start/end window, and escaped path segments (`bridge%20id%2Bvalue`, spaces/slashes) covered. |
+| **Error Handling** | ✅ PASS | Auth-failure and transport-failure paths retained and exercised against the new route strings. |
+| **Concurrency** | N/A | No concurrency behavior introduced; route reshaping only. |
+| **State Transitions** | N/A | No stateful component added. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- C#: Baseline: 89.32% lines (Core whole-assembly) -> Post-change: 98.58% lines (Core package). Change: +9.26% lines. New/changed-code coverage: 98.85% lines / 79.41% branches. Disposition: PASS. Evidence: `evidence/qa-gates/coverage-delta.2026-06-12T23-17.md`; cobertura under `tests/OpenClaw.HostAdapter.Tests/TestResults/.../coverage.cobertura.xml` (HostAdapter package 97.08% lines / 86.30% branches) and `tests/OpenClaw.Core.Tests/TestResults/.../coverage.cobertura.xml`.
+- Python / PowerShell / TypeScript / Bash / JSON: N/A — out of scope (zero changed files on the branch).
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | ✅ PASS | FluentAssertions `Should().Contain(...)`/`Should().Equal(...)` produce explicit diagnostics naming the expected route/parameter token. |
+| **Arrange-Act-Assert Pattern** | ✅ PASS | Each test arranges factory + enqueued responses, acts via `client.GetAsync(...)`, then asserts status and invocation verbs. |
+| **Document Intent** | ✅ PASS | Updated XML-doc summaries describe the Graph-shaped path under test. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | ✅ PASS | No real network/process; `FakeHttpHandler` and an enqueued in-process `ProcessRunner` substitute for the bridge. |
+| **Use Mocks/Stubs** | ✅ PASS | HTTP handler fake and process-runner stub isolate the unit under test. |
+| **Environment Stability** | ✅ PASS | In-memory configuration; no temporary files created by the changed tests. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | ✅ PASS | This audit, the accompanying code-review, and feature-audit artifacts constitute the required review. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | ✅ PASS | Objective stated in `spec.md`/`user-story.md` (#76); locked decisions D1–D6 confirmed by the orchestrator. |
+| **Read existing change plans** | ✅ PASS | `plan.2026-06-12T22-21.md` present and tracked; phase-0 instructions-read evidence present. |
+| **Document the plan** | ✅ PASS | Plan with P0–P3 tasks and acceptance gates is checked in. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | ✅ PASS | Messages and meeting-requests share one `/users/{id}/messages` handler that branches on a `$filter` predicate, removing the duplicated meeting-requests endpoint (Program.cs net -111/+... reduction). |
+| **Reusability** | ✅ PASS | `ExtractReceivedDateTimeLowerBound` and `FilterSelectsMeetingRequests` are small reusable static helpers in `HostAdapterRequestValidation`. |
+| **Extensibility** | ✅ PASS | `MailboxId` is a keyword-style option with a default; the `{id}` segment is parameterized for future per-mailbox routing. |
+| **Separation of concerns** | ✅ PASS | Filter parsing/validation isolated in `HostAdapterRequestValidation`; route registration and dispatch in `Program.cs`; the typed client emits wire paths only. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | ✅ PASS | Changes stay within the HostAdapter HTTP surface, its options/validation, the typed client, and the contract doc. |
+| **Under 500 lines** | ✅ PASS | All changed source files remain well under 500 lines (Program.cs shrank; validation, options, client, contract all small). |
+| **Public vs internal** | ✅ PASS | `HostAdapterHttpClient` stays `internal`; the public T2 surface is `IHostAdapterClient` with unchanged signatures. |
+| **No circular dependencies** | ✅ PASS | No new `ProjectReference` edge; dependency graph unchanged (see Section: architecture). |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | ✅ PASS | `MailboxId`, `ExtractReceivedDateTimeLowerBound`, `FilterSelectsMeetingRequests`, `FormatAdapterVersion`; route segments `messageId`/`eventId` renamed from generic `bridgeId` to match Graph shape. |
+| **Docs/docstrings** | ✅ PASS | `IHostAdapterClient` XML-doc updated to describe each Graph-shaped route; new options documented with `<summary>`. |
+| **Comment why, not what** | ✅ PASS | `FormatAdapterVersion` comment explains why the 4-component assembly version is reduced to 3 components for `meta.adapterVersion`. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | ✅ PASS | `csharpier check ./src ./tests` -> "Checked 149 files"; exit 0 (independently run, CSharpier 1.3.0). |
+| **2. Linting** | ✅ PASS | `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true -p:TreatWarningsAsErrors=true` -> 0 Warning(s), 0 Error(s) (independently run). |
+| **3. Type checking** | ✅ PASS | Nullable reference analysis is part of the same warnings-as-errors build; 0 nullable warnings. |
+| **4. Architecture-boundary** | ✅ PASS | `grep -rn 'ProjectReference Include' src --include=*.csproj` confirms the six allowed edges and no new edge (see below). |
+| **5. Testing** | ✅ PASS | HostAdapter.Tests 74/74, Core.Tests 178/178 (independently run with `--no-build`). |
+| **6. Contract / schema** | ✅ PASS | T2 `IHostAdapterClient` member parity confirmed; DTO/envelope unchanged (see Section: contract). |
+| **Full toolchain loop** | ✅ PASS | All stages pass in a single pass; executor recorded phase1/phase2/final qa-gate evidence, independently reconfirmed here. |
+| **Explicit reporting** | ✅ PASS | Commands and results recorded in this audit and Appendix B. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | ✅ PASS | Summarized in this audit and the code-review artifact. |
+| **Design choices explained** | ✅ PASS | D1–D6 locked decisions documented in spec; single-handler branch design noted in plan note N1. |
+| **Update supporting documents** | ✅ PASS | `spec.md`, `user-story.md`, and `IHostAdapterClient` XML-doc updated. |
+| **Provide next steps** | ✅ PASS | Recommendation recorded in Section 10. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3C#: C# Code Change Policy Compliance
+
+#### 3C#.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with CSharpier** | ✅ PASS | `csharpier check ./src ./tests` -> "Checked 149 files"; exit 0. CSharpier 1.3.0 global tool (see toolchain note below). |
+| **Linting with .NET analyzers** | ✅ PASS | `EnableNETAnalyzers=true` build: 0 warnings / 0 errors. |
+| **Type checking (nullable)** | ✅ PASS | `Nullable enable` + `TreatWarningsAsErrors=true` build clean. |
+| **Testing with MSTest** | ✅ PASS | 252/252 pass. |
+
+**CSharpier version toolchain note (assessed):** The repository pins CSharpier `0.16.0` as a dotnet local tool (command id `dotnet-csharpier`), but `dotnet tool restore` for that pin failed in this worktree (`dotnet csharpier --version` -> "Run dotnet tool restore"). The executor and this review used the globally installed CSharpier `1.3.0` via `csharpier check`. Assessment: format verification is satisfied — the diff is formatting-clean under the available formatter and the build is clean. This is a residual non-blocking concern, not a violation: a major-version difference (0.16.0 vs 1.3.0) can in principle format identical source differently, so the green `csharpier check` under 1.3.0 does not prove the source is clean under the pinned 0.16.0. The risk is low here because the changes are route-string and small-helper edits with conventional formatting, and the build is warnings-as-errors clean. Recommended (non-blocking) follow-up: repair the dotnet-tool restore so the pinned formatter is the one exercised, or update the tool pin to match the installed major version. Recorded as a Minor finding in the code-review.
+
+#### 3C#.2 C# Design & Typing
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Nullable safety** | ✅ PASS | `FormatAdapterVersion(Version?)` handles the null case explicitly; no nullable warnings. |
+| **No `dynamic`/untyped escape hatches** | ✅ PASS (T1/T2 = 0) | No `dynamic` introduced; query values handled as `StringValues`/`string`. |
+| **Public API discipline** | ✅ PASS | T2 `IHostAdapterClient` signatures unchanged; only XML-doc text changed. New options are keyword-style with defaults. |
+| **Composition over inheritance** | ✅ PASS | No new inheritance; static helper functions and option properties. |
+
+#### 3C#.3 C# Error Handling
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Fail fast / explicit** | ✅ PASS | Validation returns explicit `InvalidRequest` envelopes with specific messages naming the offending parameter. |
+| **No silent error swallowing** | ✅ PASS | Absent `$filter` predicate yields empty `StringValues`, which surfaces the standard required-parameter error downstream (documented in the helper summary). |
+| **Logging pattern** | ✅ PASS | Existing `RequestLoggingMiddleware` retained; no logging regression. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4C#: C# Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use MSTest** | ✅ PASS | `[TestClass]`/`[TestMethod]` with FluentAssertions and Moq across HostAdapter.Tests and Core.Tests. |
+| **Coverage expectation** | ✅ PASS | Changed-code 98.85% line / 79.41% branch; package-level >= 85%/75%. |
+| **Focused unit tests** | ✅ PASS | One behavior per test. |
+| **Mocking sparingly** | ✅ PASS | Only the HTTP handler and process runner are faked. |
+| **Organization** | ✅ PASS | Test files mirror the project structure under `tests/OpenClaw.*.Tests/`. |
+| **Determinism infrastructure** | ✅ PASS | No `Thread.Sleep`/`Task.Delay`/real waits in the changed tests; fixed timestamps. |
+
+---
+
+## 5. Test Coverage Detail
+
+### HostAdapter messages-branch dispatch (2 new tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `HostAdapter_should_dispatch_meeting_requests_branch_when_filter_contains_meeting_message_type_predicate` | Positive (branch select) | ✅ |
+| `HostAdapter_should_dispatch_plain_messages_branch_when_filter_has_no_meeting_message_type_predicate` | Positive (branch select) | ✅ |
+
+**Coverage:** Exercises `FilterSelectsMeetingRequests` true/false paths and the `BuildListMeetingRequests`/`BuildListMessages` dispatch fork in `Program.cs`.
+
+### HostAdapter version (1 new test)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `DefaultAdapterVersion_should_report_1_0_0_from_the_assembly_version` | Positive | ✅ |
+
+**Coverage:** `FormatAdapterVersion` happy path (3-component reduction of the assembly version).
+
+**Not covered:** Two defensive branches in `FormatAdapterVersion` (`version is null` and `version.Build < 0`) are unreachable for the loaded assembly (non-null version, Build >= 0). Justification: intentional defensive guards; aggregate changed-code branch coverage remains above threshold.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (affected projects) | 252 | ✅ |
+| Tests Passed | 252 (100%) | ✅ |
+| Tests Failed | 0 | ✅ |
+| Execution Time | ~1.18 s total (0.379 s + 0.800 s) | ✅ Fast |
+| Code Coverage (changed-code) | 98.85% line, 79.41% branch | ✅ |
+
+---
+
+## 7. Code Quality Checks
+
+**For C#:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| CSharpier Formatting | `csharpier check ./src ./tests` | Checked 149 files; exit 0 | ✅ |
+| .NET Analyzers + Style | `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` | 0 warnings / 0 errors | ✅ |
+| Nullable type checking | `dotnet build ... -p:TreatWarningsAsErrors=true` | 0 warnings / 0 errors | ✅ |
+| MSTest Tests | `dotnet test tests/OpenClaw.HostAdapter.Tests/...; dotnet test tests/OpenClaw.Core.Tests/...` | 74/74; 178/178 | ✅ |
+
+**Notes:** CSharpier pinned-tool restore is unavailable in this worktree; the global 1.3.0 tool was used. See the toolchain note in Section 3C#.1. No other deviations from clean runs.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+- **CSharpier tool pin mismatch (Minor, non-blocking):** Formatting was verified with global CSharpier 1.3.0 rather than the pinned 0.16.0 dotnet-tool, which could not be restored. Format-clean under the pinned formatter is therefore not directly proven. Low risk given the nature of the changes and the clean warnings-as-errors build.
+- **PR-context summary misclassification (Info):** `artifacts/pr_context.summary.txt` reports "Core logic changes: 0 files" despite seven changed `src/**` source files. This is a context-artifact defect; the audit used the direct branch diff instead.
+
+### Approved Exceptions
+- **None.** No exceptions to policy thresholds were required; all gates pass on the merits.
+
+### Removed/Skipped Tests
+- **None.** No tests were removed or skipped. Updated tests assert stronger, Graph-shaped routes (not weakened).
+
+---
+
+## 9. Summary of Changes
+
+### Range
+- `3041d083691cd77b2b2e888580fc9f2ab8bc611f..e3bc4506e1ebce0080e057306b91ffbbb77fd945` (base `main` -> head).
+
+### Files Modified (production)
+1. `src/OpenClaw.HostAdapter/Program.cs` (MODIFIED) — six `/v1/*` route registrations reshaped to five Graph-shaped routes; messages and meeting-requests merged into one `/users/{id}/messages` handler branching on the `$filter` predicate; `/v1/status` -> `/status`; `bridgeId` route params renamed to `messageId`/`eventId`; `MailboxId` post-configure normalization.
+2. `src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs` (MODIFIED) — added `ExtractReceivedDateTimeLowerBound` and `FilterSelectsMeetingRequests`; error messages updated to `$top`, `startDateTime`/`endDateTime`.
+3. `src/OpenClaw.HostAdapter/HostAdapterOptions.cs` (MODIFIED) — added `MailboxId` (default `"me"`); added `FormatAdapterVersion` to render 3-component `1.0.0`.
+4. `src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj` (MODIFIED) — added `<Version>1.0.0</Version>`.
+5. `src/OpenClaw.HostAdapter.Contracts/IHostAdapterClient.cs` (MODIFIED) — XML-doc only; signatures unchanged; `ListMeetingRequestsAsync` retained.
+6. `src/OpenClaw.Core/HostAdapterHttpClient.cs` (MODIFIED) — six relative paths reshaped to Graph-shaped paths sourced from `MailboxId`.
+7. `src/OpenClaw.Core/CoreOptions.cs` (MODIFIED) — `BaseUrl` default drops `/v1/`; added `MailboxId` mirror (default `"me"`) without referencing `OpenClaw.HostAdapter`.
+
+### Files Modified (tests)
+- 8 updated test files (route/parameter strings, base URL) + 1 new (`HostAdapterVersionTests.cs`).
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ✅ FULLY COMPLIANT
+
+The change satisfies the cross-language code-change and unit-test policies, the C# language policy, the T2 contract/version policy, the architecture-boundary rule, the evidence-location rule, and the coverage thresholds. All findings are non-blocking. Two residual items are recorded: a CSharpier tool-pin mismatch (Minor) and a PR-context summary misclassification (Info).
+
+**Fail-closed reminder:** No required baseline, QA, coverage, or coverage-comparison artifact is missing; coverage metrics are numeric and present. The audit is not blocked.
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- ✅ Before Making Changes
+- ✅ Design Principles
+- ✅ Module & File Structure
+- ✅ Naming, Docs, Comments
+- ✅ Toolchain Execution (7 stages clean in one pass)
+- ✅ Summarize & Document
+
+#### Language-Specific Code Change Policy (Section 3) — C#
+- ✅ Tooling & Baseline (CSharpier note non-blocking)
+- ✅ Design & Typing
+- ✅ Error Handling
+
+#### General Unit Test Policy (Section 1)
+- ✅ Core Principles
+- ✅ Coverage & Scenarios
+- ✅ Test Structure
+- ✅ External Dependencies
+- ✅ Policy Audit
+
+#### Language-Specific Unit Test Policy (Section 4) — C#
+- ✅ Framework & Scope
+- ✅ Test Style & Structure
+- ✅ Naming & Readability
+- ✅ Toolchain
+
+### Metrics Summary
+- ✅ 252/252 tests passing (100%)
+- ✅ Changed-code coverage 98.85% line / 79.41% branch (>= 85% / 75%)
+- ✅ Package-level coverage HostAdapter 97.08%/86.30%, Core 98.58%/90.32%
+- ✅ Build 0 warnings / 0 errors (analyzers + nullable + warnings-as-errors)
+- ✅ CSharpier format clean (149 files)
+- ✅ No new architecture edges; T2 contract parity; version 1.0.0
+
+### Recommendation
+
+**Ready for merge.** No blocking or material-partial findings. Optional follow-up: repair or re-pin the CSharpier dotnet-tool so formatting is verified under the pinned version.
+
+---
+
+## Appendix A: Test Inventory
+
+New and updated tests exercised by this change (affected projects):
+
+1. OpenClaw.HostAdapter.Tests › HostAdapterMappingTests › `HostAdapter_should_dispatch_meeting_requests_branch_when_filter_contains_meeting_message_type_predicate` (new)
+2. OpenClaw.HostAdapter.Tests › HostAdapterMappingTests › `HostAdapter_should_dispatch_plain_messages_branch_when_filter_has_no_meeting_message_type_predicate` (new)
+3. OpenClaw.HostAdapter.Tests › HostAdapterVersionTests › `DefaultAdapterVersion_should_report_1_0_0_from_the_assembly_version` (new file)
+4. OpenClaw.HostAdapter.Tests › HostAdapterMappingTests › existing messages mapping (route strings updated to `/users/me/messages?$filter=...&$top=...`)
+5. OpenClaw.HostAdapter.Tests › HostAdapterValidationTests › timestamp, window, and over-limit cases (route/param strings updated to `receivedDateTime`, `startDateTime`/`endDateTime`, `$top`)
+6. OpenClaw.HostAdapter.Tests › HostAdapterAuthTests › unauthorized/invalid-token (status route `/status`)
+7. OpenClaw.HostAdapter.Tests › HostAdapterEndpointTests › escaped path segments (`/users/me/messages/...`, `/users/me/events/...`)
+8. OpenClaw.HostAdapter.Tests › HostAdapterEnvelopeTests › status envelope (`/status`)
+9. OpenClaw.HostAdapter.Tests › HostAdapterStatusCacheTests › cache reuse (route strings updated to Graph-shaped messages)
+10. OpenClaw.Core.Tests › HostAdapterHttpClientTests › six route-shape/param assertions updated to Graph-shaped paths and `MailboxId`-sourced `/users/me/...`
+11. OpenClaw.Core.Tests › CoreTestWebApplicationFactory base URL updated to drop `/v1/`
+
+Full suite totals (affected projects): HostAdapter.Tests 74 tests, Core.Tests 178 tests, all passing.
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For C#:**
+```bash
+# Formatting (global CSharpier 1.3.0; pinned 0.16.0 dotnet-tool unavailable in worktree)
+csharpier check ./src ./tests
+
+# Linting + style + nullable type checking
+dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true -p:TreatWarningsAsErrors=true
+
+# Architecture boundary inspection
+grep -rn 'ProjectReference Include' src --include=*.csproj
+
+# Route surface inspection
+grep -rn '"/v1/' src/OpenClaw.HostAdapter/   # expect: no matches
+grep -n 'MapGet' src/OpenClaw.HostAdapter/Program.cs
+
+# Tests (with coverage via the runsettings used in execution)
+dotnet test tests/OpenClaw.HostAdapter.Tests/OpenClaw.HostAdapter.Tests.csproj -c Debug
+dotnet test tests/OpenClaw.Core.Tests/OpenClaw.Core.Tests.csproj -c Debug
+dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-06-12
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/spec.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/spec.md
@@ -1,0 +1,249 @@
+# evolve-hostadapter-graph-surface — Spec
+
+- **Issue:** #76
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-12
+- **Status:** Ready
+- **Version:** 1.0
+
+## Overview
+
+This is a breaking change to the `OpenClaw.HostAdapter` HTTP surface and the
+`IHostAdapterClient` contract (a T2 boundary in `OpenClaw.HostAdapter.Contracts`).
+The bespoke `/v1/*` route table is replaced with a Microsoft Graph-shaped surface
+(`/users/{id}/messages`, `/users/{id}/messages/{messageId}`, `/users/{id}/calendarView`,
+`/users/{id}/events/{eventId}`, and a messages-filtered meeting-requests form). The goal
+is that the OpenClaw agent calls the same URL shapes against the local adapter in Stage 0
+that it will use against the real Microsoft Graph in Product Increment 1.
+
+This change replaces the OR-4 mapper-shim relationship introduced by #70. Under #70 the
+`HostAdapterSchedulingService` shim (in `OpenClaw.Core`) wrapped a bespoke
+`IHostAdapterClient` and translated to the agent's scheduling contract. After #76 the
+`IHostAdapterClient` wire routes are natively Graph-shaped, so the adapter no longer needs
+a bespoke-to-Graph translation at the route layer; the shim updates its call-sites to the
+revised client and otherwise continues to operate on unchanged DTO fields.
+
+- Target users/personas and primary use cases: the PI-1 OpenClaw agent that natively
+  speaks Microsoft Graph route shapes against the local HostAdapter during Stage 0
+  development, so the agent's request construction is portable to real Graph without
+  rework.
+- Success metrics or expected impact: the HostAdapter no longer serves any `/v1/*` route
+  (the `/status` operational probe excepted); the in-repo callers (`HostAdapterHttpClient`,
+  `HostAdapterSchedulingService`) compile and pass against the Graph-shaped routes; the
+  adapter reports version `1.0.0` to signal the breaking contract change; DTO/envelope
+  schema is unchanged.
+
+## Behavior
+
+The HostAdapter route table is reshaped from bespoke `/v1/*` paths to Graph-shaped paths.
+The change is path-and-query only: request/response envelopes and DTO shapes are unchanged.
+The `{id}` path segment is sourced from the new `HostAdapterOptions.MailboxId` configuration
+property (default `"me"`), so routes render as `/users/me/...` by default.
+
+- Main user flow (happy path): the agent (or `HostAdapterHttpClient`) issues a Graph-shaped
+  request against the local adapter (for example
+  `GET /users/me/messages?$filter=receivedDateTime ge 2026-06-12T00:00:00Z&$top=50`),
+  the adapter resolves the bridge-cached data through the existing RPC chain, and returns
+  an `ApiEnvelope<ItemsResponse<MessageDto>>` exactly as before.
+
+- Per-route old -> new mapping:
+
+  | Operation | Current bespoke route | New Graph-shaped route |
+  |---|---|---|
+  | Status probe | `GET /v1/status` | `GET /status` (operational probe; no Graph equivalent, kept as a plain non-Graph path) |
+  | Messages list | `GET /v1/messages?since={iso}&limit={n}` | `GET /users/{id}/messages?$filter=receivedDateTime ge {iso8601}&$top={limit}` |
+  | Single message | `GET /v1/messages/{bridgeId}` | `GET /users/{id}/messages/{messageId}` |
+  | Meeting requests | `GET /v1/meeting-requests?since={iso}&limit={n}` | `GET /users/{id}/messages?$filter=meetingMessageType ne null and receivedDateTime ge {iso8601}&$top={limit}` (messages-filtered; see below) |
+  | Calendar window | `GET /v1/calendar?start={iso}&end={iso}&limit={n}` | `GET /users/{id}/calendarView?startDateTime={iso8601}&endDateTime={iso8601}&$top={limit}` |
+  | Single event | `GET /v1/events/{bridgeId}` | `GET /users/{id}/events/{eventId}` |
+
+- Meeting-requests handling (decision D1, explicit): the meeting-requests capability is
+  retained in full. `ListMeetingRequestsAsync` stays on `IHostAdapterClient`, the HostAdapter
+  meeting-requests route stays, the bridge RPC chain (`list_recent_meeting_requests`) stays,
+  the `MessagePollingWorker.PollMeetingRequestsAsync` path stays, and the Core UI
+  meeting-requests surface stays. Only the wire route string and query parameters change.
+  Microsoft Graph has no dedicated meeting-requests collection, so the Graph-shaped form is
+  a messages-filtered query: `GET /users/{id}/messages?$filter=meetingMessageType ne null`
+  combined with the existing `since` lower bound expressed Graph-style as
+  `receivedDateTime ge {iso8601}`, with `$top={limit}`.
+
+- Query-parameter renames (decision D4): `since` -> `$filter=receivedDateTime ge {iso8601}`;
+  `start` -> `startDateTime`; `end` -> `endDateTime`; `limit` -> `$top`. The `$filter` and
+  `$top` parameters carry the OData `$` prefix; `startDateTime` and `endDateTime` do not
+  carry a `$` prefix (they are Graph calendarView required parameters). The timestamp value
+  format remains ISO 8601 (the adapter already emits round-trip `O` format).
+
+- Alternate/edge flows: the `/status` operation has no Graph equivalent and is retained as a
+  plain operational probe at `GET /status`. The validation behavior for missing or malformed
+  timestamps and over-limit `$top` values is preserved; only the parameter names read by the
+  request validation change.
+
+- Error handling and recovery behavior: error responses continue to use the existing
+  `ApiError`/`ApiEnvelope<T>` envelope. Request validation rejects malformed Graph-shaped
+  query parameters with the same status codes and error codes used today; only the parameter
+  names that validation inspects change (`$filter` receivedDateTime bound, `startDateTime`,
+  `endDateTime`, `$top`).
+
+## Inputs / Outputs
+
+- Inputs (CLI flags, files, env vars): no new CLI flags. The new configuration input is the
+  `HostAdapterOptions.MailboxId` key (HostAdapter side) and the revised
+  `OpenClawOptions.HostAdapter.BaseUrl` default (Core side).
+- Outputs (artifacts, logs, telemetry): response envelopes are unchanged. The
+  `meta.adapterVersion` field reports `1.0.0` after the version bump.
+- Config keys and defaults:
+  - `HostAdapterOptions.MailboxId` (new, in `src/OpenClaw.HostAdapter/HostAdapterOptions.cs`),
+    default `"me"`. Sources the `{id}` path segment so routes render as `/users/me/...`.
+  - `OpenClawOptions.HostAdapter.BaseUrl` (in `src/OpenClaw.Core/CoreOptions.cs`), default
+    changes from `http://host.docker.internal:4319/v1/` to
+    `http://host.docker.internal:4319/` (decision D6 — the `/v1/` segment is dropped).
+  - Adapter version: `<Version>1.0.0</Version>` is added to
+    `src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj` (decision D5). This surfaces
+    through `HostAdapterOptions.DefaultAdapterVersion` -> `AdapterVersion` into `ApiMeta`.
+    The current effective version is the assembly fallback `0.1.0`; this is the first major
+    bump to `1.0.0`.
+- Versioning or backward-compatibility constraints: this is explicitly a breaking change to
+  the HostAdapter HTTP surface and the `IHostAdapterClient` contract. It requires a major
+  version bump (`1.0.0`). Backward compatibility with the `/v1/*` routes is not retained;
+  callers must use the Graph-shaped routes. All in-repo callers are updated as part of this
+  change: `HostAdapterHttpClient` (relative paths) and `HostAdapterSchedulingService`
+  (call-site review against the revised client). Operators with a pinned `BaseUrl` containing
+  `/v1/` must update their configuration; new deployments work without intervention because
+  the default changes.
+
+## API / CLI Surface
+
+New route table served by `OpenClaw.HostAdapter` (`Program.cs`):
+
+```
+GET /status
+GET /users/{id}/messages?$filter=receivedDateTime ge {iso8601}&$top={limit}
+GET /users/{id}/messages/{messageId}
+GET /users/{id}/messages?$filter=meetingMessageType ne null and receivedDateTime ge {iso8601}&$top={limit}
+GET /users/{id}/calendarView?startDateTime={iso8601}&endDateTime={iso8601}&$top={limit}
+GET /users/{id}/events/{eventId}
+```
+
+Example invocations with expected outputs (concise):
+
+- `GET /users/me/messages?$filter=receivedDateTime ge 2026-06-12T00:00:00Z&$top=50`
+  -> `200` with `ApiEnvelope<ItemsResponse<MessageDto>>`.
+- `GET /users/me/messages/AAMkAD...` -> `200` with `ApiEnvelope<MessageDto>`.
+- `GET /users/me/calendarView?startDateTime=2026-06-01T00:00:00Z&endDateTime=2026-06-30T00:00:00Z&$top=100`
+  -> `200` with `ApiEnvelope<ItemsResponse<EventDto>>`.
+- `GET /users/me/events/AAMkAD...` -> `200` with `ApiEnvelope<EventDto>`.
+- `GET /status` -> `200` with `ApiEnvelope<BridgeStatusDto>`.
+
+`IHostAdapterClient` method signatures: the C# shape is unchanged. The strongly-typed
+parameters (`sinceUtc`, `limit`, `bridgeId`, `startUtc`/`endUtc`, `requestId`,
+`cancellationToken`) are kept; only the wire routes the implementation emits change. The
+methods retained are:
+
+- `GetStatusAsync(requestId, cancellationToken)` -> `ApiEnvelope<BridgeStatusDto>`
+- `ListMessagesAsync(sinceUtc, limit, requestId, cancellationToken)` -> `ApiEnvelope<ItemsResponse<MessageDto>>`
+- `GetMessageAsync(bridgeId, requestId, cancellationToken)` -> `ApiEnvelope<MessageDto>`
+- `ListMeetingRequestsAsync(sinceUtc, limit, requestId, cancellationToken)` -> `ApiEnvelope<ItemsResponse<MessageDto>>` (retained per D1)
+- `ListCalendarWindowAsync(startUtc, endUtc, limit, requestId, cancellationToken)` -> `ApiEnvelope<ItemsResponse<EventDto>>`
+- `GetEventAsync(bridgeId, requestId, cancellationToken)` -> `ApiEnvelope<EventDto>`
+
+Contracts and validation rules: request validation reads the new query-parameter names
+(`$filter` receivedDateTime lower bound, `startDateTime`, `endDateTime`, `$top`) and enforces
+the existing `MaxLimit` ceiling on `$top`. The DTO and envelope contracts
+(`ApiEnvelope<T>`, `ItemsResponse<T>`, `MessageDto`, `EventDto`, `ApiMeta`, `ApiError`,
+`BridgeStatusDto`) are unchanged.
+
+## Data & State
+
+- Data transformations and invariants: none. The route reshaping is path-and-query only.
+  No DTO field is added, removed, or renamed. The `SchedulingDtoMapper` continues to operate
+  on unchanged DTO fields and is not modified by this change.
+- Caching or persistence details: no change. The bridge-cache and RPC chain that backs each
+  operation is unchanged, including `list_recent_meeting_requests` for the meeting-requests
+  route.
+- Migration or backfill requirements (if any): none for stored data. The only operator-facing
+  migration is the `BaseUrl` configuration change (drop `/v1/`), which the new default handles
+  for fresh deployments.
+
+## Constraints & Risks
+
+- Limits and acceptable trade-offs: `$top` remains bounded by the existing `MaxLimit`
+  (default 250). No latency/throughput change is introduced; the work is route-string and
+  parameter-name reshaping.
+- T1/T2 contract boundary: `IHostAdapterClient` lives in `OpenClaw.HostAdapter.Contracts`
+  (T2). Renaming query-parameter semantics on a public HTTP contract is a breaking change.
+  Per `.claude/rules/quality-tiers.md`, a contract breaking change at a T1/T2 boundary
+  requires a major version bump and a contract/schema compatibility check. The major bump is
+  `1.0.0` (decision D5). The compatibility check must confirm the new interface is correctly
+  implemented by `HostAdapterHttpClient` and that all in-repo callers are updated.
+- Architecture boundaries preserved (per `.claude/rules/architecture-boundaries.md`): no new
+  `ProjectReference` edges. `OpenClaw.Core` continues to depend only on
+  `OpenClaw.HostAdapter.Contracts`; `OpenClaw.HostAdapter` continues to depend only on
+  `OpenClaw.HostAdapter.Contracts` and `OpenClaw.MailBridge.Contracts`;
+  `OpenClaw.HostAdapter.Contracts` continues to depend only on
+  `OpenClaw.MailBridge.Contracts`. No COM boundary is crossed.
+- Security/privacy considerations: no change to authentication or token handling. The
+  `{id}` segment defaults to the non-identifying literal `"me"`; it does not place a real
+  UPN into URLs unless an operator configures one.
+- Operational/rollout risks and mitigations: operators with a pinned `BaseUrl` that includes
+  `/v1/` must update configuration; mitigated by changing the default so new deployments work
+  without intervention. The breaking route change is signaled by the `1.0.0` adapter version
+  reported in `meta.adapterVersion`.
+
+## Implementation Strategy
+
+- Implementation scope (what changes, not sequencing): reshape the HostAdapter route table,
+  update query-parameter names in request validation, update the typed client's relative
+  paths, add the `MailboxId` option, change the Core `BaseUrl` default, bump the adapter
+  version, and review the scheduling-service call-sites. No DTO/envelope change.
+
+- Production files to change:
+  - `src/OpenClaw.HostAdapter/Program.cs` — reshape the six route registrations to the
+    Graph-shaped paths (status -> `/status`; messages, single message, meeting-requests
+    messages-filtered, calendarView, single event under `/users/{id}/...`).
+  - `src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs` — read the new query-parameter
+    names (`$filter` receivedDateTime lower bound, `startDateTime`, `endDateTime`, `$top`)
+    in place of `since`, `start`, `end`, `limit`.
+  - `src/OpenClaw.HostAdapter.Contracts/IHostAdapterClient.cs` — update XML-doc text to
+    describe Graph-shaped routes; method signatures keep the same C# shape (no member
+    removal; `ListMeetingRequestsAsync` retained per D1).
+  - `src/OpenClaw.Core/HostAdapterHttpClient.cs` — update the six relative-path constructions
+    to the Graph-shaped paths, sourcing the `{id}` segment.
+  - `src/OpenClaw.HostAdapter/HostAdapterOptions.cs` — add the `MailboxId` property (default
+    `"me"`) and use it to render the `{id}` path segment.
+  - `src/OpenClaw.Core/CoreOptions.cs` — change the `HostAdapter.BaseUrl` default to
+    `http://host.docker.internal:4319/` (drop `/v1/`).
+  - `src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj` — add `<Version>1.0.0</Version>`.
+  - `src/OpenClaw.Core/Agent/Runtime/HostAdapterSchedulingService.cs` — review call-sites
+    against the revised `IHostAdapterClient`; update only if a call shape changed (signatures
+    are unchanged, so this is expected to be a review with no functional edit).
+
+- Test files to update:
+  - `tests/OpenClaw.HostAdapter.Tests/HostAdapterEndpointTests.cs` — route URL strings.
+  - `tests/OpenClaw.HostAdapter.Tests/HostAdapterAuthTests.cs` — `/status` route string.
+  - `tests/OpenClaw.HostAdapter.Tests/HostAdapterMappingTests.cs` — route and query-param strings.
+  - `tests/OpenClaw.HostAdapter.Tests/HostAdapterValidationTests.cs` — route and query-param strings.
+  - `tests/OpenClaw.HostAdapter.Tests/HostAdapterEnvelopeTests.cs` — `/status` route string.
+  - `tests/OpenClaw.Core.Tests/HostAdapterHttpClientTests.cs` — `BaseUrl`, path assertions,
+    query-param-name assertions (`$filter=receivedDateTime`, `startDateTime`, `endDateTime`,
+    `$top`).
+  - `tests/OpenClaw.Core.Tests/MessagePollingWorkerTests.cs` and
+    `tests/OpenClaw.Core.Tests/Agent/Runtime/HostAdapterSchedulingServiceTests.cs` — review
+    mock setups; `ListMeetingRequestsAsync` is retained, so mocks for it remain valid.
+
+- Dependency changes (new/removed packages) and rationale: none.
+- Logging/telemetry additions and locations: none beyond the `1.0.0` value surfacing in
+  `meta.adapterVersion`.
+- Rollout plan (feature flags, staged deploys, fallback path): no feature flag. The breaking
+  change is gated by the major version bump and the contract/schema compatibility check.
+  Operators update `BaseUrl` if pinned; the changed default covers fresh deployments.
+
+## Definition of Done
+
+- [ ] Acceptance criteria documented and mapped to tests or demos
+- [ ] Behavior matches acceptance criteria in all documented environments
+- [ ] Tests updated/added (unit/integration as applicable)
+- [ ] Edge cases and error handling covered by tests
+- [ ] Docs updated (README, docs/features/active/... links)
+- [ ] Telemetry/logging added or updated (if applicable)
+- [ ] Toolchain pass completed (format → lint → type-check → test)

--- a/docs/features/active/evolve-hostadapter-graph-surface-76/user-story.md
+++ b/docs/features/active/evolve-hostadapter-graph-surface-76/user-story.md
@@ -1,0 +1,89 @@
+# `evolve-hostadapter-graph-surface` — User Story
+
+- Issue: #76
+- Owner: drmoisan
+- Status: Ready
+- Last Updated: 2026-06-12
+
+## Story Statement
+
+- As the PI-1 OpenClaw agent, I want the local HostAdapter to expose Microsoft
+  Graph-shaped routes (`/users/{id}/messages`, `/users/{id}/messages/{messageId}`,
+  `/users/{id}/calendarView`, `/users/{id}/events/{eventId}`, and a messages-filtered
+  meeting-requests form), so that the request shapes I build in Stage 0 are the same ones I
+  will issue against the real Microsoft Graph in Product Increment 1 without rework.
+- As a maintainer of `OpenClaw.Core`, I want the breaking HostAdapter contract change to be
+  signaled by a major adapter version (`1.0.0`) and a configurable mailbox identifier
+  (`MailboxId`, default `"me"`), so that the route reshaping is explicit, traceable, and
+  configurable without changing the unchanged DTO/envelope schema.
+
+## Problem / Why
+
+The HostAdapter currently serves a bespoke `/v1/*` route table (`/v1/messages`,
+`/v1/calendar`, `/v1/meeting-requests`, and so on) with bespoke query parameters (`since`,
+`start`, `end`, `limit`). The OpenClaw agent in Product Increment 1 will call Microsoft Graph,
+which uses a different URL shape (`/users/{id}/messages` with OData `$filter` and `$top`,
+`/users/{id}/calendarView` with `startDateTime`/`endDateTime`). If the agent is developed
+against bespoke routes in Stage 0, its request-construction code must be rewritten to reach
+Graph later. Reshaping the local adapter to Graph-shaped routes now lets the agent's
+request-construction code be portable across the local adapter and real Graph, removing that
+rework and reducing the divergence between Stage 0 and PI-1 behavior. This is one of the two
+pieces of work identified as required to reach the Local MVP.
+
+## Personas & Scenarios
+
+- Persona: the PI-1 OpenClaw agent (acting through `HostAdapterHttpClient` and the
+  scheduling layer in `OpenClaw.Core`).
+  - who the user is: the local agent runtime that reads mail and calendar data over loopback
+    HTTP from the HostAdapter.
+  - what they care about: building request URLs once and reusing them unchanged against the
+    real Microsoft Graph in PI-1.
+  - their constraints: must operate over the existing envelope/DTO contract
+    (`ApiEnvelope<T>`, `ItemsResponse<T>`, `MessageDto`, `EventDto`); must not introduce new
+    project dependencies or cross the COM boundary.
+  - their goals and frustrations: the goal is Graph-portable request construction; the
+    frustration being removed is the bespoke `/v1/*` shape that has no Graph equivalent.
+  - their context and motivations: Stage 0 local development that must transfer cleanly to a
+    real Graph integration in PI-1.
+- Scenario: the agent retrieves a recent message window.
+  - who is acting? the OpenClaw agent, through `HostAdapterHttpClient`.
+  - what triggered the action? a polling cycle or an agent task that needs recent messages
+    since a known timestamp.
+  - what steps do they take? the client issues
+    `GET /users/me/messages?$filter=receivedDateTime ge 2026-06-12T00:00:00Z&$top=50`
+    against the local adapter at the new base URL `http://host.docker.internal:4319/`
+    (no `/v1/`). The `{id}` segment resolves to `me` from `HostAdapterOptions.MailboxId`.
+  - what obstacles or decisions occur? the adapter validates the Graph-shaped query
+    parameters (`$filter` receivedDateTime lower bound, `$top` against `MaxLimit`) and
+    resolves the request through the unchanged bridge-cache RPC chain.
+  - what outcome do they expect? a `200` response with an
+    `ApiEnvelope<ItemsResponse<MessageDto>>` whose `meta.adapterVersion` is `1.0.0`, and a
+    URL shape identical to the one the agent will later send to real Microsoft Graph.
+
+## Acceptance Criteria
+
+- [x] HostAdapter exposes the Graph-shaped routes (`/users/{id}/messages`, `/users/{id}/messages/{messageId}`, `/users/{id}/calendarView`, `/users/{id}/events/{eventId}`, and meeting-requests as a messages-filtered query on `meetingMessageType`) and no longer serves the `/v1/*` bespoke routes (the `/status` operational probe excepted).
+- [x] `IHostAdapterClient` and `HostAdapterHttpClient` call the Graph-shaped endpoints and receive envelope-wrapped (`ApiEnvelope<T>`) results, with `ListMeetingRequestsAsync` retained on the interface.
+- [x] `OpenClawOptions.HostAdapter.BaseUrl` default no longer contains `/v1/`.
+- [x] The adapter version reports `1.0.0` (via `meta.adapterVersion`) to signal the breaking change.
+- [x] `MailboxId` (default `"me"`) is configurable on `HostAdapterOptions` and is used to render the `{id}` path segment.
+- [x] Existing contract/endpoint tests pass against the new routes (HostAdapter.Tests and Core.Tests updated, not weakened).
+- [x] Line coverage >= 85% and branch coverage >= 75% on changed code; no coverage regression on changed lines.
+
+## Non-Goals
+
+The following are explicitly excluded from #76:
+
+- Removing or reducing the meeting-requests capability. `ListMeetingRequestsAsync`, the
+  HostAdapter meeting-requests route, the `list_recent_meeting_requests` bridge RPC chain,
+  the `MessagePollingWorker.PollMeetingRequestsAsync` path, and the Core UI meeting-requests
+  surface are all retained. Only the meeting-requests wire route and query parameters change
+  to the Graph-shaped messages-filtered form.
+- Changing DTOs or the envelope schema. `ApiEnvelope<T>`, `ItemsResponse<T>`, `MessageDto`,
+  `EventDto`, `ApiMeta`, `ApiError`, and `BridgeStatusDto` are not modified. This is a
+  path-and-query change only.
+- Refactoring meeting-request filtering into the agent layer. Moving meeting-request
+  identification out of the adapter and into client-side filtering on `meetingMessageType`
+  is out of scope; the dedicated meeting-requests method and route are kept.
+- Adding mailbox-settings, free/busy, or send-mail Graph routes. Those are scoped to #74/#75
+  and remain unsupported here.

--- a/src/OpenClaw.Core/CoreOptions.cs
+++ b/src/OpenClaw.Core/CoreOptions.cs
@@ -13,9 +13,16 @@ public sealed class OpenClawOptions
 
 public sealed class HostAdapterOptions
 {
-    public string BaseUrl { get; set; } = "http://host.docker.internal:4319/v1/";
+    public string BaseUrl { get; set; } = "http://host.docker.internal:4319/";
 
     public string TokenFile { get; set; } = "/run/openclaw/hostadapter.token";
+
+    /// <summary>
+    /// The mailbox identifier rendered into the Graph-shaped <c>/users/{id}/...</c> route segment.
+    /// Mirrors the HostAdapter-side default <c>"me"</c> without crossing the project boundary into
+    /// <c>OpenClaw.HostAdapter</c>.
+    /// </summary>
+    public string MailboxId { get; set; } = "me";
 }
 
 public sealed class PollingOptions

--- a/src/OpenClaw.Core/HostAdapterHttpClient.cs
+++ b/src/OpenClaw.Core/HostAdapterHttpClient.cs
@@ -40,8 +40,9 @@ internal sealed class HostAdapterHttpClient(
         CancellationToken cancellationToken = default
     )
     {
+        var id = Uri.EscapeDataString(options.HostAdapter.MailboxId);
         return SendAsync<ItemsResponse<MessageDto>>(
-            $"messages?since={Uri.EscapeDataString(sinceUtc.ToString("O"))}&limit={limit}",
+            $"users/{id}/messages?$filter=receivedDateTime ge {Uri.EscapeDataString(sinceUtc.ToString("O"))}&$top={limit}",
             requestId,
             cancellationToken
         );
@@ -53,8 +54,9 @@ internal sealed class HostAdapterHttpClient(
         CancellationToken cancellationToken = default
     )
     {
+        var id = Uri.EscapeDataString(options.HostAdapter.MailboxId);
         return SendAsync<MessageDto>(
-            $"messages/{Uri.EscapeDataString(bridgeId)}",
+            $"users/{id}/messages/{Uri.EscapeDataString(bridgeId)}",
             requestId,
             cancellationToken
         );
@@ -67,8 +69,9 @@ internal sealed class HostAdapterHttpClient(
         CancellationToken cancellationToken = default
     )
     {
+        var id = Uri.EscapeDataString(options.HostAdapter.MailboxId);
         return SendAsync<ItemsResponse<MessageDto>>(
-            $"meeting-requests?since={Uri.EscapeDataString(sinceUtc.ToString("O"))}&limit={limit}",
+            $"users/{id}/messages?$filter=meetingMessageType ne null and receivedDateTime ge {Uri.EscapeDataString(sinceUtc.ToString("O"))}&$top={limit}",
             requestId,
             cancellationToken
         );
@@ -82,8 +85,9 @@ internal sealed class HostAdapterHttpClient(
         CancellationToken cancellationToken = default
     )
     {
+        var id = Uri.EscapeDataString(options.HostAdapter.MailboxId);
         return SendAsync<ItemsResponse<EventDto>>(
-            $"calendar?start={Uri.EscapeDataString(startUtc.ToString("O"))}&end={Uri.EscapeDataString(endUtc.ToString("O"))}&limit={limit}",
+            $"users/{id}/calendarView?startDateTime={Uri.EscapeDataString(startUtc.ToString("O"))}&endDateTime={Uri.EscapeDataString(endUtc.ToString("O"))}&$top={limit}",
             requestId,
             cancellationToken
         );
@@ -95,8 +99,9 @@ internal sealed class HostAdapterHttpClient(
         CancellationToken cancellationToken = default
     )
     {
+        var id = Uri.EscapeDataString(options.HostAdapter.MailboxId);
         return SendAsync<EventDto>(
-            $"events/{Uri.EscapeDataString(bridgeId)}",
+            $"users/{id}/events/{Uri.EscapeDataString(bridgeId)}",
             requestId,
             cancellationToken
         );

--- a/src/OpenClaw.HostAdapter.Contracts/IHostAdapterClient.cs
+++ b/src/OpenClaw.HostAdapter.Contracts/IHostAdapterClient.cs
@@ -3,12 +3,15 @@ using OpenClaw.MailBridge.Contracts.Models;
 namespace OpenClaw.HostAdapter.Contracts;
 
 /// <summary>
-/// Defines the read-only HTTP operations exposed by the HostAdapter.
+/// Defines the read-only HTTP operations exposed by the HostAdapter using
+/// Microsoft Graph-shaped routes (<c>/users/{id}/messages</c>,
+/// <c>/users/{id}/messages/{messageId}</c>, <c>/users/{id}/calendarView</c>,
+/// <c>/users/{id}/events/{eventId}</c>, and the operational <c>/status</c> probe).
 /// </summary>
 public interface IHostAdapterClient
 {
     /// <summary>
-    /// Retrieves the current bridge status snapshot.
+    /// Retrieves the current bridge status snapshot via <c>GET /status</c>.
     /// </summary>
     /// <param name="requestId">An optional caller-supplied correlation identifier.</param>
     /// <param name="cancellationToken">Cancels the outbound operation.</param>
@@ -19,9 +22,10 @@ public interface IHostAdapterClient
     );
 
     /// <summary>
-    /// Lists recent messages from the bridge cache after the provided UTC timestamp.
+    /// Lists recent messages from the bridge cache after the provided UTC timestamp via
+    /// <c>GET /users/{id}/messages?$filter=receivedDateTime ge {iso8601}&amp;$top={limit}</c>.
     /// </summary>
-    /// <param name="sinceUtc">The inclusive UTC lower bound for returned messages.</param>
+    /// <param name="sinceUtc">The inclusive UTC lower bound emitted as the <c>$filter</c> <c>receivedDateTime ge</c> predicate.</param>
     /// <param name="limit">The maximum number of items to return.</param>
     /// <param name="requestId">An optional caller-supplied correlation identifier.</param>
     /// <param name="cancellationToken">Cancels the outbound operation.</param>
@@ -34,9 +38,10 @@ public interface IHostAdapterClient
     );
 
     /// <summary>
-    /// Retrieves a single message by its opaque bridge identifier.
+    /// Retrieves a single message by its opaque bridge identifier via
+    /// <c>GET /users/{id}/messages/{messageId}</c>.
     /// </summary>
-    /// <param name="bridgeId">The bridge-generated message identifier.</param>
+    /// <param name="bridgeId">The bridge-generated message identifier rendered into the <c>{messageId}</c> route segment.</param>
     /// <param name="requestId">An optional caller-supplied correlation identifier.</param>
     /// <param name="cancellationToken">Cancels the outbound operation.</param>
     /// <returns>A message detail wrapped in an API envelope.</returns>
@@ -47,9 +52,11 @@ public interface IHostAdapterClient
     );
 
     /// <summary>
-    /// Lists recent meeting requests after the provided UTC timestamp.
+    /// Lists recent meeting requests after the provided UTC timestamp via the messages-filtered form
+    /// <c>GET /users/{id}/messages?$filter=meetingMessageType ne null and receivedDateTime ge {iso8601}&amp;$top={limit}</c>.
+    /// Microsoft Graph has no dedicated meeting-requests collection, so this is a filtered messages query.
     /// </summary>
-    /// <param name="sinceUtc">The inclusive UTC lower bound for returned meeting requests.</param>
+    /// <param name="sinceUtc">The inclusive UTC lower bound emitted as the <c>$filter</c> <c>receivedDateTime ge</c> predicate.</param>
     /// <param name="limit">The maximum number of items to return.</param>
     /// <param name="requestId">An optional caller-supplied correlation identifier.</param>
     /// <param name="cancellationToken">Cancels the outbound operation.</param>
@@ -62,10 +69,11 @@ public interface IHostAdapterClient
     );
 
     /// <summary>
-    /// Lists calendar events within the provided UTC window.
+    /// Lists calendar events within the provided UTC window via
+    /// <c>GET /users/{id}/calendarView?startDateTime={iso8601}&amp;endDateTime={iso8601}&amp;$top={limit}</c>.
     /// </summary>
-    /// <param name="startUtc">The inclusive UTC window start.</param>
-    /// <param name="endUtc">The exclusive UTC window end.</param>
+    /// <param name="startUtc">The inclusive UTC window start emitted as the <c>startDateTime</c> parameter.</param>
+    /// <param name="endUtc">The exclusive UTC window end emitted as the <c>endDateTime</c> parameter.</param>
     /// <param name="limit">The maximum number of items to return.</param>
     /// <param name="requestId">An optional caller-supplied correlation identifier.</param>
     /// <param name="cancellationToken">Cancels the outbound operation.</param>
@@ -79,9 +87,10 @@ public interface IHostAdapterClient
     );
 
     /// <summary>
-    /// Retrieves a single event by its opaque bridge identifier.
+    /// Retrieves a single event by its opaque bridge identifier via
+    /// <c>GET /users/{id}/events/{eventId}</c>.
     /// </summary>
-    /// <param name="bridgeId">The bridge-generated event identifier.</param>
+    /// <param name="bridgeId">The bridge-generated event identifier rendered into the <c>{eventId}</c> route segment.</param>
     /// <param name="requestId">An optional caller-supplied correlation identifier.</param>
     /// <param name="cancellationToken">Cancels the outbound operation.</param>
     /// <returns>An event detail wrapped in an API envelope.</returns>

--- a/src/OpenClaw.HostAdapter/HostAdapterOptions.cs
+++ b/src/OpenClaw.HostAdapter/HostAdapterOptions.cs
@@ -27,7 +27,21 @@ public sealed class HostAdapterOptions
     public static string DefaultClientExecutablePath => "OpenClaw.MailBridge.Client.exe";
 
     public static string DefaultAdapterVersion =>
-        typeof(HostAdapterOptions).Assembly.GetName().Version?.ToString() ?? "0.1.0";
+        FormatAdapterVersion(typeof(HostAdapterOptions).Assembly.GetName().Version);
+
+    private static string FormatAdapterVersion(Version? version)
+    {
+        // The assembly version renders four components (major.minor.build.revision); the adapter
+        // version reported in meta.adapterVersion uses the three-component major.minor.patch form
+        // (for example 1.0.0). A missing version falls back to the historical 0.1.0 value.
+        if (version is null)
+        {
+            return "0.1.0";
+        }
+
+        var build = version.Build < 0 ? 0 : version.Build;
+        return $"{version.Major}.{version.Minor}.{build}";
+    }
 
     public string AppSettingsPath { get; set; } = DefaultAppSettingsPath;
 
@@ -40,4 +54,10 @@ public sealed class HostAdapterOptions
     public int MaxLimit { get; set; } = 250;
 
     public string AdapterVersion { get; set; } = DefaultAdapterVersion;
+
+    /// <summary>
+    /// The mailbox identifier rendered into the Graph-shaped <c>/users/{id}/...</c> route segment.
+    /// Defaults to the non-identifying literal <c>"me"</c>.
+    /// </summary>
+    public string MailboxId { get; set; } = "me";
 }

--- a/src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs
+++ b/src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs
@@ -53,6 +53,45 @@ internal static class HostAdapterRequestValidation
         return true;
     }
 
+    /// <summary>
+    /// Extracts the <c>receivedDateTime ge {iso8601}</c> lower bound from a Graph-shaped
+    /// OData <c>$filter</c> expression. The returned value is the raw timestamp token, which the
+    /// caller validates with <see cref="TryGetUtcTimestamp{T}"/>. When the predicate is absent the
+    /// returned value is empty, which surfaces the standard required-parameter error downstream.
+    /// </summary>
+    public static StringValues ExtractReceivedDateTimeLowerBound(StringValues filterValues)
+    {
+        var filter = filterValues.ToString();
+        if (string.IsNullOrWhiteSpace(filter))
+        {
+            return StringValues.Empty;
+        }
+
+        const string predicate = "receivedDateTime ge ";
+        var index = filter.IndexOf(predicate, StringComparison.OrdinalIgnoreCase);
+        if (index < 0)
+        {
+            return StringValues.Empty;
+        }
+
+        var start = index + predicate.Length;
+        var remainder = filter[start..].TrimStart();
+        var end = remainder.IndexOf(" and ", StringComparison.OrdinalIgnoreCase);
+        var token = end < 0 ? remainder : remainder[..end];
+        return token.Trim();
+    }
+
+    /// <summary>
+    /// Determines whether a Graph-shaped OData <c>$filter</c> selects the meeting-requests branch
+    /// via the <c>meetingMessageType ne null</c> predicate.
+    /// </summary>
+    public static bool FilterSelectsMeetingRequests(StringValues filterValues)
+    {
+        var filter = filterValues.ToString();
+        return !string.IsNullOrWhiteSpace(filter)
+            && filter.Contains("meetingMessageType ne null", StringComparison.OrdinalIgnoreCase);
+    }
+
     public static bool TryGetLimit<T>(
         StringValues values,
         string requestId,
@@ -75,7 +114,7 @@ internal static class HostAdapterRequestValidation
             failure = HostAdapterResponses.InvalidRequest<T>(
                 requestId,
                 options.AdapterVersion,
-                "Query parameter 'limit' must be an integer.",
+                "Query parameter '$top' must be an integer.",
                 bridge
             );
             return false;
@@ -86,7 +125,7 @@ internal static class HostAdapterRequestValidation
             failure = HostAdapterResponses.InvalidRequest<T>(
                 requestId,
                 options.AdapterVersion,
-                "Query parameter 'limit' must be greater than zero.",
+                "Query parameter '$top' must be greater than zero.",
                 bridge
             );
             return false;
@@ -97,7 +136,7 @@ internal static class HostAdapterRequestValidation
             failure = HostAdapterResponses.InvalidRequest<T>(
                 requestId,
                 options.AdapterVersion,
-                $"Query parameter 'limit' must not exceed {options.MaxLimit}.",
+                $"Query parameter '$top' must not exceed {options.MaxLimit}.",
                 bridge
             );
             return false;
@@ -121,7 +160,7 @@ internal static class HostAdapterRequestValidation
             failure = HostAdapterResponses.InvalidRequest<T>(
                 requestId,
                 options.AdapterVersion,
-                "Query parameter 'end' must be later than 'start'.",
+                "Query parameter 'endDateTime' must be later than 'startDateTime'.",
                 bridge
             );
             return false;

--- a/src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj
+++ b/src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <Version>1.0.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/OpenClaw.HostAdapter/Program.cs
+++ b/src/OpenClaw.HostAdapter/Program.cs
@@ -40,6 +40,7 @@ builder
         options.AdapterVersion = string.IsNullOrWhiteSpace(options.AdapterVersion)
             ? HostAdapterOptions.DefaultAdapterVersion
             : options.AdapterVersion;
+        options.MailboxId = string.IsNullOrWhiteSpace(options.MailboxId) ? "me" : options.MailboxId;
     });
 builder.Services.AddSingleton<HostAdapterCommandBuilder>();
 builder.Services.AddSingleton<IHostAdapterProcessRunner, HostAdapterProcessRunner>();
@@ -51,7 +52,7 @@ app.UseMiddleware<RequestLoggingMiddleware>();
 app.UseMiddleware<BearerTokenMiddleware>();
 
 app.MapGet(
-    "/v1/status",
+    "/status",
     async (
         HttpContext context,
         StatusCacheService statusCache,
@@ -64,8 +65,9 @@ app.MapGet(
 );
 
 app.MapGet(
-    "/v1/messages",
+    "/users/{id}/messages",
     async (
+        string id,
         HttpContext context,
         StatusCacheService statusCache,
         HostAdapterCommandBuilder commandBuilder,
@@ -87,10 +89,12 @@ app.MapGet(
             return ToHttpResult(context, failure);
         }
 
+        var filter = context.Request.Query["$filter"];
+        var sinceValues = HostAdapterRequestValidation.ExtractReceivedDateTimeLowerBound(filter);
         if (
             !HostAdapterRequestValidation.TryGetUtcTimestamp<ItemsResponse<MessageDto>>(
-                context.Request.Query["since"],
-                "since",
+                sinceValues,
+                "$filter (receivedDateTime ge)",
                 requestId,
                 options,
                 bridgeStatus,
@@ -104,7 +108,7 @@ app.MapGet(
 
         if (
             !HostAdapterRequestValidation.TryGetLimit<ItemsResponse<MessageDto>>(
-                context.Request.Query["limit"],
+                context.Request.Query["$top"],
                 requestId,
                 options,
                 bridgeStatus,
@@ -116,8 +120,12 @@ app.MapGet(
             return ToHttpResult(context, limitFailure!);
         }
 
+        var command = HostAdapterRequestValidation.FilterSelectsMeetingRequests(filter)
+            ? commandBuilder.BuildListMeetingRequests(sinceUtc, limit)
+            : commandBuilder.BuildListMessages(sinceUtc, limit);
+
         var result = await processRunner.ExecuteAsync<ItemsResponse<MessageDto>>(
-            commandBuilder.BuildListMessages(sinceUtc, limit),
+            command,
             requestId,
             bridgeStatus,
             DeserializeItemsResponse<MessageDto>,
@@ -128,9 +136,10 @@ app.MapGet(
 );
 
 app.MapGet(
-    "/v1/messages/{bridgeId}",
+    "/users/{id}/messages/{messageId}",
     async (
-        string bridgeId,
+        string id,
+        string messageId,
         HttpContext context,
         StatusCacheService statusCache,
         HostAdapterCommandBuilder commandBuilder,
@@ -154,7 +163,7 @@ app.MapGet(
 
         if (
             !HostAdapterRequestValidation.TryGetBridgeId<MessageDto>(
-                bridgeId,
+                messageId,
                 requestId,
                 options,
                 bridgeStatus,
@@ -178,72 +187,9 @@ app.MapGet(
 );
 
 app.MapGet(
-    "/v1/meeting-requests",
+    "/users/{id}/calendarView",
     async (
-        HttpContext context,
-        StatusCacheService statusCache,
-        HostAdapterCommandBuilder commandBuilder,
-        IHostAdapterProcessRunner processRunner,
-        IOptions<HostAdapterOptions> optionsAccessor,
-        CancellationToken cancellationToken
-    ) =>
-    {
-        var requestId = context.GetRequestId();
-        var options = optionsAccessor.Value;
-        var (bridgeStatus, failure) = await RequireReadyBridgeAsync<ItemsResponse<MessageDto>>(
-            requestId,
-            options,
-            statusCache,
-            cancellationToken
-        );
-        if (failure is not null)
-        {
-            return ToHttpResult(context, failure);
-        }
-
-        if (
-            !HostAdapterRequestValidation.TryGetUtcTimestamp<ItemsResponse<MessageDto>>(
-                context.Request.Query["since"],
-                "since",
-                requestId,
-                options,
-                bridgeStatus,
-                out var sinceUtc,
-                out var timestampFailure
-            )
-        )
-        {
-            return ToHttpResult(context, timestampFailure!);
-        }
-
-        if (
-            !HostAdapterRequestValidation.TryGetLimit<ItemsResponse<MessageDto>>(
-                context.Request.Query["limit"],
-                requestId,
-                options,
-                bridgeStatus,
-                out var limit,
-                out var limitFailure
-            )
-        )
-        {
-            return ToHttpResult(context, limitFailure!);
-        }
-
-        var result = await processRunner.ExecuteAsync<ItemsResponse<MessageDto>>(
-            commandBuilder.BuildListMeetingRequests(sinceUtc, limit),
-            requestId,
-            bridgeStatus,
-            DeserializeItemsResponse<MessageDto>,
-            cancellationToken
-        );
-        return ToHttpResult(context, result);
-    }
-);
-
-app.MapGet(
-    "/v1/calendar",
-    async (
+        string id,
         HttpContext context,
         StatusCacheService statusCache,
         HostAdapterCommandBuilder commandBuilder,
@@ -267,8 +213,8 @@ app.MapGet(
 
         if (
             !HostAdapterRequestValidation.TryGetUtcTimestamp<ItemsResponse<EventDto>>(
-                context.Request.Query["start"],
-                "start",
+                context.Request.Query["startDateTime"],
+                "startDateTime",
                 requestId,
                 options,
                 bridgeStatus,
@@ -282,8 +228,8 @@ app.MapGet(
 
         if (
             !HostAdapterRequestValidation.TryGetUtcTimestamp<ItemsResponse<EventDto>>(
-                context.Request.Query["end"],
-                "end",
+                context.Request.Query["endDateTime"],
+                "endDateTime",
                 requestId,
                 options,
                 bridgeStatus,
@@ -311,7 +257,7 @@ app.MapGet(
 
         if (
             !HostAdapterRequestValidation.TryGetLimit<ItemsResponse<EventDto>>(
-                context.Request.Query["limit"],
+                context.Request.Query["$top"],
                 requestId,
                 options,
                 bridgeStatus,
@@ -335,9 +281,10 @@ app.MapGet(
 );
 
 app.MapGet(
-    "/v1/events/{bridgeId}",
+    "/users/{id}/events/{eventId}",
     async (
-        string bridgeId,
+        string id,
+        string eventId,
         HttpContext context,
         StatusCacheService statusCache,
         HostAdapterCommandBuilder commandBuilder,
@@ -361,7 +308,7 @@ app.MapGet(
 
         if (
             !HostAdapterRequestValidation.TryGetBridgeId<EventDto>(
-                bridgeId,
+                eventId,
                 requestId,
                 options,
                 bridgeStatus,

--- a/tests/OpenClaw.Core.Tests/CoreTestWebApplicationFactory.cs
+++ b/tests/OpenClaw.Core.Tests/CoreTestWebApplicationFactory.cs
@@ -32,7 +32,7 @@ internal sealed class CoreTestWebApplicationFactory(
                 configurationBuilder.AddInMemoryCollection(
                     new Dictionary<string, string?>
                     {
-                        ["OpenClaw:HostAdapter:BaseUrl"] = "http://127.0.0.1:4319/v1/",
+                        ["OpenClaw:HostAdapter:BaseUrl"] = "http://127.0.0.1:4319/",
                         ["OpenClaw:HostAdapter:TokenFile"] = "/run/openclaw/hostadapter.token",
                         ["OpenClaw:Storage:DbPath"] = dbPath,
                     }

--- a/tests/OpenClaw.Core.Tests/HostAdapterHttpClientTests.cs
+++ b/tests/OpenClaw.Core.Tests/HostAdapterHttpClientTests.cs
@@ -28,7 +28,7 @@ public class HostAdapterHttpClientTests
     {
         var opts = new OpenClawOptions();
         opts.HostAdapter.TokenFile = tokenFile;
-        opts.HostAdapter.BaseUrl = "http://localhost:4319/v1/";
+        opts.HostAdapter.BaseUrl = "http://localhost:4319/";
         return Options.Create(opts);
     }
 
@@ -45,7 +45,7 @@ public class HostAdapterHttpClientTests
     {
         var httpClient = new HttpClient(handler)
         {
-            BaseAddress = new Uri("http://localhost:4319/v1/"),
+            BaseAddress = new Uri("http://localhost:4319/"),
         };
         return new HostAdapterHttpClient(httpClient, BuildOptions(tokenFile))
         {
@@ -338,15 +338,16 @@ public class HostAdapterHttpClientTests
 
         await client.GetStatusAsync();
 
-        capturedPath.Should().EndWith("/v1/status");
+        capturedPath.Should().EndWith("/status");
     }
 
     /// <summary>
     /// Verifies that <see cref="HostAdapterHttpClient.ListMessagesAsync"/> sends a GET request
-    /// to the <c>messages</c> path and includes <c>since</c> and <c>limit</c> query parameters.
+    /// to the Graph-shaped <c>users/{id}/messages</c> path with the <c>$filter</c>
+    /// receivedDateTime lower bound and <c>$top</c> parameters.
     /// </summary>
     [TestMethod]
-    public async Task ListMessagesAsync_SendsGetToMessagesPathWithSinceAndLimit()
+    public async Task ListMessagesAsync_SendsGetToMessagesPathWithFilterAndTop()
     {
         string? capturedPath = null;
         var handler = new FakeHttpHandler(req =>
@@ -361,9 +362,9 @@ public class HostAdapterHttpClientTests
             limit: 50
         );
 
-        capturedPath.Should().Contain("messages");
-        capturedPath.Should().Contain("since=");
-        capturedPath.Should().Contain("limit=50");
+        capturedPath.Should().Contain("users/me/messages");
+        capturedPath.Should().Contain("$filter=receivedDateTime");
+        capturedPath.Should().Contain("$top=50");
     }
 
     /// <summary>
@@ -383,7 +384,7 @@ public class HostAdapterHttpClientTests
 
         await client.GetMessageAsync("msg/with/slashes");
 
-        capturedPath.Should().Contain("messages/");
+        capturedPath.Should().Contain("users/me/messages/");
         capturedPath
             .Should()
             .Contain(
@@ -394,10 +395,11 @@ public class HostAdapterHttpClientTests
 
     /// <summary>
     /// Verifies that <see cref="HostAdapterHttpClient.ListMeetingRequestsAsync"/> sends a GET
-    /// request to the <c>meeting-requests</c> path with <c>since</c> and <c>limit</c>.
+    /// request to the Graph-shaped messages-filtered form: the <c>users/{id}/messages</c> path
+    /// carrying the <c>meetingMessageType ne null</c> predicate and the <c>$top</c> parameter.
     /// </summary>
     [TestMethod]
-    public async Task ListMeetingRequestsAsync_SendsGetToMeetingRequestsPathWithSinceAndLimit()
+    public async Task ListMeetingRequestsAsync_SendsGetToMessagesPathWithMeetingMessageTypeFilter()
     {
         string? capturedPath = null;
         var handler = new FakeHttpHandler(req =>
@@ -412,17 +414,18 @@ public class HostAdapterHttpClientTests
             limit: 25
         );
 
-        capturedPath.Should().Contain("meeting-requests");
-        capturedPath.Should().Contain("since=");
-        capturedPath.Should().Contain("limit=25");
+        capturedPath.Should().Contain("users/me/messages");
+        capturedPath.Should().Contain("meetingMessageType");
+        capturedPath.Should().Contain("$top=25");
     }
 
     /// <summary>
     /// Verifies that <see cref="HostAdapterHttpClient.ListCalendarWindowAsync"/> sends a GET
-    /// request to the <c>calendar</c> path with <c>start</c>, <c>end</c>, and <c>limit</c>.
+    /// request to the Graph-shaped <c>users/{id}/calendarView</c> path with
+    /// <c>startDateTime</c>, <c>endDateTime</c>, and <c>$top</c>.
     /// </summary>
     [TestMethod]
-    public async Task ListCalendarWindowAsync_SendsGetToCalendarPathWithStartEndAndLimit()
+    public async Task ListCalendarWindowAsync_SendsGetToCalendarViewPathWithStartEndAndTop()
     {
         string? capturedPath = null;
         var handler = new FakeHttpHandler(req =>
@@ -438,10 +441,10 @@ public class HostAdapterHttpClientTests
             limit: 75
         );
 
-        capturedPath.Should().Contain("calendar");
-        capturedPath.Should().Contain("start=");
-        capturedPath.Should().Contain("end=");
-        capturedPath.Should().Contain("limit=75");
+        capturedPath.Should().Contain("users/me/calendarView");
+        capturedPath.Should().Contain("startDateTime=");
+        capturedPath.Should().Contain("endDateTime=");
+        capturedPath.Should().Contain("$top=75");
     }
 
     /// <summary>
@@ -461,7 +464,7 @@ public class HostAdapterHttpClientTests
 
         await client.GetEventAsync("event id with spaces");
 
-        capturedPath.Should().Contain("events/");
+        capturedPath.Should().Contain("users/me/events/");
         capturedPath
             .Should()
             .Contain(
@@ -490,7 +493,7 @@ public class HostAdapterHttpClientTests
         // Omit limit; default is 100 per the method signature
         await client.ListMessagesAsync(DateTimeOffset.UtcNow);
 
-        capturedPath.Should().Contain("limit=100");
+        capturedPath.Should().Contain("$top=100");
     }
 
     // ─── TRANSPORT_FAILURE ────────────────────────────────────────────────────────

--- a/tests/OpenClaw.HostAdapter.Tests/HostAdapterAuthTests.cs
+++ b/tests/OpenClaw.HostAdapter.Tests/HostAdapterAuthTests.cs
@@ -16,7 +16,7 @@ public class HostAdapterAuthTests
         using var factory = new HostAdapterTestWebApplicationFactory();
         using var client = factory.CreateClient();
 
-        using var response = await client.GetAsync("/v1/status");
+        using var response = await client.GetAsync("/status");
         var payload = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
 
@@ -52,7 +52,7 @@ public class HostAdapterAuthTests
             "invalid-token"
         );
 
-        using var response = await client.GetAsync("/v1/status");
+        using var response = await client.GetAsync("/status");
         var payload = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
 

--- a/tests/OpenClaw.HostAdapter.Tests/HostAdapterEndpointTests.cs
+++ b/tests/OpenClaw.HostAdapter.Tests/HostAdapterEndpointTests.cs
@@ -144,8 +144,8 @@ public class HostAdapterEndpointTests
         );
         using var client = factory.CreateAuthorizedClient();
 
-        using var messageResponse = await client.GetAsync("/v1/messages/bridge%20id%2Bvalue");
-        using var eventResponse = await client.GetAsync("/v1/events/bridge%20id%2Bvalue");
+        using var messageResponse = await client.GetAsync("/users/me/messages/bridge%20id%2Bvalue");
+        using var eventResponse = await client.GetAsync("/users/me/events/bridge%20id%2Bvalue");
 
         messageResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         eventResponse.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/tests/OpenClaw.HostAdapter.Tests/HostAdapterEnvelopeTests.cs
+++ b/tests/OpenClaw.HostAdapter.Tests/HostAdapterEnvelopeTests.cs
@@ -28,7 +28,7 @@ public class HostAdapterEnvelopeTests
         );
         using var client = factory.CreateAuthorizedClient();
 
-        using var response = await client.GetAsync("/v1/status");
+        using var response = await client.GetAsync("/status");
         var payload = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
         var meta = document.RootElement.GetProperty("meta");

--- a/tests/OpenClaw.HostAdapter.Tests/HostAdapterMappingTests.cs
+++ b/tests/OpenClaw.HostAdapter.Tests/HostAdapterMappingTests.cs
@@ -97,7 +97,7 @@ public class HostAdapterMappingTests
         using var client = factory.CreateAuthorizedClient();
 
         using var response = await client.GetAsync(
-            "/v1/messages?since=2026-04-12T13:00:00Z&limit=1"
+            "/users/me/messages?$filter=receivedDateTime ge 2026-04-12T13:00:00Z&$top=1"
         );
         var payload = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
@@ -111,5 +111,83 @@ public class HostAdapterMappingTests
             .GetBoolean()
             .Should()
             .BeTrue();
+    }
+
+    [TestMethod]
+    public async Task HostAdapter_should_dispatch_meeting_requests_branch_when_filter_contains_meeting_message_type_predicate()
+    {
+        using var factory = new HostAdapterTestWebApplicationFactory();
+        var readyBridge = new BridgeStatusDto(
+            BridgeState.ready.ToString(),
+            BridgeMode.safe.ToString(),
+            true,
+            false,
+            null,
+            null,
+            null
+        );
+        factory.ProcessRunner.EnqueueResponse(
+            "status",
+            HostAdapterResponses.Success(readyBridge, "status-request", "test-version", readyBridge)
+        );
+        factory.ProcessRunner.EnqueueResponse(
+            "list-meeting-requests",
+            HostAdapterResponses.Success(
+                new ItemsResponse<MessageDto>(Array.Empty<MessageDto>()),
+                "meeting-requests-request",
+                "test-version",
+                readyBridge
+            )
+        );
+        using var client = factory.CreateAuthorizedClient();
+
+        using var response = await client.GetAsync(
+            "/users/me/messages?$filter=meetingMessageType ne null and receivedDateTime ge 2026-04-12T13:00:00Z&$top=5"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        factory
+            .ProcessRunner.Invocations.Select(invocation => invocation.Verb)
+            .Should()
+            .Equal("status", "list-meeting-requests");
+    }
+
+    [TestMethod]
+    public async Task HostAdapter_should_dispatch_plain_messages_branch_when_filter_has_no_meeting_message_type_predicate()
+    {
+        using var factory = new HostAdapterTestWebApplicationFactory();
+        var readyBridge = new BridgeStatusDto(
+            BridgeState.ready.ToString(),
+            BridgeMode.safe.ToString(),
+            true,
+            false,
+            null,
+            null,
+            null
+        );
+        factory.ProcessRunner.EnqueueResponse(
+            "status",
+            HostAdapterResponses.Success(readyBridge, "status-request", "test-version", readyBridge)
+        );
+        factory.ProcessRunner.EnqueueResponse(
+            "list-messages",
+            HostAdapterResponses.Success(
+                new ItemsResponse<MessageDto>(Array.Empty<MessageDto>()),
+                "messages-request",
+                "test-version",
+                readyBridge
+            )
+        );
+        using var client = factory.CreateAuthorizedClient();
+
+        using var response = await client.GetAsync(
+            "/users/me/messages?$filter=receivedDateTime ge 2026-04-12T13:00:00Z&$top=5"
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        factory
+            .ProcessRunner.Invocations.Select(invocation => invocation.Verb)
+            .Should()
+            .Equal("status", "list-messages");
     }
 }

--- a/tests/OpenClaw.HostAdapter.Tests/HostAdapterStatusCacheTests.cs
+++ b/tests/OpenClaw.HostAdapter.Tests/HostAdapterStatusCacheTests.cs
@@ -47,10 +47,10 @@ public class HostAdapterStatusCacheTests
         using var client = factory.CreateAuthorizedClient();
 
         using var firstResponse = await client.GetAsync(
-            "/v1/messages?since=2026-04-12T13:00:00Z&limit=1"
+            "/users/me/messages?$filter=receivedDateTime ge 2026-04-12T13:00:00Z&$top=1"
         );
         using var secondResponse = await client.GetAsync(
-            "/v1/messages?since=2026-04-12T13:05:00Z&limit=1"
+            "/users/me/messages?$filter=receivedDateTime ge 2026-04-12T13:05:00Z&$top=1"
         );
 
         firstResponse.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/tests/OpenClaw.HostAdapter.Tests/HostAdapterValidationTests.cs
+++ b/tests/OpenClaw.HostAdapter.Tests/HostAdapterValidationTests.cs
@@ -29,7 +29,9 @@ public class HostAdapterValidationTests
         );
         using var client = factory.CreateAuthorizedClient();
 
-        using var response = await client.GetAsync("/v1/messages?since=2026-04-12T09:15:00-04:00");
+        using var response = await client.GetAsync(
+            "/users/me/messages?$filter=receivedDateTime ge 2026-04-12T09:15:00-04:00"
+        );
         var payload = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
 
@@ -46,7 +48,7 @@ public class HostAdapterValidationTests
             .GetProperty("message")
             .GetString()
             .Should()
-            .Contain("since")
+            .Contain("receivedDateTime")
             .And.Contain("UTC");
         document
             .RootElement.GetProperty("meta")
@@ -81,7 +83,7 @@ public class HostAdapterValidationTests
         using var client = factory.CreateAuthorizedClient();
 
         using var response = await client.GetAsync(
-            "/v1/calendar?start=2026-04-12T13:00:00Z&end=2026-04-12T13:00:00Z"
+            "/users/me/calendarView?startDateTime=2026-04-12T13:00:00Z&endDateTime=2026-04-12T13:00:00Z"
         );
         var payload = await response.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
@@ -99,8 +101,8 @@ public class HostAdapterValidationTests
             .GetProperty("message")
             .GetString()
             .Should()
-            .Contain("end")
-            .And.Contain("start");
+            .Contain("endDateTime")
+            .And.Contain("startDateTime");
         document
             .RootElement.GetProperty("meta")
             .GetProperty("requestId")
@@ -157,10 +159,10 @@ public class HostAdapterValidationTests
         using var client = factory.CreateAuthorizedClient();
 
         using var defaultLimitResponse = await client.GetAsync(
-            "/v1/messages?since=2026-04-12T13:00:00Z"
+            "/users/me/messages?$filter=receivedDateTime ge 2026-04-12T13:00:00Z"
         );
         using var overMaxResponse = await client.GetAsync(
-            "/v1/messages?since=2026-04-12T13:00:00Z&limit=251"
+            "/users/me/messages?$filter=receivedDateTime ge 2026-04-12T13:00:00Z&$top=251"
         );
 
         var overMaxPayload = await overMaxResponse.Content.ReadAsStringAsync();

--- a/tests/OpenClaw.HostAdapter.Tests/HostAdapterVersionTests.cs
+++ b/tests/OpenClaw.HostAdapter.Tests/HostAdapterVersionTests.cs
@@ -1,0 +1,18 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace OpenClaw.HostAdapter.Tests;
+
+[TestClass]
+public class HostAdapterVersionTests
+{
+    [TestMethod]
+    public void DefaultAdapterVersion_should_report_1_0_0_from_the_assembly_version()
+    {
+        // The in-process test web factory overrides AdapterVersion to "test-version", so the
+        // envelope meta value cannot assert the real version. The assembly-derived
+        // DefaultAdapterVersion is asserted directly. The HostAdapter csproj declares
+        // <Version>1.0.0</Version>, which is the major bump signalling the breaking route change.
+        HostAdapterOptions.DefaultAdapterVersion.Should().Be("1.0.0");
+    }
+}


### PR DESCRIPTION
# feat(hostadapter)!: evolve HTTP surface to Graph-shaped endpoints

## Summary

- Replaces the bespoke `/v1/*` HostAdapter route table with a Microsoft Graph-shaped surface (`/users/{id}/messages`, `/users/{id}/messages/{messageId}`, `/users/{id}/calendarView`, `/users/{id}/events/{eventId}`, plus a messages-filtered meeting-requests form), keeping `/status` as the operational probe.
- Breaking change to the `OpenClaw.HostAdapter` HTTP surface and the `IHostAdapterClient` contract (a T2 boundary in `OpenClaw.HostAdapter.Contracts`); signalled by an adapter version bump to `1.0.0`.
- Adds a configurable `MailboxId` option (default `"me"`) that renders the `{id}` path segment, so routes default to `/users/me/...`.
- Drops the `/v1/` segment from the `OpenClaw.Core` HostAdapter `BaseUrl` default.
- Path-and-query reshaping only: request/response envelopes and DTO shapes (`ApiEnvelope<T>`, `ItemsResponse<T>`, `MessageDto`, `EventDto`) are unchanged.
- Preserves `ListMeetingRequestsAsync` on the contract; meeting-requests is served by a `meetingMessageType` filter branch on a single `/users/{id}/messages` handler.

## Why

The HostAdapter currently serves a bespoke `/v1/*` route table with bespoke query parameters (`since`, `start`, `end`, `limit`). The OpenClaw agent in Product Increment 1 will call Microsoft Graph, which uses a different URL shape (`/users/{id}/messages` with OData `$filter` and `$top`, `/users/{id}/calendarView` with `startDateTime`/`endDateTime`). Developing the agent against bespoke routes in Stage 0 would force its request-construction code to be rewritten to reach Graph later. Reshaping the local adapter to Graph-shaped routes now makes the agent's request-construction code portable across the local adapter and real Graph, removing that rework and reducing the divergence between Stage 0 and PI-1 behavior. This change replaces the OR-4 mapper-shim relationship introduced by #70.

## What Changed

**HostAdapter (route surface, options, version)**
- `src/OpenClaw.HostAdapter/Program.cs`: route table rewritten to Graph shapes; the messages list and meeting-requests routes are consolidated into a single `GET /users/{id}/messages` handler that branches on the `meetingMessageType ne null` filter predicate; `/v1/status` becomes `/status`.
- `src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs`: reads and validates the Graph-shaped parameter names (`$filter` lower-bound, `$top`, `startDateTime`, `endDateTime`).
- `src/OpenClaw.HostAdapter/HostAdapterOptions.cs`: adds `MailboxId` (default `"me"`); `DefaultAdapterVersion` surfaces the 3-component `1.0.0`.
- `src/OpenClaw.HostAdapter/OpenClaw.HostAdapter.csproj`: `<Version>1.0.0</Version>`.

**Contract**
- `src/OpenClaw.HostAdapter.Contracts/IHostAdapterClient.cs`: XML documentation updated to describe the Graph-shaped routes; C# method signatures are unchanged.

**Core (client + config)**
- `src/OpenClaw.Core/HostAdapterHttpClient.cs`: six relative request paths rewritten to Graph shapes, sourcing `{id}` from a Core-side `MailboxId`.
- `src/OpenClaw.Core/CoreOptions.cs`: `BaseUrl` default drops `/v1/`; adds the Core-side `MailboxId` mirror (boundary-preserving — `OpenClaw.Core` does not reference `OpenClaw.HostAdapter`).

**Tests**
- `tests/OpenClaw.HostAdapter.Tests/`: endpoint, auth, envelope, mapping, validation, and status-cache tests updated to the new route templates and parameters; new `HostAdapterVersionTests.cs` asserts `1.0.0`.
- `tests/OpenClaw.Core.Tests/`: `HostAdapterHttpClientTests.cs` updated to the Graph-shaped paths and new base URL; `CoreTestWebApplicationFactory.cs` base URL updated to drop `/v1/`.

**Docs / evidence**
- Adds the feature spec, user story, atomic plan, the three feature-review audit artifacts, and the phase/QA evidence under `docs/features/active/evolve-hostadapter-graph-surface-76/`.

## Architecture / How It Fits Together

Data flow is unchanged: the agent or `HostAdapterHttpClient` issues a Graph-shaped request (for example `GET /users/me/messages?$filter=receivedDateTime ge 2026-06-12T00:00:00Z&$top=50`) against the local adapter; the HostAdapter resolves bridge-cached data through the existing RPC chain and returns an `ApiEnvelope<T>` exactly as before. Only the inbound HTTP route/query surface and the typed client's relative paths change. The meeting-requests capability is retained: because Graph has no dedicated meeting-requests collection, the single `/users/{id}/messages` handler dispatches `BuildListMeetingRequests` vs `BuildListMessages` based on the `meetingMessageType` filter, preserving the bridge RPC chain (`list_recent_meeting_requests`), the Core polling worker, and the Core UI surface. Architecture boundaries are preserved: no new `ProjectReference` edges; `OpenClaw.Core` depends only on `OpenClaw.HostAdapter.Contracts`.

## Verification

**Completed (from context):**
- Build with analyzers and code-style enforcement: EXIT_CODE 0.
- Nullable type-check (`-p:TreatWarningsAsErrors=true`): EXIT_CODE 0.
- Format (CSharpier `check`): EXIT_CODE 0. Note: CSharpier 1.3.0 global tool was used; the `dotnet csharpier` tool-pin form was unavailable in this worktree (recorded in the baseline-format note).
- Tests (`dotnet test ... --collect:"XPlat Code Coverage"`): EXIT_CODE 0.
- Changed-code coverage: 98.85% line / 79.41% branch (above the uniform 85% / 75% thresholds); no regression on changed lines.
- Architecture-boundary check: pass (no new `ProjectReference` edges).
- Route-surface check: no `/v1/*` template remains except `/status`.
- All 7 acceptance criteria checked off in the user story.

**Recommended:**
- `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
- `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
- `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`

## Backward Compatibility / Migration Notes

- **Breaking:** the HostAdapter no longer serves `/v1/*` routes. Clients must call the Graph-shaped surface. The adapter version is now `1.0.0` (surfaced via `meta.adapterVersion`).
- **Config:** `OpenClawOptions.HostAdapter.BaseUrl` default no longer contains `/v1/`. The new `MailboxId` option (default `"me"`) controls the `{id}` path segment.
- **Unchanged:** request/response envelope and DTO schemas (`ApiEnvelope<T>`, `ItemsResponse<T>`, `MessageDto`, `EventDto`). The `IHostAdapterClient` C# method signatures are unchanged; only the wire routes and the version change.

## Risks and Mitigations

- **Route consolidation regression** (messages vs meeting-requests now share `/users/{id}/messages`): mitigated by the filter-branch dispatch and dedicated tests asserting branch selection; the bridge RPC chain and Core polling/UI surfaces are unchanged.
- **Breaking contract for downstream callers:** all in-repo callers (`HostAdapterHttpClient`, `HostAdapterSchedulingService`, polling workers) compile and pass; the contract/schema compatibility check confirmed member parity and the `1.0.0` bump.
- **Formatter provenance:** format verified under CSharpier 1.3.0 rather than the pinned tool; recommended follow-up is to repair the tool restore or re-pin to the installed major version. Rollback is a single-branch revert; no data migration is involved.

## Review Guide

Suggested order:
1. `docs/features/active/evolve-hostadapter-graph-surface-76/spec.md` and `user-story.md` for intent and acceptance criteria.
2. `src/OpenClaw.HostAdapter/Program.cs` — the route consolidation (design note N1) is the substantive change.
3. `src/OpenClaw.HostAdapter/HostAdapterRequestValidation.cs` and `HostAdapterOptions.cs`.
4. `src/OpenClaw.Core/HostAdapterHttpClient.cs` and `CoreOptions.cs` (Core-side `MailboxId` mirror, design note N2).
5. Test updates, which are largely mechanical route-string and parameter-name changes.

## Follow-ups

- #74 — HostAdapter Graph-shaped `mailboxSettings` and `calendar/getSchedule` endpoints (next in Track H; shares this contract/route table).
- #75 — HostAdapter Graph-shaped `sendMail` endpoint backed by COM send (Track H).
- Repair the CSharpier `dotnet` tool-pin restore (or re-pin to the installed major version) so formatting is verifiable under the pinned tool.

## GitHub Auto-close

- Closes #76
