### PR TITLE
feat(mailbridge): add Graph-shaped event fields to EventDto

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The repository also contains the local-only HTTP and Docker components required 
 
 - Scans the default Outlook Inbox and Calendar on a dedicated STA thread.
 - Stores cached message, meeting-request, and event metadata in `%LOCALAPPDATA%\OpenClaw\MailBridge\cache.db`.
+- Exposes Graph-shaped calendar event fields on `EventDto` (`categories`, `isOrganizer`, `isOnlineMeeting`, `allowNewTimeProposals`, `iCalUId`, `seriesMasterId`, `lastModifiedDateTime`, `bodyFull`, `sensitivityLabel`) populated from Outlook COM. See [`docs/api-reference.md`](./docs/api-reference.md) for the full field contract.
 - Serves cache-backed read-only responses over a named pipe.
 - Keeps `safe` mode as the default response-shaping mode.
 - Supports two Windows installation paths today:
@@ -352,8 +353,8 @@ Default values:
 
 Key behavior:
 
-- `safe` is the default mode and redacts protected fields such as sender details and body previews.
-- `enhanced` returns sanitized preview content and should only be enabled after operator validation.
+- `safe` is the default mode and redacts protected fields such as sender details, body previews, and full event body text (`bodyFull`).
+- `enhanced` returns sanitized preview content plus the full event body text (`bodyFull`) and should only be enabled after operator validation.
 - `pipeName` controls the named pipe used by the bridge and client.
 
 ## Canonical Client Commands

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -396,9 +396,9 @@ List calendar events whose start time falls within a given window.
 
 **Safe mode vs Enhanced mode:**
 
-In **safe mode**, `bodyPreview` is `null` and `isRedacted` is `true`.
+In **safe mode**, `bodyPreview` and `bodyFull` are `null` and `isRedacted` is `true`.
 
-In **enhanced mode**, `bodyPreview` contains sanitized event body text and `isRedacted` is `false`.
+In **enhanced mode**, `bodyPreview` contains sanitized event body text, `bodyFull` contains the full untruncated body text, and `isRedacted` is `false`.
 
 **Items are sorted by `startUtc` ascending** (earliest first).
 
@@ -478,6 +478,16 @@ Retrieve a single calendar event by its bridge ID.
 | `bodyPreview` | string? | Sanitized event body text. **Null in safe mode.** |
 | `protectedFieldsAvailable` | bool | Whether protected fields could be retrieved from Outlook. |
 | `isRedacted` | bool | `true` in safe mode, `false` in enhanced mode. |
+| `responseStatus` | int? | Outlook response status: 0=None, 1=Organized, 2=Tentative, 3=Accepted, 4=Declined, 5=NotResponded. |
+| `categories` | string[]? | Outlook categories assigned to the event. |
+| `isOrganizer` | bool | Whether the mailbox owner organized the event (derived from `responseStatus == 1`). |
+| `isOnlineMeeting` | bool | Whether Outlook flags the event as an online meeting. May report `false` for some third-party add-in meetings. |
+| `allowNewTimeProposals` | bool | Whether the organizer permits new time proposals. |
+| `iCalUId` | string? | iCalendar UID. Sourced from Outlook's GlobalAppointmentID; not a true RFC 5545 UID. |
+| `seriesMasterId` | string? | Identifier of the recurring-series master for an occurrence or exception; `null` for non-recurring events and series masters. |
+| `lastModifiedDateTime` | string? | ISO-8601 timestamp of the event's last modification. |
+| `bodyFull` | string? | Full (untruncated) event body text. **Null in safe mode**; returned unsanitized in enhanced mode. |
+| `sensitivityLabel` | string? | Sensitivity as a label string: `normal`, `personal`, `private`, or `confidential` (derived from `sensitivity`). |
 
 ---
 

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-file-sizes.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-file-sizes.md
@@ -1,0 +1,23 @@
+# Baseline — File Line Counts (500-line cap sizing)
+
+Timestamp: 2026-06-13T03-05
+
+Recorded with `wc -l` against the working tree before any Phase 1+ edits.
+
+| File | Lines | Status vs 500-line cap |
+|---|---|---|
+| `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` | 157 | Under cap; headroom for nine new EventDto parameters. |
+| `src/OpenClaw.MailBridge/CacheRepository.cs` | 465 | Under cap; 35 lines of headroom. Watch P4 additions; split to a partial if it crosses 500. |
+| `src/OpenClaw.MailBridge/CacheRepository.Readers.cs` | 84 | Under cap; ample headroom for ReadEvent extension. |
+| `src/OpenClaw.MailBridge/OutlookScanner.cs` | 507 | PRE-EXISTING OVER-CAP (507 > 500). Must not grow; new helpers go in `OutlookScanner.GraphFields.cs` (P2). |
+| `src/OpenClaw.MailBridge/ResponseShaper.cs` | 65 | Under cap. |
+| `src/OpenClaw.Core/CoreCacheRepository.cs` | 691 | PRE-EXISTING OVER-CAP (691 > 500). Split schema/migration helpers to `CoreCacheRepository.Schema.cs` (P5) to avoid worsening. |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingDtoMapper.cs` | 169 | Under cap. |
+
+Decisions for sizing:
+- `OutlookScanner.cs` (507): new splitter + seriesMasterId helpers MUST land in new partial `OutlookScanner.GraphFields.cs`; only the nine named-argument additions occur in `OutlookScanner.cs` (these replace existing `null` placeholders, near net-zero growth).
+- `CacheRepository.cs` (465): DDL/migration/parameter additions will push it over 500; plan P4-T6 prescribes splitting schema/migration into a new partial (`CacheRepository.Schema.cs`).
+- `CoreCacheRepository.cs` (691): already over cap; P5-T6 prescribes extracting schema/migration into `CoreCacheRepository.Schema.cs`.
+
+EXIT_CODE: 0
+Output Summary: Line counts recorded. Two pre-existing over-cap files identified: OutlookScanner.cs (507) and CoreCacheRepository.cs (691). Split strategy defined per plan.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-format.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-format.md
@@ -1,0 +1,11 @@
+# Baseline — CSharpier Format Check
+
+Timestamp: 2026-06-13T03-03
+
+Command: `csharpier check .`
+
+Note on command form: The plan lists `dotnet csharpier --check .`. The repo has no tracked `.config/dotnet-tools.json`; a stale parent-directory manifest pins csharpier 0.16.0 with a command-name mismatch that makes `dotnet csharpier` fail to restore. CSharpier 1.3.0 is installed as a global tool (`csharpier`), and the 1.x CLI uses `csharpier check .` (the `--check` flag was renamed to the `check` subcommand in 1.x). Same tool, same purpose; this is a tooling-invocation adaptation, not a plan change.
+
+EXIT_CODE: 0
+
+Output Summary: PASS. Checked 148 files in ~348ms. 0 files needed formatting.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-lint.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-lint.md
@@ -1,0 +1,9 @@
+# Baseline — Analyzer / Lint Build
+
+Timestamp: 2026-06-13T03-03
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). All nine projects (6 src + 3 test) compiled with analyzers and code-style enforcement enabled.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-test.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-test.md
@@ -1,0 +1,19 @@
+# Baseline — Test + Coverage
+
+Timestamp: 2026-06-13T03-05
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+
+EXIT_CODE: 0
+
+Output Summary:
+- Test result: PASS. Failed: 0, Passed: 425 (HostAdapter.Tests 71, Core.Tests 178, MailBridge.Tests 176), Skipped: 3, Total: 428.
+- Skipped (platform/publish-gated): Com_active_object_create_and_logon_should_throw_on_non_windows; PublishOutput_BridgeDirectory_ContainsBridgeExecutable; PublishOutput_ClientDirectory_ContainsClientExecutable.
+
+Coverage headline (cobertura, XPlat Code Coverage / coverlet):
+- OpenClaw.MailBridge.Tests module: line-rate 93.22% (880/944 lines), branch-rate 83.08% (226/272 branches).
+- OpenClaw.Core.Tests module: line-rate 89.32% (1373/1537 lines), branch-rate 77.58% (308/397 branches).
+
+Threshold check (line >= 85%, branch >= 75%): both modules PASS at baseline.
+
+Note: the "Code Coverage" (Vanguard) collector reports "No code coverage data available. Profiler was not initialized." in this CLI/Git Bash context; the authoritative coverage is the coverlet XPlat cobertura output, consistent with the runsettings note that the XPlat collector is the CLI path.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-typecheck.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/baseline-typecheck.md
@@ -1,0 +1,9 @@
+# Baseline — Nullable Type-Check Build
+
+Timestamp: 2026-06-13T03-03
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). No nullable-flow warnings under TreatWarningsAsErrors.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,31 @@
+# Phase 0 — Policy Instructions Read
+
+Timestamp: 2026-06-13T03-03
+
+Policy Order: Per `.claude/skills/policy-compliance-order`, repository policy files were read in the required precedence order before any execution.
+
+Files read (in order):
+1. `CLAUDE.md` (standing instructions; auto-loaded into context)
+2. `.claude/rules/general-code-change.md` (cross-language code change policy)
+3. `.claude/rules/general-unit-test.md` (cross-language unit test policy)
+4. `.claude/rules/csharp.md` (C# standards — language-specific, in scope)
+5. `.claude/rules/quality-tiers.md` (T1–T4 tier system; uniform coverage thresholds line >= 85%, branch >= 75%)
+6. `.claude/rules/architecture-boundaries.md` (project-graph + COM confinement rules)
+
+Additional in-scope policy rules auto-loaded and observed:
+- `.claude/rules/tonality.md`
+- `.claude/rules/benchmark-baselines.md` (not applicable; no benchmark baseline touched)
+- `.claude/rules/ci-workflows.md` (not applicable; no workflow YAML touched)
+
+Key constraints carried into execution:
+- EventDto: append nine new optional parameters AFTER `ResponseStatus = null`; existing positional call sites must compile unmodified.
+- Redaction: `ResponseShaper.ShapeEvent` nulls `bodyFull` in safe mode; enhanced mode returns raw untruncated body (NOT through `BodySanitizer.NormalizePreview`).
+- 500-line file cap: `OutlookScanner.cs` is pre-existing over-cap (507 lines); new scanner helpers go in new partial `OutlookScanner.GraphFields.cs`. `CoreCacheRepository.cs` is pre-existing over-cap (692 lines); split if it grows materially.
+- COM stays only in `OpenClaw.MailBridge`; EventDto + sensitivity helper stay in leaf `OpenClaw.MailBridge.Contracts`.
+- Out of scope: `CoreCacheRepository` missing-`response_status` gap (issue #80).
+- Tests: MSTest + Moq + FluentAssertions; deterministic; no temp files; no Thread.Sleep/Task.Delay; in-memory/shared-cache SQLite.
+- Coverage: line >= 85%, branch >= 75% (T2); no regression on changed lines.
+- Evidence canonical scheme only: `docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/<kind>/`.
+
+EXIT_CODE: 0
+Output Summary: All required policy files read in order; constraints recorded. No policy edits performed.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/acceptance-traceability.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/acceptance-traceability.md
@@ -1,0 +1,26 @@
+# Acceptance Criteria Traceability — Issue #72
+
+Timestamp: 2026-06-13T03-27
+
+AC source: `docs/features/active/mailbridge-eventdto-graph-fields-72/user-story.md` (`## Acceptance Criteria`). Work Mode: full-feature (`spec.md` Definition of Done also tracked).
+
+| AC | Criterion | Satisfying tasks | Tests / evidence | Status |
+|---|---|---|---|---|
+| AC1 | `EventDto` exposes all nine new fields, source-compatible (existing callers compile unmodified) | P1-T1, P1-T2, P1-T3, P7-T2 | `EventSensitivityLabelTests`; full-solution build green with no call-site edits (`evidence/qa-gates/final-lint.md`, `phase1-toolchain.md`) | SATISFIED |
+| AC2 | `OutlookScanner.NormalizeEvent` populates all nine fields from COM analogs/derivations | P2-T1..T4 | `OutlookScannerGraphFieldsTests` (categories split/empty, isOrganizer, isOnlineMeeting, allowNewTimeProposals, iCalUId, seriesMasterId per state, lastModifiedDateTime, bodyFull raw, sensitivityLabel); `evidence/qa-gates/phase2-toolchain.md` | SATISFIED |
+| AC3 | `ResponseShaper.ShapeEvent` nulls `bodyFull` in safe mode; enhanced returns full untruncated body | P3-T1, P3-T2 | `ResponseShaperEventBodyFullTests` (safe nulls BodyFull+IsRedacted; enhanced returns >cap body verbatim, not normalized); `evidence/qa-gates/phase3-toolchain.md` | SATISFIED |
+| AC4 | Both SQLite caches round-trip all nine fields with idempotent migrations | P4-T1..T4, P5-T1..T4 | `CacheRepositoryGraphFieldsTests`, `CoreCacheRepositoryGraphFieldsTests` (populated + empty categories round-trip; idempotent double InitializeAsync); `phase4-toolchain.md`, `phase5-toolchain.md` | SATISFIED |
+| AC5 | Recurring online meeting yields non-null `iCalUId`, `isOnlineMeeting=true`, correct `sensitivityLabel` | P2-T4, P6-T2 | `OutlookScannerGraphFieldsTests.NormalizeEvent_recurring_online_meeting_yields_expected_graph_fields`; `SchedulingDtoMapperTests.MapEvent_RecurringOnlineMeeting_MapsExpectedGraphFields` | SATISFIED |
+| AC6 | Existing contract tests pass; new tests cover new fields, safe/enhanced bodyFull, cache round-trip; coverage line >= 85%, branch >= 75% (T2) | P1-T4, P2-T6, P3-T3, P4-T5, P5-T5, P6-T2, P7-T1..T6 | 459 passed / 0 failed / 3 skipped; coverage MailBridge 93.55%/85.47%, Core 89.09%/77.59% (`final-test.md`, `coverage-delta.md`) | SATISFIED |
+
+## Definition of Done (spec.md)
+
+- Acceptance criteria documented and mapped to tests — done (this artifact).
+- Behavior matches acceptance criteria — verified by passing tests.
+- Tests added (unit) — `EventSensitivityLabelTests`, `OutlookScannerGraphFieldsTests`, `ResponseShaperEventBodyFullTests`, `CacheRepositoryGraphFieldsTests`, `CoreCacheRepositoryGraphFieldsTests`, extended `SchedulingDtoMapperTests`.
+- Edge cases / error handling covered — empty categories, out-of-range sensitivity, null COM values, idempotent migration, untruncated body.
+- Docs updated — XML doc remarks in `SchedulingDtoMapper.cs` and `SchedulingEventDto.cs` updated to reflect #72 supplying the fields.
+- Telemetry/logging — none required (feature adds no telemetry).
+- Toolchain pass completed (format -> lint -> type-check -> test) — all green; evidence under `evidence/qa-gates/`.
+
+All six acceptance criteria are SATISFIED.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-architecture.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-architecture.md
@@ -1,0 +1,32 @@
+# Final QA — Architecture Boundaries
+
+Timestamp: 2026-06-13T03-26
+
+Verified against `.claude/rules/architecture-boundaries.md` by inspecting the `ProjectReference` graph and the placement of all changed/new files.
+
+## Project-reference graph (unchanged)
+
+| Project | ProjectReferences | Verdict |
+|---|---|---|
+| `OpenClaw.MailBridge.Contracts` | none (leaf) | OK — leaf project, no solution dependencies. |
+| `OpenClaw.MailBridge` | `OpenClaw.MailBridge.Contracts` only | OK — bridge host may depend only on Contracts. |
+| `OpenClaw.Core` | `OpenClaw.HostAdapter.Contracts` only | OK — Core depends only on HostAdapter.Contracts; no bridge/client/COM. |
+
+No new `ProjectReference` edges were added by this feature.
+
+## COM confinement (unchanged)
+
+- All Outlook COM interop for the nine new fields runs through `OutlookComHelpers` and the new `BuildEventDto` helper, both inside `OpenClaw.MailBridge` (the only COM-permitted project).
+- `OpenClaw.Core` and `OpenClaw.MailBridge.Contracts` contain no Outlook COM. `EventSensitivityLabel` (Contracts) is a pure int→string mapping; `SchedulingDtoMapper` (Core) consumes only contract DTO fields.
+
+## File placement of the contract additions
+
+- `EventDto` nine new parameters: `OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` (leaf).
+- `EventSensitivityLabel`: `OpenClaw.MailBridge.Contracts/Models/EventSensitivityLabel.cs` (leaf).
+
+## Outcome
+
+No architecture-boundary violations. COM stays confined to `OpenClaw.MailBridge`; the sensitivity-label helper and EventDto changes live only in the leaf `OpenClaw.MailBridge.Contracts`.
+
+EXIT_CODE: 0
+Output Summary: PASS. Project graph and COM confinement unchanged; 0 violations.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-format.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-format.md
@@ -1,0 +1,9 @@
+# Final QA — CSharpier Format Check
+
+Timestamp: 2026-06-13T03-26
+
+Command: `csharpier check .` (global csharpier 1.3.0; see baseline-format.md for the command-form note)
+
+EXIT_CODE: 0
+
+Output Summary: PASS. Checked 157 files; 0 needing format. No files changed by the check.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-lint.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-lint.md
@@ -1,0 +1,11 @@
+# Final QA — Analyzer / Lint Build
+
+Timestamp: 2026-06-13T03-26
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). All nine projects compiled with analyzers + code-style enforcement.
+
+AC1 source-compatibility confirmed: the full solution builds with no edits to any existing positional `new EventDto(...)` call site (`OutlookScanner` construction, `CacheRepository.Readers` and `CoreCacheRepository` materializers were extended by choice to populate the new columns, not because the contract change forced a compile break). The nine appended parameters are trailing optional with defaults.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-test.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-test.md
@@ -1,0 +1,38 @@
+# Final QA — Test + Coverage
+
+Timestamp: 2026-06-13T03-26
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+
+EXIT_CODE: 0
+
+Output Summary:
+- Tests PASS. Failed: 0, Passed: 459 (HostAdapter.Tests 71, Core.Tests 184, MailBridge.Tests 204), Skipped: 3, Total: 462.
+- Skipped (platform/publish-gated, same as baseline): Com_active_object_create_and_logon_should_throw_on_non_windows; PublishOutput_BridgeDirectory_ContainsBridgeExecutable; PublishOutput_ClientDirectory_ContainsClientExecutable.
+
+## Post-change coverage (cobertura)
+
+| Module | Line | Branch |
+|---|---|---|
+| OpenClaw.MailBridge.Tests | 93.55% (973/1040) | 85.47% (259/303) |
+| OpenClaw.Core.Tests | 89.09% (1430/1605) | 77.59% (329/424) |
+
+Threshold (line >= 85%, branch >= 75%): PASS for both modules.
+
+## Per-changed-file coverage (no regression on changed lines)
+
+| File | Line | Branch |
+|---|---|---|
+| `OpenClaw.MailBridge.Contracts/Models/EventDto` (BridgeContracts.cs) | 100% | 100% |
+| `OpenClaw.MailBridge.Contracts/Models/EventSensitivityLabel.cs` | 100% | 100% |
+| `OpenClaw.MailBridge/OutlookScanner.cs` | 92.12% | 88.63% |
+| `OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` | 100% | 100% |
+| `OpenClaw.MailBridge/ResponseShaper.cs` | 100% | 100% |
+| `OpenClaw.MailBridge/CacheRepository.cs` | 90.0% | 83.82% |
+| `OpenClaw.MailBridge/CacheRepository.Readers.cs` | 96.1% | 83.33% |
+| `OpenClaw.MailBridge/CacheRepository.Schema.cs` | 100% | 100% |
+| `OpenClaw.Core/CoreCacheRepository.cs` | 97.44% | 91.83% |
+| `OpenClaw.Core/CoreCacheRepository.Schema.cs` | 100% | 100% |
+| `OpenClaw.Core/Agent/Runtime/SchedulingDtoMapper.cs` | 92.7% | 80.0% |
+
+All changed/new files are at or above the 85%/75% thresholds; the new files added by #72 are at 100% line/branch.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-typecheck.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/final-typecheck.md
@@ -1,0 +1,9 @@
+# Final QA — Nullable Type-Check Build
+
+Timestamp: 2026-06-13T03-26
+
+Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+
+EXIT_CODE: 0
+
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). No nullable-flow warnings under TreatWarningsAsErrors across the whole solution.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase1-toolchain.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase1-toolchain.md
@@ -1,0 +1,21 @@
+# Phase 1 — Toolchain (Contract Changes)
+
+Timestamp: 2026-06-13T03-08
+
+Phase boundary: build-green and test-green confirmed in a single clean pass.
+
+## Stage results
+
+1. Format — `csharpier check .` → EXIT 0. Checked 150 files, 0 needing format.
+2. Lint/analyzers — `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` → EXIT 0, 0 warnings, 0 errors.
+3. Type-check (nullable) — same build with `-p:TreatWarningsAsErrors=true` → EXIT 0, 0 warnings, 0 errors. Confirms AC1 source-compatibility: all existing positional `new EventDto(...)` call sites compile unmodified.
+4. Architecture — no new ProjectReference edges; `EventSensitivityLabel` + EventDto changes are in leaf `OpenClaw.MailBridge.Contracts`; no COM added. Boundaries intact.
+5. Test — `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+EXIT_CODE: 0
+
+Output Summary:
+- Tests PASS. Failed: 0, Passed: 431 (HostAdapter 71, Core 178, MailBridge 182), Skipped: 3, Total: 434. MailBridge.Tests grew from 176 to 182 (six new EventSensitivityLabel rows/methods).
+- Coverage (cobertura): MailBridge.Tests line 93.34% (897/961), branch 83.51% (233/279). Core.Tests line 88.93% (1382/1554), branch 76.23% (308/404).
+- Threshold check (line >= 85%, branch >= 75%): PASS for both modules.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase2-filesize.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase2-filesize.md
@@ -1,0 +1,14 @@
+# Phase 2 — File Size (500-line cap)
+
+Timestamp: 2026-06-13T03-13
+
+| File | Pre-P2 lines | Post-P2 lines | Status |
+|---|---|---|---|
+| `src/OpenClaw.MailBridge/OutlookScanner.cs` | 507 (pre-existing over-cap) | 485 | Under 500. The COM-read + nine-field construction was extracted into `BuildEventDto` in the new partial, so `OutlookScanner.cs` did NOT grow; it shrank below its pre-existing 507 count and is now within the cap. |
+| `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` | n/a (new) | 104 | Under 500. Holds `BuildEventDto`, `SplitCategories`, and `DeriveSeriesMasterId`. |
+
+Notes:
+- The plan's P2-T5 acceptance required `OutlookScanner.cs` not to grow beyond its pre-existing 507 count. The initial inline-construction edit pushed it to 523 (worsening the over-cap). To honor the directive constraint ("the pre-existing OutlookScanner.cs over-cap is documented, not worsened"), the `EventDto` construction was moved into a `BuildEventDto` helper in `OutlookScanner.GraphFields.cs`. Net effect: `OutlookScanner.cs` is now 485 (no longer over cap) and all new helpers live in the partial, as the plan intended.
+
+EXIT_CODE: 0
+Output Summary: PASS. Both scanner files under 500 lines (485 and 104). OutlookScanner.cs reduced from 507 to 485; over-cap not worsened.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase2-toolchain.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase2-toolchain.md
@@ -1,0 +1,22 @@
+# Phase 2 — Toolchain (Scanner Population)
+
+Timestamp: 2026-06-13T03-13
+
+Phase boundary: build-green and test-green in a single clean pass.
+
+## Stage results
+
+1. Format — `csharpier format .` then `csharpier check .` → EXIT 0. 152 files clean.
+2. Lint/analyzers — `dotnet build ... -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` → EXIT 0, 0 warnings, 0 errors.
+3. Type-check (nullable) — `... -p:TreatWarningsAsErrors=true` → EXIT 0, 0 warnings, 0 errors.
+4. Architecture — COM reads remain in `OpenClaw.MailBridge` (`BuildEventDto` in the scanner partial); no new ProjectReference. Boundaries intact.
+5. Test — see below.
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+EXIT_CODE: 0
+
+Output Summary:
+- Tests PASS. Failed: 0, Passed: 448 (HostAdapter 71, Core 178, MailBridge 199), Skipped: 3, Total: 451. MailBridge.Tests grew 182 -> 199 (17 new OutlookScannerGraphFields tests: categories split + empty, isOrganizer true/false rows, isOnlineMeeting, allowNewTimeProposals, iCalUId, seriesMasterId for each recurrence state, lastModifiedDateTime, bodyFull raw untruncated, sensitivityLabel, recurring-online-meeting AC5 composite).
+- Coverage (cobertura): MailBridge.Tests line 93.55% (929/993), branch 83.85% (239/285). Threshold (line >= 85%, branch >= 75%): PASS.
+
+AC2 (scanner populates all nine fields) and AC5 (recurring online meeting yields non-null iCalUId, isOnlineMeeting=true, correct sensitivityLabel) verified by passing tests.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase3-toolchain.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase3-toolchain.md
@@ -1,0 +1,22 @@
+# Phase 3 — Toolchain (Redaction / ShapeEvent)
+
+Timestamp: 2026-06-13T03-15
+
+Phase boundary: build-green and test-green in a single clean pass.
+
+## Stage results
+
+1. Format — `csharpier format .` then `csharpier check .` → EXIT 0. 153 files clean.
+2. Lint/analyzers — EXIT 0, 0 warnings, 0 errors.
+3. Type-check (nullable, TreatWarningsAsErrors) — EXIT 0, 0 warnings, 0 errors.
+4. Architecture — change confined to `OpenClaw.MailBridge/ResponseShaper.cs`; no new references; no COM. Intact.
+5. Test — below.
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+EXIT_CODE: 0
+
+Output Summary:
+- Tests PASS. Failed: 0, Passed: 450 (HostAdapter 71, Core 178, MailBridge 201), Skipped: 3, Total: 453. MailBridge.Tests grew 199 -> 201 (two new ResponseShaperEventBodyFull tests).
+- Coverage (cobertura): MailBridge.Tests line 93.56% (930/994), branch 83.85% (239/285). Threshold (line >= 85%, branch >= 75%): PASS.
+
+AC3 verified: safe mode nulls BodyFull and sets IsRedacted=true; enhanced mode returns the full untruncated body verbatim (a body longer than BodyPreviewMaxChars is not truncated in BodyFull and is not routed through BodySanitizer.NormalizePreview).

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase4-filesize.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase4-filesize.md
@@ -1,0 +1,12 @@
+# Phase 4 — File Size (500-line cap)
+
+Timestamp: 2026-06-13T03-18
+
+| File | Pre-P4 lines | Post-P4 lines | Status |
+|---|---|---|---|
+| `src/OpenClaw.MailBridge/CacheRepository.cs` | 465 | 460 | Under 500. DDL constant + migration helpers moved to the new `CacheRepository.Schema.cs` partial, so adding the eight INSERT/UPDATE columns and parameter bindings kept the file below cap. |
+| `src/OpenClaw.MailBridge/CacheRepository.Schema.cs` | n/a (new) | 80 | Under 500. Holds `CreateTablesSql`, `GraphFieldColumns`, `MigrateEventsSchemaAsync`, `AddEventsColumnAsync`, `EventsColumnExistsAsync`. |
+| `src/OpenClaw.MailBridge/CacheRepository.Readers.cs` | 84 | 116 | Under 500. `ReadEvent` extended with nine trailing columns + `GetCategories` JSON helper. |
+
+EXIT_CODE: 0
+Output Summary: PASS. No CacheRepository file exceeds 500 lines (460 / 80 / 116). Schema/migration split into a partial per P4-T6.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase4-toolchain.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase4-toolchain.md
@@ -1,0 +1,22 @@
+# Phase 4 — Toolchain (Bridge Cache Persistence)
+
+Timestamp: 2026-06-13T03-18
+
+Phase boundary: build-green and test-green in a single clean pass.
+
+## Stage results
+
+1. Format — `csharpier format .` then `csharpier check .` → EXIT 0. 155 files clean.
+2. Lint/analyzers — EXIT 0, 0 warnings, 0 errors.
+3. Type-check (nullable, TreatWarningsAsErrors) → EXIT 0, 0 warnings, 0 errors.
+4. Architecture — changes confined to `OpenClaw.MailBridge` (CacheRepository + new Schema partial + Readers); no new ProjectReference; no COM. Intact.
+5. Test — below.
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+EXIT_CODE: 0
+
+Output Summary:
+- Tests PASS. Failed: 0, Passed: 453 (HostAdapter 71, Core 178, MailBridge 204), Skipped: 3, Total: 456. MailBridge.Tests grew 201 -> 204 (three new CacheRepositoryGraphFields tests: full populated round-trip, empty-categories round-trip, idempotent double InitializeAsync).
+- Coverage (cobertura): MailBridge.Tests line 93.55% (973/1040), branch 85.47% (259/303). Threshold (line >= 85%, branch >= 75%): PASS.
+
+AC4 (bridge cache) verified: all nine new fields write-then-read identically (populated + empty categories); migration idempotent across two InitializeAsync calls.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase5-filesize.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase5-filesize.md
@@ -1,0 +1,15 @@
+# Phase 5 — File Size (500-line cap)
+
+Timestamp: 2026-06-13T03-21
+
+| File | Pre-P5 lines | Post-P5 lines | Status |
+|---|---|---|---|
+| `src/OpenClaw.Core/CoreCacheRepository.cs` | 691 (pre-existing over-cap) | 687 | PRE-EXISTING OVER-CAP, NOT worsened (687 < 691). The DDL block (~75 lines) was moved into the new `CoreCacheRepository.Schema.cs` partial; the new parameter bindings + JSON helpers (~70 lines) net to a small decrease. |
+| `src/OpenClaw.Core/CoreCacheRepository.Schema.cs` | n/a (new) | 158 | Under 500. Holds `CreateTablesSql`, `GraphFieldColumns`, `MigrateEventsSchemaAsync`, `EventsColumnExistsAsync`. |
+
+Notes:
+- `CoreCacheRepository.cs` is a pre-existing over-cap file (691 lines at baseline per `evidence/baseline/baseline-file-sizes.md`). Per P5-T6 the schema/migration was extracted to a new partial to avoid worsening the condition. Post-change it is 687 lines — slightly below its pre-existing count, so the over-cap is not worsened.
+- The new partial is well under 500 lines.
+
+EXIT_CODE: 0
+Output Summary: PASS. CoreCacheRepository.cs reduced 691 -> 687 (pre-existing over-cap not worsened); new partial 158 lines (under cap).

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase5-toolchain.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase5-toolchain.md
@@ -1,0 +1,24 @@
+# Phase 5 — Toolchain (Core Cache Persistence)
+
+Timestamp: 2026-06-13T03-21
+
+Phase boundary: build-green and test-green in a single clean pass.
+
+## Stage results
+
+1. Format — `csharpier format .` then `csharpier check .` → EXIT 0. 157 files clean.
+2. Lint/analyzers — EXIT 0, 0 warnings, 0 errors.
+3. Type-check (nullable, TreatWarningsAsErrors) → EXIT 0, 0 warnings, 0 errors.
+4. Architecture — changes confined to `OpenClaw.Core` (CoreCacheRepository + new Schema partial); no new ProjectReference; no COM pulled into Core's closure. Intact.
+5. Test — below.
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+EXIT_CODE: 0
+
+Output Summary:
+- Tests PASS. Failed: 0, Passed: 456 (HostAdapter 71, Core 181, MailBridge 204), Skipped: 3, Total: 459. Core.Tests grew 178 -> 181 (three new CoreCacheRepositoryGraphFields tests: full populated round-trip, empty-categories round-trip, idempotent double InitializeAsync).
+- Coverage (cobertura): Core.Tests line 89.10% (1431/1606), branch 77.48% (327/422). Threshold (line >= 85%, branch >= 75%): PASS.
+
+AC4 (both caches) now fully verified: bridge cache (Phase 4) and Core cache (Phase 5) round-trip all nine fields with idempotent migrations.
+
+Scope note: the Core migration adds the nine Graph-field columns plus `last_modified_utc` only. No `response_status` column is added (deferred to issue #80 per spec Non-Goals); an in-code comment in `CoreCacheRepository.Schema.cs` cites #80.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase6-toolchain.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/phase6-toolchain.md
@@ -1,0 +1,22 @@
+# Phase 6 — Toolchain (Downstream Mapper Propagation)
+
+Timestamp: 2026-06-13T03-24
+
+Phase boundary: build-green and test-green in a single clean pass.
+
+## Stage results
+
+1. Format — `csharpier format .` then `csharpier check .` → EXIT 0. 157 files clean.
+2. Lint/analyzers — EXIT 0, 0 warnings, 0 errors.
+3. Type-check (nullable, TreatWarningsAsErrors) → EXIT 0, 0 warnings, 0 errors.
+4. Architecture — changes confined to `OpenClaw.Core` (SchedulingDtoMapper + SchedulingEventDto doc); no new ProjectReference; no COM. Intact.
+5. Test — below.
+
+Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+EXIT_CODE: 0
+
+Output Summary:
+- Tests PASS. Failed: 0, Passed: 459 (HostAdapter 71, Core 184, MailBridge 204), Skipped: 3, Total: 462. Core.Tests grew 181 -> 184 (added populated-passthrough, null-categories-to-empty, and recurring-online-meeting AC5 mapper tests; renamed the former "DeferredFields" test to reflect default passthrough).
+- Coverage (cobertura): Core.Tests line 89.09% (1430/1605), branch 77.59% (329/424). Threshold (line >= 85%, branch >= 75%): PASS.
+
+P6 wired the six placeholder fields (Categories, IsOrganizer, IsOnlineMeeting, AllowNewTimeProposals, LastModifiedDateTime, SeriesMasterId) to the new EventDto fields; ICalUId now reads evt.ICalUId; Sensitivity continues via MapSensitivity(evt.Sensitivity). Doc remarks in SchedulingDtoMapper.cs and SchedulingEventDto.cs no longer claim the #72 fields are unavailable. AC5 (recurring online meeting) confirmed end-to-end through the mapper.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/regression-testing/coverage-delta.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/regression-testing/coverage-delta.md
@@ -1,0 +1,45 @@
+# Coverage Delta — Baseline (P0-T5) vs Post-Change (P7-T5)
+
+Timestamp: 2026-06-13T03-27
+
+Thresholds (uniform T1–T4): line >= 85%, branch >= 75%; no regression on changed lines.
+
+## Module coverage: baseline vs post-change
+
+| Module | Baseline line | Post line | Baseline branch | Post branch |
+|---|---|---|---|---|
+| OpenClaw.MailBridge.Tests | 93.22% (880/944) | 93.55% (973/1040) | 83.08% (226/272) | 85.47% (259/303) |
+| OpenClaw.Core.Tests | 89.32% (1373/1537) | 89.09% (1430/1605) | 77.58% (308/397) | 77.59% (329/424) |
+
+- MailBridge module: line +0.33 pts, branch +2.39 pts.
+- Core module: line -0.23 pts (89.32% -> 89.09%), branch +0.01 pts. The small Core line dip is from adding ~68 valid lines (1537 -> 1605) of which the new graph-field code is fully covered; the dilution reflects pre-existing uncovered lines elsewhere in `OpenClaw.Core`, not new uncovered code. Both Core figures remain above the 85%/75% thresholds.
+
+## Changed-code coverage (new/modified files this feature)
+
+All files changed or added by #72, from the post-change cobertura per-class data:
+
+| File | Line | Branch |
+|---|---|---|
+| EventDto (BridgeContracts.cs) | 100% | 100% |
+| EventSensitivityLabel.cs (new) | 100% | 100% |
+| OutlookScanner.cs | 92.12% | 88.63% |
+| OutlookScanner.GraphFields.cs (new) | 100% | 100% |
+| ResponseShaper.cs | 100% | 100% |
+| CacheRepository.cs | 90.0% | 83.82% |
+| CacheRepository.Readers.cs | 96.1% | 83.33% |
+| CacheRepository.Schema.cs (new) | 100% | 100% |
+| CoreCacheRepository.cs | 97.44% | 91.83% |
+| CoreCacheRepository.Schema.cs (new) | 100% | 100% |
+| SchedulingDtoMapper.cs | 92.7% | 80.0% |
+
+Every changed/new file is at or above 85% line and 75% branch. The graph-field code added by this feature is fully exercised by the new tests; no changed line lost coverage.
+
+## Verdict
+
+PASS.
+- Post-change line coverage: MailBridge 93.55%, Core 89.09% (both >= 85%).
+- Post-change branch coverage: MailBridge 85.47%, Core 77.59% (both >= 75%).
+- No regression on changed lines: all changed/new files >= thresholds; new files at 100%.
+
+EXIT_CODE: 0
+Output Summary: PASS. Both modules above thresholds post-change; changed-code coverage at/above thresholds with new files at 100%; no changed-line regression.

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/plan.2026-06-12T22-20.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/plan.2026-06-12T22-20.md
@@ -1,0 +1,226 @@
+# mailbridge-eventdto-graph-fields - Plan
+
+- **Issue:** #72
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-12T22-20
+- **Status:** Draft
+- **Version:** 1.0
+- **Work Mode:** full-feature
+- **Language / Tier:** C# (.NET 10), T2 (managed surface of `OpenClaw.MailBridge.Contracts` and consumers)
+
+## Required References
+
+- General code-change policy: `.claude/rules/general-code-change.md`
+- General unit-test policy: `.claude/rules/general-unit-test.md`
+- C# standards: `.claude/rules/csharp.md`
+- Quality tiers / coverage thresholds: `.claude/rules/quality-tiers.md` (line >= 85%, branch >= 75%, uniform T1–T4)
+- Architecture boundaries: `.claude/rules/architecture-boundaries.md` (COM confined to `OpenClaw.MailBridge`; `EventDto` + sensitivity label live in leaf `OpenClaw.MailBridge.Contracts`)
+- Spec: `docs/features/active/mailbridge-eventdto-graph-fields-72/spec.md` (Status: Approved)
+- User story / acceptance criteria: `docs/features/active/mailbridge-eventdto-graph-fields-72/user-story.md`
+- Research: `artifacts/research/2026-06-12-issue-72-eventdto-com-analogs-research.md`
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Acceptance Criteria Mapping (user-story.md)
+
+The user-story `## Acceptance Criteria` section contains six checkboxes, referenced here as AC1–AC6 in document order:
+
+- **AC1** — `EventDto` exposes all nine new fields with the specified types and remains source-compatible (existing callers compile unmodified). → P1-T2, P1-T3, P7-T2
+- **AC2** — `OutlookScanner.NormalizeEvent` populates all nine fields from the specified COM analogs/derivations. → P2-T1, P2-T2, P2-T3, P2-T4
+- **AC3** — `ResponseShaper.ShapeEvent` nulls `bodyFull` in safe mode (parity with `BodyPreview`); enhanced mode returns full untruncated `bodyFull`. → P3-T1, P3-T2
+- **AC4** — Both SQLite caches (`CacheRepository`, `CoreCacheRepository`) round-trip all nine new fields with idempotent schema migrations. → P4-T1..T4, P5-T1..T4
+- **AC5** — A scan of a recurring online meeting yields non-null `iCalUId`, `isOnlineMeeting=true`, and the correct `sensitivityLabel`. → P2-T4, P6-T2
+- **AC6** — Existing contract tests pass; new unit tests cover the new fields, the safe/enhanced shaping of `bodyFull`, and the cache round-trip. Coverage thresholds hold: line >= 85%, branch >= 75% (T2). → P1-T4, P2-T6, P3-T3, P4-T5, P5-T5, P6-T3, P7-T1..T5
+
+## Mandatory Toolchain Loop (per implementation task)
+
+Every code/test task runs the seven-stage C# loop in order and restarts from stage 1 if any stage fails or auto-fixes files (see `.claude/rules/general-code-change.md` and `.claude/rules/csharp.md`):
+
+1. **Format** — `dotnet csharpier .`
+2. **Lint / analyzers** — `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+3. **Type-check (nullable)** — `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+4. **Architecture** — verify `ProjectReference` graph against `.claude/rules/architecture-boundaries.md` (no new project references; COM stays in `OpenClaw.MailBridge`)
+5. **Test** — `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+
+Stages 1–3 share the build invocation pattern; treat any analyzer or nullable warning as a failure. Phase boundaries must be build-green and test-green.
+
+## Evidence Locations (canonical — non-overridable)
+
+All evidence artifacts MUST be written under `docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/<kind>/` per `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`. Writing to `artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`, or any non-canonical path is a policy violation.
+
+- Baseline: `docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/baseline/`
+- Final QA gates: `docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/qa-gates/`
+- Regression / coverage delta: `docs/features/active/mailbridge-eventdto-graph-fields-72/evidence/regression-testing/`
+
+Each command-step artifact MUST include `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`. Test artifacts MUST record numeric coverage headline values.
+
+---
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Baseline Capture & Policy Read
+
+- [x] [P0-T1] Read repo policy files in required order and record evidence: `CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/csharp.md`, `.claude/rules/quality-tiers.md`, `.claude/rules/architecture-boundaries.md`.
+  - Acceptance: `evidence/baseline/phase0-instructions-read.md` exists with `Timestamp:`, `Policy Order:`, and the explicit list of files read.
+- [x] [P0-T2] Capture baseline CSharpier format state. Command: `dotnet csharpier --check .`
+  - Acceptance: `evidence/baseline/baseline-format.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (pass/fail, count of files needing format).
+- [x] [P0-T3] Capture baseline analyzer/lint build state. Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+  - Acceptance: `evidence/baseline/baseline-lint.md` with required schema fields and `Output Summary:` (warning/error counts).
+- [x] [P0-T4] Capture baseline nullable type-check build state. Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+  - Acceptance: `evidence/baseline/baseline-typecheck.md` with required schema fields and `Output Summary:`.
+- [x] [P0-T5] Capture baseline test + coverage state. Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+  - Acceptance: `evidence/baseline/baseline-test.md` with required schema fields and `Output Summary:` containing numeric baseline line coverage % and branch coverage % (not placeholders), and passed/failed test counts.
+- [x] [P0-T6] Record baseline line counts for files that approach the 500-line cap to size split decisions later. Files: `src/OpenClaw.MailBridge/CacheRepository.cs`, `src/OpenClaw.Core/CoreCacheRepository.cs`, `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs`.
+  - Acceptance: `evidence/baseline/baseline-file-sizes.md` records the current line count of each file with `Timestamp:`.
+
+### Phase 1 — Contract Changes (`BridgeContracts.cs`)
+
+- [x] [P1-T1] Add an `EventSensitivityLabel` constants/enum-string helper in `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` (or a sibling file in the same project if it would push `BridgeContracts.cs` past 500 lines) exposing the four values `normal`/`personal`/`private`/`confidential` and a `FromSensitivity(int?)` mapping (0=normal,1=personal,2=private,3=confidential, else null), mirroring `SchedulingDtoMapper.MapSensitivity`.
+  - File: `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` (or new `EventSensitivityLabel.cs` in `OpenClaw.MailBridge.Contracts/Models/`).
+  - Acceptance: Helper compiles; no project reference added; build-green via toolchain loop stages 1–4.
+- [x] [P1-T2] Append the nine new optional parameters to the `EventDto` record in `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` after `int? ResponseStatus = null`, in this exact order with defaults: `string[]? Categories = null`, `bool IsOrganizer = false`, `bool IsOnlineMeeting = false`, `bool AllowNewTimeProposals = false`, `string? ICalUId = null`, `string? SeriesMasterId = null`, `DateTimeOffset? LastModifiedDateTime = null`, `string? BodyFull = null`, `string? SensitivityLabel = null`.
+  - File: `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` (EventDto record at ~lines 94-113).
+  - Acceptance: `EventDto` declares 27 positional parameters total; the nine new ones are trailing optional with defaults; file remains under 500 lines (else perform split in P1-T1's sibling-file path).
+- [x] [P1-T3] Verify source-compatibility of all existing positional `new EventDto(...)` construction sites by building the full solution without editing any call site.
+  - Files verified (no edits): `src/OpenClaw.MailBridge/OutlookScanner.cs:447`, `src/OpenClaw.MailBridge/CacheRepository.Readers.cs:34`, `src/OpenClaw.Core/CoreCacheRepository.cs:642`, and all test construction sites listed in the research §3.1 table.
+  - Acceptance: `dotnet build OpenClaw.MailBridge.sln -c Debug` succeeds with zero errors and no changes to those call sites. (AC1)
+- [x] [P1-T4] Add a unit test asserting the `EventSensitivityLabel.FromSensitivity` mapping for inputs 0, 1, 2, 3, null, and an out-of-range value (e.g., 99), using `[DataTestMethod]`/`[DataRow]`, MSTest + FluentAssertions.
+  - File: `tests/OpenClaw.MailBridge.Tests/EventSensitivityLabelTests.cs` (new).
+  - Acceptance: Test class compiles and all rows pass; covers the four valid values plus null and out-of-range branches. (AC6)
+- [x] [P1-T5] Run the full seven-stage C# toolchain loop and confirm phase boundary is build-green and test-green.
+  - Acceptance: All five stages pass in a single pass; `evidence/qa-gates/phase1-toolchain.md` records the test stage with numeric coverage in `Output Summary:`.
+
+### Phase 2 — Scanner Population (`OutlookScanner.NormalizeEvent`)
+
+- [x] [P2-T1] In `src/OpenClaw.MailBridge/OutlookScanner.cs`, read COM `Body` once into a local in `NormalizeEvent` and reuse it for both the `BodyPreview` shaping and the new `bodyFull` value (avoid a redundant COM read), per spec §"Limits".
+  - File: `src/OpenClaw.MailBridge/OutlookScanner.cs` (`NormalizeEvent` ~lines 431-472).
+  - Acceptance: A single `GetOptionalString(item, "Body")` read feeds both `ShapePreview(...)` and the raw `bodyFull`; build-green.
+- [x] [P2-T2] Add a private static `string[]` splitter helper to a NEW partial-class file `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` (partial class `OutlookScanner`; the class is already `internal sealed partial`) that splits `Categories` on `", "` with per-token `Trim()` and `RemoveEmptyEntries`, returning `Array.Empty<string>()` for null/empty input (never null). Do NOT add this helper to `OutlookScanner.cs`, which is already over the 500-line cap.
+  - File: `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` (new partial of `OutlookScanner`).
+  - Acceptance: Helper returns non-null `string[]`; empty input yields a zero-length array; the helper resides in `OutlookScanner.GraphFields.cs`, not `OutlookScanner.cs`.
+- [x] [P2-T3] Add a private static `seriesMasterId` derivation helper to the NEW partial-class file `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` (partial class `OutlookScanner`) from `GetOptionalInt(item, "RecurrenceState")`: return null for not-recurring (0) and master; return `GlobalAppointmentID` for occurrence/exception. Confirm OlRecurrenceState integers at implementation time per research OQ-1; logic must be null for master/non-recurring and `GlobalAppointmentID` for occurrence/exception. Do NOT add this helper to `OutlookScanner.cs`, which is already over the 500-line cap.
+  - File: `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` (new partial of `OutlookScanner`).
+  - Acceptance: Helper resides in `OutlookScanner.GraphFields.cs` (not `OutlookScanner.cs`) and returns null for master and non-recurring inputs and `GlobalAppointmentID` for the non-master recurring states; the integer mapping is documented in an in-code comment citing OQ-1.
+- [x] [P2-T4] Populate the nine new `EventDto` arguments in the `NormalizeEvent` constructor call (this method lives in `OutlookScanner.cs`, so the nine named-argument additions occur there): `Categories` (P2-T2 split helper from `OutlookScanner.GraphFields.cs`), `IsOrganizer = GetOptionalInt(item,"ResponseStatus") == 1`, `IsOnlineMeeting = GetOptionalBool(item,"IsOnlineMeeting")`, `AllowNewTimeProposals = GetOptionalBool(item,"AllowNewTimeProposal")` (singular COM name), `ICalUId = globalAppointmentId`, `SeriesMasterId` (P2-T3 helper from `OutlookScanner.GraphFields.cs`), `LastModifiedDateTime = GetOptionalUtcDateTimeOffset(item,"LastModificationTime")`, `BodyFull` (raw local from P2-T1, not normalized), `SensitivityLabel = EventSensitivityLabel.FromSensitivity(GetOptionalInt(item,"Sensitivity"))`.
+  - File: `src/OpenClaw.MailBridge/OutlookScanner.cs` (`new EventDto(...)` at ~line 447).
+  - Acceptance: All nine fields are passed by name (use named arguments for the appended parameters); COM interop stays in `OpenClaw.MailBridge`; build-green. (AC2, AC5)
+- [x] [P2-T5] Verify the 500-line cap after Phase 2 changes: place the new helpers (P2-T2, P2-T3) in `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` so `OutlookScanner.cs` does not grow further beyond its pre-existing over-cap state, and confirm both files stay under 500 lines (the new partial must be under 500; `OutlookScanner.cs` must not increase beyond its pre-existing count). Record pre/post line counts for both files.
+  - Files: `src/OpenClaw.MailBridge/OutlookScanner.cs`, `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs`.
+  - Acceptance: `evidence/qa-gates/phase2-filesize.md` records pre/post line counts for both `OutlookScanner.cs` and `OutlookScanner.GraphFields.cs`, noting the pre-existing over-cap status of `OutlookScanner.cs` (507 lines); `OutlookScanner.GraphFields.cs` is under 500 lines and `OutlookScanner.cs` does not grow further.
+- [x] [P2-T6] Add scanner unit tests via the existing COM-double pattern (parallel to `OutlookScannerResponseStatusTests.cs`) asserting each new field is populated correctly: categories split (including empty), `isOrganizer` for ResponseStatus 1 vs other, `isOnlineMeeting`, `allowNewTimeProposals`, `iCalUId == GlobalAppointmentID`, `seriesMasterId` for each recurrence state, `lastModifiedDateTime`, `bodyFull` raw, and `sensitivityLabel`.
+  - File: `tests/OpenClaw.MailBridge.Tests/OutlookScannerGraphFieldsTests.cs` (new).
+  - Acceptance: Tests use Moq/COM-double seams (no live COM, no temp files, deterministic); all assertions pass. (AC2, AC6)
+- [x] [P2-T7] Run the full toolchain loop; phase boundary build-green and test-green.
+  - Acceptance: All stages pass; `evidence/qa-gates/phase2-toolchain.md` records the test stage with numeric coverage.
+
+### Phase 3 — Redaction (`ResponseShaper.ShapeEvent`)
+
+- [x] [P3-T1] Update `ShapeEvent` in `src/OpenClaw.MailBridge/ResponseShaper.cs` so the safe-mode branch sets `BodyFull = null` alongside `BodyPreview = null` and `IsRedacted = true`.
+  - File: `src/OpenClaw.MailBridge/ResponseShaper.cs` (`ShapeEvent` lines 34-54).
+  - Acceptance: Safe-mode `with`-expression nulls `BodyFull`; build-green. (AC3)
+- [x] [P3-T2] Update the enhanced-mode branch of `ShapeEvent` so `BodyFull` passes through unchanged (raw, untruncated, NOT through `BodySanitizer.NormalizePreview`); `BodyPreview` continues to use `ShapePreview`.
+  - File: `src/OpenClaw.MailBridge/ResponseShaper.cs`.
+  - Acceptance: Enhanced-mode `BodyFull` equals the input `evt.BodyFull` verbatim. (AC3)
+- [x] [P3-T3] Add unit tests for `ShapeEvent` body shaping: safe mode nulls `BodyFull` and sets `IsRedacted=true`; enhanced mode returns full untruncated `BodyFull` (assert a body longer than `BodyPreviewMaxChars` is not truncated in `BodyFull`).
+  - File: `tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs` (new), or extend an existing `ResponseShaper` test file if present.
+  - Acceptance: Both branches asserted with FluentAssertions; tests pass. (AC3, AC6)
+- [x] [P3-T4] Run the full toolchain loop; phase boundary build-green and test-green.
+  - Acceptance: All stages pass; `evidence/qa-gates/phase3-toolchain.md` records the test stage with numeric coverage.
+
+### Phase 4 — Bridge Cache Persistence (`CacheRepository`)
+
+- [x] [P4-T1] Add the eight new columns to the bridge `events` `CREATE TABLE IF NOT EXISTS` DDL in `src/OpenClaw.MailBridge/CacheRepository.cs` (`InitializeAsync`, ~line 93): `categories_json TEXT NULL`, `is_organizer INTEGER NOT NULL DEFAULT 0`, `is_online_meeting INTEGER NOT NULL DEFAULT 0`, `allow_new_time_proposals INTEGER NOT NULL DEFAULT 0`, `ical_uid TEXT NULL`, `series_master_id TEXT NULL`, `body_full TEXT NULL`, `sensitivity_label TEXT NULL`. (`last_modified_utc` already exists; no new column.)
+  - File: `src/OpenClaw.MailBridge/CacheRepository.cs`.
+  - Acceptance: Fresh-database DDL includes all eight new columns; build-green.
+- [x] [P4-T2] Extend `MigrateEventsSchemaAsync` in `CacheRepository.cs` to idempotently `ALTER TABLE events ADD COLUMN` each of the eight new columns, guarded by `EventsColumnExistsAsync` (mirroring the existing `response_status` pattern).
+  - File: `src/OpenClaw.MailBridge/CacheRepository.cs` (~lines 105-115).
+  - Acceptance: Running migration twice produces no "duplicate column" error; each column has its own guarded ALTER. (AC4)
+- [x] [P4-T3] Extend the `UpsertEventAsync` INSERT column list, VALUES list, and `ON CONFLICT DO UPDATE SET` clause in `CacheRepository.cs` (~lines 264-297) to include the eight new columns plus `last_modified_utc`.
+  - File: `src/OpenClaw.MailBridge/CacheRepository.cs`.
+  - Acceptance: All eight new columns plus `last_modified_utc` appear in INSERT, VALUES, and the conflict-update clause.
+- [x] [P4-T4] Extend `AddEventParameters` in `CacheRepository.cs` (~lines 418-464): wire `$last_modified_utc` to `ToDbValue(evt.LastModifiedDateTime)` (replacing the hardcoded `DBNull.Value` at line 458), and add the eight new parameters (`categories_json` via JSON serialization of `evt.Categories`, the three bool flags as 1/0, `ical_uid`, `series_master_id`, `body_full`, `sensitivity_label` with `?? DBNull.Value` for nullables). Extend the `ReadEvent` materializer in `src/OpenClaw.MailBridge/CacheRepository.Readers.cs` (~lines 34-54) to read all nine new columns by column name (matching the existing GetString/ReadString-by-name pattern), supplying them as the trailing constructor arguments in the same order as the appended EventDto parameters (deserialize categories_json to string[]).
+  - Files: `src/OpenClaw.MailBridge/CacheRepository.cs`, `src/OpenClaw.MailBridge/CacheRepository.Readers.cs`.
+  - Acceptance: Writer parameters and reader columns align with the `EventDto` parameter order; `categories` round-trips via JSON; build-green. (AC4)
+- [x] [P4-T5] Add a round-trip unit test for the bridge cache asserting that an `EventDto` carrying non-default values for all nine new fields is written and read back identically (including empty-categories and populated-categories cases). Use the named-parameter `EventDto` construction pattern from `CacheRepositoryResponseStatusTests.cs`. No temp files (use in-memory or shared-cache SQLite per existing test pattern).
+  - File: `tests/OpenClaw.MailBridge.Tests/CacheRepositoryGraphFieldsTests.cs` (new).
+  - Acceptance: Write-then-read returns equal values for all nine fields; idempotent migration verified by initializing twice; tests pass. (AC4, AC6)
+- [x] [P4-T6] Verify `CacheRepository.cs` remains under the 500-line cap after the additions; if it exceeds 500 lines, move the writer-parameter helper or DDL/migration into a new partial-class file (e.g., `CacheRepository.Schema.cs`) in `OpenClaw.MailBridge`.
+  - File: `src/OpenClaw.MailBridge/CacheRepository.cs` (and new partial if split is required).
+  - Acceptance: `evidence/qa-gates/phase4-filesize.md` records the post-change line count; no source file exceeds 500 lines.
+- [x] [P4-T7] Run the full toolchain loop; phase boundary build-green and test-green.
+  - Acceptance: All stages pass; `evidence/qa-gates/phase4-toolchain.md` records the test stage with numeric coverage.
+
+### Phase 5 — Core Cache Persistence (`CoreCacheRepository`)
+
+- [x] [P5-T1] Add the eight new columns to the Core `events` `CREATE TABLE IF NOT EXISTS` DDL in `src/OpenClaw.Core/CoreCacheRepository.cs` (`InitializeAsync`, ~lines 94-117) and add a `last_modified_utc TEXT NULL` column (the Core schema does not currently have it): same column set as the bridge cache plus `last_modified_utc`.
+  - File: `src/OpenClaw.Core/CoreCacheRepository.cs`.
+  - Acceptance: Fresh-database Core DDL includes the new columns; build-green.
+- [x] [P5-T2] Add a new idempotent migration helper in `CoreCacheRepository.cs` modeled on the bridge's `MigrateEventsSchemaAsync` (with a Core `EventsColumnExistsAsync` equivalent) that adds each new column via guarded `ALTER TABLE events ADD COLUMN`, and call it from `InitializeAsync`. Scope: the nine `EventDto` graph-field columns plus `last_modified_utc` only. Do NOT add a `response_status` column (deferred to issue #80 per spec Non-Goals).
+  - File: `src/OpenClaw.Core/CoreCacheRepository.cs`.
+  - Acceptance: Migration is idempotent (running twice is safe); `response_status` is not touched; an in-code comment cites issue #80 for the deferred gap. (AC4)
+- [x] [P5-T3] Extend the Core `INSERT INTO events` column list, VALUES list, and `ON CONFLICT DO UPDATE SET` clause in `CoreCacheRepository.cs` (~lines 222-253) to include the eight new columns plus `last_modified_utc`.
+  - File: `src/OpenClaw.Core/CoreCacheRepository.cs`.
+  - Acceptance: New columns appear in INSERT, VALUES, and conflict-update clauses.
+- [x] [P5-T4] Extend `AddEventParameters` in `CoreCacheRepository.cs` (~lines 538-589) to bind the eight new parameters plus `$last_modified_utc` (JSON-serialize `Categories`, bools as 1/0, nullables with `?? DBNull.Value`), and extend `ReadEvent` (~lines 642-661) to read all nine new columns by column name (matching the existing GetString/ReadString-by-name pattern), supplying them as the trailing constructor arguments in the same order as the appended EventDto parameters (deserialize categories_json to string[]).
+  - File: `src/OpenClaw.Core/CoreCacheRepository.cs`.
+  - Acceptance: Writer parameters and reader columns align with `EventDto` parameter order; build-green. (AC4)
+- [x] [P5-T5] Add a round-trip unit test for the Core cache asserting an `EventDto` with non-default values for all nine new fields writes and reads back identically (empty and populated categories), and that the new migration is idempotent across two `InitializeAsync` calls. No temp files.
+  - File: `tests/OpenClaw.Core.Tests/CoreCacheRepositoryGraphFieldsTests.cs` (new).
+  - Acceptance: Write-then-read equality for all nine fields; idempotent migration verified; tests pass. (AC4, AC6)
+- [x] [P5-T6] Verify the additive change does not worsen the existing 500-line condition of `CoreCacheRepository.cs` beyond a reasonable margin; if the file grows materially, extract the schema/migration helpers into a new partial-class file (e.g., `CoreCacheRepository.Schema.cs`) in `OpenClaw.Core`. Record the file as a pre-existing over-cap file.
+  - File: `src/OpenClaw.Core/CoreCacheRepository.cs` (and new partial if split is performed).
+  - Acceptance: `evidence/qa-gates/phase5-filesize.md` records pre- and post-change line counts; any new file added stays under 500 lines; note the pre-existing over-cap status of `CoreCacheRepository.cs`.
+- [x] [P5-T7] Run the full toolchain loop; phase boundary build-green and test-green.
+  - Acceptance: All stages pass; `evidence/qa-gates/phase5-toolchain.md` records the test stage with numeric coverage.
+
+### Phase 6 — Downstream Mapper Propagation (`SchedulingDtoMapper`)
+
+- [x] [P6-T1] Update `MapEvent` in `src/OpenClaw.Core/Agent/Runtime/SchedulingDtoMapper.cs` (~lines 65-97) to wire the new `EventDto` fields into `SchedulingEventDto` in place of placeholders: `Categories = evt.Categories ?? Array.Empty<string>()`, `IsOrganizer = evt.IsOrganizer`, `IsOnlineMeeting = evt.IsOnlineMeeting`, `AllowNewTimeProposals = evt.AllowNewTimeProposals`, `LastModifiedDateTime = evt.LastModifiedDateTime`, `SeriesMasterId = evt.SeriesMasterId`. Set ICalUId = evt.ICalUId (the new EventDto field, which P2-T4 populates from GlobalAppointmentID per spec); do not read evt.GlobalAppointmentId directly in the mapper. For `Sensitivity`, continue using `MapSensitivity(evt.Sensitivity)` (or `evt.SensitivityLabel` if preferred for parity — choose the one consistent with the existing switch).
+  - File: `src/OpenClaw.Core/Agent/Runtime/SchedulingDtoMapper.cs`.
+  - Acceptance: No remaining hardcoded `Array.Empty<string>()`/`false`/`null` placeholders for the six wired fields; build-green.
+- [x] [P6-T2] Update or add a `SchedulingDtoMapper` unit test asserting a recurring online meeting `EventDto` (non-null `ICalUId`, `IsOnlineMeeting=true`, `Sensitivity=2/private`, occurrence `SeriesMasterId`) maps to a `SchedulingEventDto` with the same values; assert categories pass-through.
+  - File: existing `SchedulingDtoMapper` test file under `tests/OpenClaw.Core.Tests/` (update), or new `SchedulingDtoMapperGraphFieldsTests.cs`.
+  - Acceptance: Mapped DTO carries the expected non-placeholder values; tests pass. (AC5, AC6)
+- [x] [P6-T3] Update the `SchedulingDtoMapper` XML doc remarks (~lines 14-20, 71-72, 84) and `SchedulingEventDto` doc comments where they state fields are "not yet available (#71-#76)" for the now-populated fields, to reflect that #72 supplies them.
+  - Files: `src/OpenClaw.Core/Agent/Runtime/SchedulingDtoMapper.cs`, `src/OpenClaw.Core/Agent/Contracts/SchedulingEventDto.cs`.
+  - Acceptance: Doc comments no longer claim the #72 fields are unavailable; build-green.
+- [x] [P6-T4] Run the full toolchain loop; phase boundary build-green and test-green.
+  - Acceptance: All stages pass; `evidence/qa-gates/phase6-toolchain.md` records the test stage with numeric coverage.
+
+### Phase 7 — Final QA Loop, Coverage, and Acceptance Verification
+
+- [x] [P7-T1] Run final CSharpier format check. Command: `dotnet csharpier --check .`
+  - Acceptance: `evidence/qa-gates/final-format.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (EXIT_CODE 0). If it changes files, restart the loop.
+- [x] [P7-T2] Run final analyzer/lint build. Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`
+  - Acceptance: `evidence/qa-gates/final-lint.md` with schema fields and `Output Summary:` (0 errors; warnings enumerated). Confirms AC1 source-compatibility (no call-site edits required).
+- [x] [P7-T3] Run final nullable type-check build. Command: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`
+  - Acceptance: `evidence/qa-gates/final-typecheck.md` with schema fields and `Output Summary:` (EXIT_CODE 0).
+- [x] [P7-T4] Verify architecture boundaries: confirm no new `ProjectReference` edges were added and COM interop remains only in `OpenClaw.MailBridge` (the sensitivity-label helper and `EventDto` changes live only in `OpenClaw.MailBridge.Contracts`).
+  - Acceptance: `evidence/qa-gates/final-architecture.md` lists the unchanged project-reference graph and confirms COM confinement; no violations.
+- [x] [P7-T5] Run final test + coverage. Command: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+  - Acceptance: `evidence/qa-gates/final-test.md` with schema fields and `Output Summary:` containing numeric post-change line coverage % and branch coverage %, plus passed/failed counts; all tests pass.
+- [x] [P7-T6] Produce a coverage delta/threshold verification artifact comparing baseline (P0-T5) to post-change (P7-T5): report baseline coverage, post-change coverage, and changed-code coverage; confirm line >= 85%, branch >= 75%, and no regression on changed lines.
+  - Acceptance: `evidence/regression-testing/coverage-delta.md` records baseline %, post-change %, changed-code %, and PASS/FAIL against thresholds. If any threshold or no-regression condition fails, outcome is remediation-required (not PASS). (AC6)
+- [x] [P7-T7] Map each acceptance criterion AC1–AC6 to the tests/evidence that satisfy it and confirm all six are covered.
+  - Acceptance: `evidence/qa-gates/acceptance-traceability.md` lists AC1–AC6 with the satisfying P#-T# tasks, test files, and evidence paths; all six are marked satisfied.
+
+## Test Plan
+
+- Unit (MailBridge.Tests): `EventSensitivityLabelTests`, `OutlookScannerGraphFieldsTests`, `ResponseShaperEventBodyFullTests`, `CacheRepositoryGraphFieldsTests`.
+- Unit (Core.Tests): `CoreCacheRepositoryGraphFieldsTests`, `SchedulingDtoMapper` graph-fields tests.
+- Determinism: MSTest + Moq + FluentAssertions; `TimeProvider`/`FakeTimeProvider` where time is involved; no `Thread.Sleep`/`Task.Delay`; no temp files; SQLite tests use in-memory/shared-cache per existing patterns.
+- Coverage evidence:
+  - Baseline: `evidence/baseline/baseline-test.md`
+  - Post-change: `evidence/qa-gates/final-test.md`
+  - Comparison: `evidence/regression-testing/coverage-delta.md`
+- Thresholds: line >= 85%, branch >= 75% (uniform T1–T4); no regression on changed lines.
+
+## Open Questions / Notes
+
+- OQ-1 (research): exact `OlRecurrenceState` integer values must be confirmed at implementation time in P2-T3; the derivation logic is structured to be insensitive to the exact integers as long as master/non-recurring → null and occurrence/exception → `GlobalAppointmentID`.
+- `CoreCacheRepository.cs` is already over the 500-line cap as a pre-existing condition; P5-T6 guards against materially worsening it and prescribes a partial-class split if needed.
+- Out of scope (do not address): the `CoreCacheRepository` missing-`response_status` gap (issue #80); the MAPI `PidLidGlobalObjectId` true-iCalUId path; `Location`/`Body` heuristics for `isOnlineMeeting` add-in gaps.
+- `SchedulingEventDto` already declares all target fields; this feature wires the previously-hardcoded placeholders in `SchedulingDtoMapper.MapEvent` to the new `EventDto` fields.
+</content>
+</invoke>

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/spec.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/spec.md
@@ -1,0 +1,133 @@
+# mailbridge-eventdto-graph-fields — Spec
+
+- **Issue:** #72
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-12T22-20
+- **Status:** Approved
+- **Version:** 1.0
+
+## Overview
+
+Brief summary of the behavior and scope.
+- Target users/personas and primary use cases: The downstream agent triage pipeline (`SchedulingDtoMapper` → `DependencyScorer`) consumes calendar events normalized from Outlook. It currently receives placeholder values for several Graph-shaped fields (`Categories`, `IsOrganizer`, `IsOnlineMeeting`, `AllowNewTimeProposals`, `LastModifiedDateTime`) because `EventDto` does not carry them. This feature adds nine Graph-shaped fields to `EventDto` and populates them from Outlook COM analogs so that triage and scoring operate on real data.
+- Success metrics or expected impact: Nine fields are populated from the COM bridge for scanned calendar items; `SchedulingDtoMapper` can wire real values instead of placeholders; persistence round-trips the new fields in both SQLite caches without schema-migration failures.
+
+The authoritative source for COM-analog mappings, propagation surface, persistence impact, and source-compatibility is the research artifact `artifacts/research/2026-06-12-issue-72-eventdto-com-analogs-research.md`.
+
+## Behavior
+
+Describe how the feature should behave end-to-end.
+- Main user flow (happy path): `OutlookScanner.NormalizeEvent` reads an Outlook `AppointmentItem`, derives the nine new fields from their COM analogs, and constructs an `EventDto` carrying them. `ResponseShaper.ShapeEvent` applies mode-dependent redaction. The shaped DTO is persisted to the bridge SQLite cache (`CacheRepository`) and, downstream over the HTTP boundary, to the Core SQLite cache (`CoreCacheRepository`). Reads from either cache return the same field values that were written.
+- Alternate/edge flows:
+  - Recurring online meeting: a scan yields non-null `iCalUId`, `isOnlineMeeting=true`, and the correct `sensitivityLabel`. For an occurrence or exception, `seriesMasterId` is non-null; for the series master and non-recurring items, `seriesMasterId` is null.
+  - SAFE mode (non-enhanced): `bodyFull` is nulled together with `BodyPreview` and `IsRedacted=true`.
+  - ENHANCED mode: `bodyFull` is the raw full COM `Body` text, untruncated and with structure preserved.
+- Error handling and recovery behavior: COM read failures fall back to the existing optional-accessor contracts — `GetOptionalBool` returns `false`, `GetOptionalString` and `GetOptionalInt` and `GetOptionalDateTimeOffset` return null. `categories` never returns null; it returns a zero-length `string[]` when `Categories` is null or empty.
+
+## Inputs / Outputs
+
+- Inputs (CLI flags, files, env vars): No new CLI flags or environment variables. Inputs are the Outlook `AppointmentItem` COM properties listed in the COM-analog table below.
+- Outputs (artifacts, logs, telemetry): The nine new fields on `EventDto`, persisted in both SQLite caches and surfaced through the existing pipe/HTTP contracts. No new telemetry is introduced by this feature.
+- Config keys and defaults: No new config keys. `bodyFull` shaping is governed by the existing `BridgeSettings.Mode` value (`enhanced` vs other).
+- Versioning or backward-compatibility constraints: `EventDto` remains source-compatible. New parameters are appended to the positional record after the current last parameter (`ResponseStatus = null`), each optional with a default, so all existing positional callers continue to compile.
+
+## API / CLI Surface
+
+List commands, flags, request/response shapes, and examples.
+- Example invocations with expected outputs (concise): No CLI surface change. The contract change is the addition of nine fields to the `EventDto` record.
+- Contracts and validation rules: The new `EventDto` parameters, appended after `ResponseStatus = null`:
+
+```csharp
+string[]? Categories = null,
+bool IsOrganizer = false,
+bool IsOnlineMeeting = false,
+bool AllowNewTimeProposals = false,
+string? ICalUId = null,
+string? SeriesMasterId = null,
+DateTimeOffset? LastModifiedDateTime = null,
+string? BodyFull = null,
+string? SensitivityLabel = null
+```
+
+### COM-Analog Mapping (authoritative; confidence per research)
+
+| Field | Type | COM analog / derivation | Confidence | Fallback |
+|---|---|---|---|---|
+| `categories` | `string[]` | `AppointmentItem.Categories` (comma-space delimited string), split on `", "` with per-token trim | HIGH | Empty `string[]` (never null) |
+| `isOrganizer` | `bool` | Derived: `ResponseStatus == 1` (olResponseOrganized); no address-book lookup | HIGH | `false` |
+| `isOnlineMeeting` | `bool` | `AppointmentItem.IsOnlineMeeting` | MEDIUM | `false` |
+| `allowNewTimeProposals` | `bool` | `AppointmentItem.AllowNewTimeProposal` (COM property is singular) | HIGH | `false` |
+| `iCalUId` | `string?` | Reuse `GlobalAppointmentID` (already on the DTO); MAPI `PidLidGlobalObjectId` path rejected | HIGH (no native iCalUId); MEDIUM (GlobalAppointmentID relationship) | null |
+| `seriesMasterId` | `string?` | From `RecurrenceState` (OlRecurrenceState): null for not-recurring and master; `GlobalAppointmentID` for occurrence/exception | MEDIUM | null |
+| `lastModifiedDateTime` | `DateTimeOffset?` | `AppointmentItem.LastModificationTime` | HIGH | null |
+| `bodyFull` | `string?` | Raw full `AppointmentItem.Body`, untruncated, not normalized | HIGH | null |
+| `sensitivityLabel` | `string?` (normal/personal/private/confidential) | Derived from the existing `Sensitivity` int via `SchedulingDtoMapper.MapSensitivity` mapping (0=normal,1=personal,2=private,3=confidential) | HIGH | null for unrecognized values |
+
+## Data & State
+
+Data flow, storage, or state changes introduced by this feature.
+- Data transformations and invariants:
+  - `categories` is always a non-null `string[]`; empty when the source is null/empty.
+  - `bodyFull` is the raw COM `Body` text. COM `Body` is plain text (HTML is in `HTMLBody`), so tag-stripping is not relevant. `bodyFull` is NOT passed through `BodySanitizer.NormalizePreview`, which truncates and collapses whitespace.
+  - `sensitivityLabel` is derived from the existing `Sensitivity` int and reuses the `SchedulingDtoMapper.MapSensitivity` switch logic; it is not an independent COM read.
+  - `iCalUId` equals `GlobalAppointmentID`. This is an Outlook-specific opaque identifier, not the RFC 5545 UID. Downstream consumers treating `iCalUId` as a true iCalendar UID may not achieve cross-system interoperability. This limitation is accepted for #72.
+  - `seriesMasterId` derivation depends on the OlRecurrenceState integer mapping (NotRecurring=0, Master=1, Occurrence=2, Exception=3). The exact integer assignment for master/occurrence/exception is to be confirmed at implementation time (research OQ-1); the logic must return null for the master and non-recurring cases and `GlobalAppointmentID` for occurrence/exception cases.
+- Caching or persistence details: New columns are required in BOTH SQLite caches.
+  - `src/OpenClaw.MailBridge/CacheRepository.cs`: add eight new columns via the existing idempotent `MigrateEventsSchemaAsync` ALTER-TABLE pattern (`categories_json` TEXT NULL, `is_organizer`, `is_online_meeting`, `allow_new_time_proposals` INTEGER NOT NULL DEFAULT 0, `ical_uid`, `series_master_id`, `body_full`, `sensitivity_label` TEXT NULL). `lastModifiedDateTime` reuses the already-present-but-unwired `last_modified_utc` column; no migration is needed for it, but the write must be wired.
+  - `src/OpenClaw.Core/CoreCacheRepository.cs`: add the mirroring columns via a new idempotent migration helper modeled on `MigrateEventsSchemaAsync`. The `ReadEvent` materializer must be extended to read the new columns.
+  - `categories` is serialized as a JSON array column (`categories_json`), consistent with the existing `RequiredAttendeesJson`/`ResourcesJson` columns.
+- Migration or backfill requirements (if any): Additive idempotent schema migrations only. No backfill of existing rows is required; pre-existing rows default to the optional defaults on read.
+
+## Constraints & Risks
+
+Performance, compatibility, security, rollout constraints.
+- Limits (latency/throughput/memory) and acceptable trade-offs: COM `Body` is read once already in `NormalizeEvent`; the implementation reads it once into a local and uses it for both `BodyPreview` and `bodyFull` to avoid a redundant COM read.
+- Security/privacy considerations: `bodyFull` carries full appointment body text. `ResponseShaper.ShapeEvent` MUST null `bodyFull` in SAFE mode together with `BodyPreview`. Failing to do so is a redaction regression that leaks body content in SAFE mode.
+- Operational/rollout risks and mitigations:
+  - `isOnlineMeeting` (MEDIUM confidence) returns `false` for some third-party add-in meetings (for example Teams meetings inserted via the Teams Outlook add-in may report `false` despite containing a join URL). No `Location`/`Body` heuristic is used; the known gap is accepted. Downstream consumers can layer heuristics if needed.
+  - The two SQLite `ReadEvent` materializers construct `EventDto` positionally; after appending optional parameters they continue to compile but will not populate the new fields until explicitly extended to read the new columns. Both reader methods must be updated.
+
+## Implementation Strategy
+
+- Implementation scope (what changes, not sequencing):
+  - `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` — append nine optional parameters to `EventDto`.
+  - `src/OpenClaw.MailBridge/OutlookScanner.cs` `NormalizeEvent` — populate the nine fields from the COM analogs/derivations.
+  - `src/OpenClaw.MailBridge/ResponseShaper.cs` `ShapeEvent` — null `bodyFull` in SAFE mode; return full untruncated `bodyFull` in ENHANCED mode.
+  - `src/OpenClaw.MailBridge/CacheRepository.cs` and `CacheRepository.Readers.cs` — extend the DDL, `MigrateEventsSchemaAsync`, `AddEventParameters` (including wiring `last_modified_utc`), and `ReadEvent`.
+  - `src/OpenClaw.Core/CoreCacheRepository.cs` — extend the DDL, add a mirroring idempotent migration helper, extend `AddEventParameters` and `ReadEvent`.
+  - `src/OpenClaw.Core/Agent/Runtime/SchedulingDtoMapper.cs` — wire the nine new fields through `MapEvent` in place of the current placeholder values; reuse `MapSensitivity` for `sensitivityLabel`.
+- New classes/functions/commands to add or update: No new public classes are required. A private helper for the `categories` string split may be added in `NormalizeEvent`; a `GetOptionalStringArray` helper in `OutlookComHelpers` is optional and not required.
+- Dependency changes (new/removed packages) and rationale: None.
+- Logging/telemetry additions and locations: None.
+- Rollout plan (feature flags, staged deploys, fallback path): No feature flag. The change is additive and source-compatible. The `bodyFull` shaping is governed by the existing `BridgeSettings.Mode` value.
+
+### Locked Design Decisions (authoritative — do not reopen)
+
+- **Source compatibility:** New parameters are appended after `ResponseStatus = null`, each optional with a default.
+- **`bodyFull` shaping/redaction:** ENHANCED = raw full COM `Body`, not passed through `BodySanitizer.NormalizePreview`. SAFE = nulled with `BodyPreview`, `IsRedacted=true`. `ResponseShaper.ShapeEvent` must null `bodyFull` in SAFE mode.
+- **`sensitivityLabel`:** Field on `EventDto` (enum string), derived from the existing `Sensitivity` int using 0=normal, 1=personal, 2=private, 3=confidential (reuse `SchedulingDtoMapper.MapSensitivity`).
+- **`categories` persistence:** JSON array column in both SQLite caches.
+- **`isOrganizer` derivation:** `ResponseStatus == 1` (olResponseOrganized); no address-book lookup.
+- **`iCalUId` derivation:** Reuse `GlobalAppointmentID`; MAPI `PidLidGlobalObjectId` path rejected as disproportionate.
+- **`seriesMasterId` derivation:** From `RecurrenceState`; null for non-recurring and master items.
+- **`isOnlineMeeting`:** COM `IsOnlineMeeting` (MEDIUM confidence; documented add-in limitation).
+- **`allowNewTimeProposals`:** COM `AllowNewTimeProposal` (singular).
+- **`lastModifiedDateTime`:** COM `LastModificationTime`.
+- **Persistence:** New columns in both `CacheRepository` (idempotent ALTER-TABLE) and `CoreCacheRepository` (mirroring idempotent helper); bridge `lastModifiedDateTime` reuses `last_modified_utc`.
+
+### Non-Goals / Constraints
+
+- The pre-existing `CoreCacheRepository` missing-`response_status`-column gap is OUT of scope for #72 and is tracked separately as issue #80.
+- The MAPI named-property (`PidLidGlobalObjectId`) path for a true iCalendar UID is out of scope.
+- `Location`/`Body` heuristics to compensate for `isOnlineMeeting` add-in gaps are out of scope.
+
+## Definition of Done
+
+- [x] Acceptance criteria documented and mapped to tests or demos
+- [x] Behavior matches acceptance criteria in all documented environments
+- [x] Tests updated/added (unit/integration as applicable)
+- [x] Edge cases and error handling covered by tests
+- [x] Docs updated (README, docs/features/active/... links)
+- [x] Telemetry/logging added or updated (if applicable)
+- [x] Toolchain pass completed (format → lint → type-check → test)

--- a/docs/features/active/mailbridge-eventdto-graph-fields-72/user-story.md
+++ b/docs/features/active/mailbridge-eventdto-graph-fields-72/user-story.md
@@ -1,0 +1,45 @@
+# `mailbridge-eventdto-graph-fields` — User Story
+
+- Issue: #72
+- Owner: drmoisan
+- Status: Approved
+- Last Updated: 2026-06-12T22-20
+
+## Story Statement
+
+- As the downstream agent triage pipeline (`SchedulingDtoMapper` → `DependencyScorer`), I want `EventDto` to carry the nine Graph-shaped calendar fields populated from Outlook COM, so that scoring and triage operate on real values instead of hardcoded placeholders.
+- As a maintainer of the bridge, I want the new fields appended to `EventDto` source-compatibly and round-tripped through both SQLite caches, so that the change adds capability without breaking existing callers or persistence.
+
+## Problem / Why
+
+`EventDto` does not carry several fields that the Graph-shaped consumer model expects (`categories`, `isOrganizer`, `isOnlineMeeting`, `allowNewTimeProposals`, `iCalUId`, `seriesMasterId`, `lastModifiedDateTime`, full body, sensitivity label). `SchedulingDtoMapper.MapEvent` currently substitutes placeholder values (`Array.Empty<string>()`, `false`, `null`) for the fields it cannot source. As a result, triage signals that depend on these fields — for example `isOnlineMeeting` contributing a dependency point and `categories` matching protected categories — cannot be computed accurately. Populating the fields from their Outlook COM analogs is the prerequisite for accurate triage.
+
+## Personas & Scenarios
+
+- Persona: Triage pipeline consumer
+  - who the user is: The agent runtime code that maps `EventDto` to `SchedulingEventDto` and scores meeting dependencies.
+  - what they care about: Accurate, populated calendar fields; deterministic mapping; no placeholder data.
+  - their constraints: Reads only cached, contract-shaped data over the HTTP boundary; does not call Outlook directly.
+  - their goals and frustrations: Goal is correct dependency scoring; current frustration is that several scoring inputs are hardcoded placeholders.
+  - their context and motivations: Operates downstream of the COM bridge and depends on the bridge to supply real field values.
+- Scenario: Scanning a recurring online meeting
+  - who is acting? The bridge scanner (`OutlookScanner.NormalizeEvent`) during a calendar scan.
+  - what triggered the action? A scheduled or requested calendar scan reaches a recurring online meeting appointment.
+  - what steps do they take? The scanner reads the COM analogs, derives `isOrganizer` from `ResponseStatus`, derives `seriesMasterId` from `RecurrenceState`, maps `sensitivityLabel` from the `Sensitivity` int, reuses `GlobalAppointmentID` for `iCalUId`, and reads `IsOnlineMeeting`, `AllowNewTimeProposal`, `LastModificationTime`, `Categories`, and `Body`.
+  - what obstacles or decisions occur? In SAFE mode, `bodyFull` must be nulled with `BodyPreview`. `isOnlineMeeting` may report `false` for some add-in meetings (MEDIUM confidence).
+  - what outcome do they expect? The resulting `EventDto` has non-null `iCalUId`, `isOnlineMeeting=true`, and the correct `sensitivityLabel`, and persists/reads back identically from both caches.
+
+## Acceptance Criteria
+
+- [x] `EventDto` exposes all nine new fields with the specified types and remains source-compatible (all existing in-repo callers compile without modification to their call sites).
+- [x] `OutlookScanner.NormalizeEvent` populates all nine fields from the specified COM analogs/derivations.
+- [x] `ResponseShaper.ShapeEvent` nulls `bodyFull` in safe mode (redaction parity with `BodyPreview`); enhanced mode returns the full untruncated `bodyFull`.
+- [x] Both SQLite caches (`CacheRepository`, `CoreCacheRepository`) round-trip all nine new fields (write then read returns the same values), with idempotent schema migrations.
+- [x] A scan of a recurring online meeting yields non-null `iCalUId`, `isOnlineMeeting=true`, and the correct `sensitivityLabel`.
+- [x] Existing contract tests pass; new unit tests cover the new fields, the safe/enhanced shaping of `bodyFull`, and the cache round-trip. Coverage thresholds hold: line >= 85%, branch >= 75% (T2).
+
+## Non-Goals
+
+- The pre-existing `CoreCacheRepository` missing-`response_status`-column gap is excluded from #72 and tracked separately as issue #80.
+- The MAPI named-property (`PidLidGlobalObjectId`) path for a true RFC 5545 iCalendar UID is excluded; `iCalUId` reuses `GlobalAppointmentID`.
+- `Location`/`Body` heuristics to compensate for `isOnlineMeeting` add-in detection gaps are excluded.

--- a/src/OpenClaw.Core/Agent/Contracts/SchedulingEventDto.cs
+++ b/src/OpenClaw.Core/Agent/Contracts/SchedulingEventDto.cs
@@ -2,8 +2,10 @@ namespace OpenClaw.Core.Agent;
 
 /// <summary>
 /// Graph-shaped scheduling event (D6), mirroring the <c>GraphEvent</c> type in master
-/// Section 9.2. Fields not yet available from the bridge cache (issues #71-#76) are
-/// mapped to null/empty by the runtime mapper and remain so until those issues land.
+/// Section 9.2. The event Graph fields (iCalUId, seriesMasterId, categories, isOrganizer,
+/// online-meeting and new-time-proposal flags, last-modified time) are supplied by the bridge
+/// cache as of #72 and populated by the runtime mapper. Body content/content-type remain null
+/// until a later issue lands.
 /// </summary>
 /// <param name="Id">The event identifier, or null.</param>
 /// <param name="ICalUId">The cross-store iCalendar identifier, or null.</param>

--- a/src/OpenClaw.Core/Agent/Runtime/SchedulingDtoMapper.cs
+++ b/src/OpenClaw.Core/Agent/Runtime/SchedulingDtoMapper.cs
@@ -12,11 +12,11 @@ namespace OpenClaw.Core.Agent.Runtime;
 /// no new project reference is added.
 /// </summary>
 /// <remarks>
-/// Several Graph fields are not yet available from the bridge cache and remain
-/// null/empty until issues #71-#76 land: message conversation id, meeting-message type,
-/// from/sender split, To/Cc recipients, body content type, event iCalUId,
-/// seriesMasterId, categories, online-meeting and new-time-proposal flags, last-modified
-/// time, and event type. The mapper maps these to null or empty deterministically.
+/// The event Graph fields iCalUId, seriesMasterId, categories, isOrganizer, online-meeting and
+/// new-time-proposal flags, and last-modified time are supplied by the bridge cache as of #72 and
+/// are mapped through directly. Some message Graph fields remain unavailable until later issues
+/// (#71-#76) land — message conversation id, from/sender split nuances, and body content type —
+/// and are mapped to null deterministically.
 /// </remarks>
 public sealed class SchedulingDtoMapper
 {
@@ -57,7 +57,9 @@ public sealed class SchedulingDtoMapper
 
     /// <summary>
     /// Maps a bridge <see cref="EventDto"/> to a Graph-shaped
-    /// <see cref="SchedulingEventDto"/>. Absent Graph fields map to null/empty (#71-#76).
+    /// <see cref="SchedulingEventDto"/>. The event Graph fields supplied by #72 (iCalUId,
+    /// seriesMasterId, categories, isOrganizer, online-meeting and new-time-proposal flags,
+    /// last-modified time) map through directly; body content type remains null.
     /// </summary>
     /// <param name="evt">The bridge event. Must not be null.</param>
     /// <returns>The Graph-shaped scheduling event.</returns>
@@ -68,10 +70,10 @@ public sealed class SchedulingDtoMapper
 
         return new SchedulingEventDto(
             Id: evt.BridgeId,
-            // iCalUId, seriesMasterId, categories, online-meeting and new-time-proposal
-            // flags, last-modified time, and event type are not yet available (#71-#76).
-            ICalUId: evt.GlobalAppointmentId,
-            SeriesMasterId: null,
+            // iCalUId reuses GlobalAppointmentID, populated by the bridge scanner into
+            // EventDto.ICalUId (#72); the mapper consumes the contract field directly.
+            ICalUId: evt.ICalUId,
+            SeriesMasterId: evt.SeriesMasterId,
             Subject: evt.Subject,
             BodyPreview: evt.BodyPreview,
             BodyContent: null,
@@ -80,17 +82,16 @@ public sealed class SchedulingDtoMapper
             RequiredAttendees: ParseAttendees(evt.RequiredAttendeesJson),
             OptionalAttendees: ParseAttendees(evt.OptionalAttendeesJson),
             ResourceAttendees: ParseAttendees(evt.ResourcesJson),
-            Categories: Array.Empty<string>(),
-            // The bridge cache does not yet expose the owner-organizer flag (#71-#76).
-            IsOrganizer: false,
-            IsOnlineMeeting: false,
-            AllowNewTimeProposals: false,
+            Categories: evt.Categories ?? Array.Empty<string>(),
+            IsOrganizer: evt.IsOrganizer,
+            IsOnlineMeeting: evt.IsOnlineMeeting,
+            AllowNewTimeProposals: evt.AllowNewTimeProposals,
             Sensitivity: MapSensitivity(evt.Sensitivity),
             Start: evt.StartUtc,
             StartTimeZone: "UTC",
             End: evt.EndUtc,
             EndTimeZone: "UTC",
-            LastModifiedDateTime: null,
+            LastModifiedDateTime: evt.LastModifiedDateTime,
             // The series-master type is inferred from the recurrence flag where possible.
             Type: evt.IsRecurring ? "seriesMaster" : null
         );

--- a/src/OpenClaw.Core/CoreCacheRepository.Schema.cs
+++ b/src/OpenClaw.Core/CoreCacheRepository.Schema.cs
@@ -1,0 +1,158 @@
+using Microsoft.Data.Sqlite;
+
+namespace OpenClaw.Core;
+
+/// <summary>
+/// Schema DDL and idempotent migration helpers for <see cref="CoreCacheRepository"/>. Split into a
+/// partial-class file so the (pre-existing over-cap) <c>CoreCacheRepository.cs</c> does not grow
+/// further after the issue-#72 column additions. The Core <c>events</c> schema mirrors the bridge
+/// cache's Graph-field columns and adds <c>last_modified_utc</c>, which the Core schema previously
+/// lacked. Per the spec Non-Goals (issue #80), no <c>response_status</c> column is added here.
+/// </summary>
+internal sealed partial class CoreCacheRepository
+{
+    private const string CreateTablesSql =
+        @"
+CREATE TABLE IF NOT EXISTS bridge_status_snapshots(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    request_id TEXT NOT NULL,
+    observed_at_utc TEXT NOT NULL,
+    state TEXT NOT NULL,
+    mode TEXT NOT NULL,
+    outlook_connected INTEGER NOT NULL,
+    cache_stale INTEGER NOT NULL,
+    stale_reason TEXT NULL,
+    last_inbox_scan_utc TEXT NULL,
+    last_calendar_scan_utc TEXT NULL
+);
+CREATE TABLE IF NOT EXISTS messages(
+    bridge_id TEXT PRIMARY KEY,
+    item_kind TEXT NOT NULL,
+    subject TEXT NULL,
+    received_utc TEXT NULL,
+    sent_utc TEXT NULL,
+    importance INTEGER NULL,
+    sensitivity INTEGER NULL,
+    unread INTEGER NOT NULL,
+    has_attachments INTEGER NOT NULL,
+    message_class TEXT NULL,
+    sender_name TEXT NULL,
+    sender_email TEXT NULL,
+    to_json TEXT NULL,
+    cc_json TEXT NULL,
+    body_preview TEXT NULL,
+    protected_fields_available INTEGER NOT NULL,
+    is_redacted INTEGER NOT NULL,
+    bridge_mode TEXT NOT NULL,
+    cache_stale INTEGER NOT NULL,
+    stale_reason TEXT NULL,
+    adapter_request_id TEXT NOT NULL,
+    observed_at_utc TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS events(
+    bridge_id TEXT PRIMARY KEY,
+    global_appointment_id TEXT NULL,
+    subject TEXT NULL,
+    start_utc TEXT NOT NULL,
+    end_utc TEXT NOT NULL,
+    location TEXT NULL,
+    busy_status INTEGER NULL,
+    meeting_status INTEGER NULL,
+    is_recurring INTEGER NOT NULL,
+    sensitivity INTEGER NULL,
+    organizer TEXT NULL,
+    required_attendees_json TEXT NULL,
+    optional_attendees_json TEXT NULL,
+    resources_json TEXT NULL,
+    body_preview TEXT NULL,
+    protected_fields_available INTEGER NOT NULL,
+    is_redacted INTEGER NOT NULL,
+    bridge_mode TEXT NOT NULL,
+    cache_stale INTEGER NOT NULL,
+    stale_reason TEXT NULL,
+    adapter_request_id TEXT NOT NULL,
+    observed_at_utc TEXT NOT NULL,
+    last_modified_utc TEXT NULL,
+    categories_json TEXT NULL,
+    is_organizer INTEGER NOT NULL DEFAULT 0,
+    is_online_meeting INTEGER NOT NULL DEFAULT 0,
+    allow_new_time_proposals INTEGER NOT NULL DEFAULT 0,
+    ical_uid TEXT NULL,
+    series_master_id TEXT NULL,
+    body_full TEXT NULL,
+    sensitivity_label TEXT NULL
+);
+CREATE TABLE IF NOT EXISTS poll_cursors(
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    observed_at_utc TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS ingest_runs(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    operation_name TEXT NOT NULL,
+    outcome TEXT NOT NULL,
+    request_id TEXT NULL,
+    started_at_utc TEXT NOT NULL,
+    finished_at_utc TEXT NOT NULL,
+    error_message TEXT NULL
+);";
+
+    /// <summary>
+    /// The issue-#72 columns added to the Core <c>events</c> table on existing databases via
+    /// guarded ALTER. Includes <c>last_modified_utc</c> because the Core schema did not previously
+    /// have it. The <c>response_status</c> column is intentionally NOT added here; that gap is
+    /// deferred to issue #80 per the spec Non-Goals. Each entry is a column name plus its
+    /// column definition.
+    /// </summary>
+    private static readonly (string Name, string Definition)[] GraphFieldColumns =
+    [
+        ("last_modified_utc", "last_modified_utc TEXT NULL"),
+        ("categories_json", "categories_json TEXT NULL"),
+        ("is_organizer", "is_organizer INTEGER NOT NULL DEFAULT 0"),
+        ("is_online_meeting", "is_online_meeting INTEGER NOT NULL DEFAULT 0"),
+        ("allow_new_time_proposals", "allow_new_time_proposals INTEGER NOT NULL DEFAULT 0"),
+        ("ical_uid", "ical_uid TEXT NULL"),
+        ("series_master_id", "series_master_id TEXT NULL"),
+        ("body_full", "body_full TEXT NULL"),
+        ("sensitivity_label", "sensitivity_label TEXT NULL"),
+    ];
+
+    /// <summary>
+    /// Idempotent schema migration for the Core <c>events</c> table. Adds the issue-#72 Graph-field
+    /// columns (and <c>last_modified_utc</c>) when absent on an existing database. Running this
+    /// twice is safe: each ALTER is guarded by a <c>PRAGMA table_info</c> check, so no
+    /// "duplicate column" error occurs.
+    /// </summary>
+    private static async Task MigrateEventsSchemaAsync(SqliteConnection connection)
+    {
+        foreach (var (name, definition) in GraphFieldColumns)
+        {
+            if (!await EventsColumnExistsAsync(connection, name))
+            {
+                var alter = connection.CreateCommand();
+                alter.CommandText = $"ALTER TABLE events ADD COLUMN {definition};";
+                await alter.ExecuteNonQueryAsync();
+            }
+        }
+    }
+
+    private static async Task<bool> EventsColumnExistsAsync(
+        SqliteConnection connection,
+        string column
+    )
+    {
+        var cmd = connection.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info(events);";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            // table_info column index 1 is the column name.
+            var name = reader.GetString(1);
+            if (string.Equals(name, column, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/OpenClaw.Core/CoreCacheRepository.cs
+++ b/src/OpenClaw.Core/CoreCacheRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using OpenClaw.MailBridge.Contracts.Models;
 
@@ -11,7 +12,7 @@ internal sealed record StoredBridgeStatusSnapshot(
     DateTimeOffset ObservedAtUtc
 );
 
-internal sealed class CoreCacheRepository : IDisposable
+internal sealed partial class CoreCacheRepository : IDisposable
 {
     private readonly string connectionString;
     private readonly SqliteConnection? anchor;
@@ -53,84 +54,9 @@ internal sealed class CoreCacheRepository : IDisposable
         await using var connection = Open();
         await connection.OpenAsync();
 
-        const string sql =
-            @"
-CREATE TABLE IF NOT EXISTS bridge_status_snapshots(
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    request_id TEXT NOT NULL,
-    observed_at_utc TEXT NOT NULL,
-    state TEXT NOT NULL,
-    mode TEXT NOT NULL,
-    outlook_connected INTEGER NOT NULL,
-    cache_stale INTEGER NOT NULL,
-    stale_reason TEXT NULL,
-    last_inbox_scan_utc TEXT NULL,
-    last_calendar_scan_utc TEXT NULL
-);
-CREATE TABLE IF NOT EXISTS messages(
-    bridge_id TEXT PRIMARY KEY,
-    item_kind TEXT NOT NULL,
-    subject TEXT NULL,
-    received_utc TEXT NULL,
-    sent_utc TEXT NULL,
-    importance INTEGER NULL,
-    sensitivity INTEGER NULL,
-    unread INTEGER NOT NULL,
-    has_attachments INTEGER NOT NULL,
-    message_class TEXT NULL,
-    sender_name TEXT NULL,
-    sender_email TEXT NULL,
-    to_json TEXT NULL,
-    cc_json TEXT NULL,
-    body_preview TEXT NULL,
-    protected_fields_available INTEGER NOT NULL,
-    is_redacted INTEGER NOT NULL,
-    bridge_mode TEXT NOT NULL,
-    cache_stale INTEGER NOT NULL,
-    stale_reason TEXT NULL,
-    adapter_request_id TEXT NOT NULL,
-    observed_at_utc TEXT NOT NULL
-);
-CREATE TABLE IF NOT EXISTS events(
-    bridge_id TEXT PRIMARY KEY,
-    global_appointment_id TEXT NULL,
-    subject TEXT NULL,
-    start_utc TEXT NOT NULL,
-    end_utc TEXT NOT NULL,
-    location TEXT NULL,
-    busy_status INTEGER NULL,
-    meeting_status INTEGER NULL,
-    is_recurring INTEGER NOT NULL,
-    sensitivity INTEGER NULL,
-    organizer TEXT NULL,
-    required_attendees_json TEXT NULL,
-    optional_attendees_json TEXT NULL,
-    resources_json TEXT NULL,
-    body_preview TEXT NULL,
-    protected_fields_available INTEGER NOT NULL,
-    is_redacted INTEGER NOT NULL,
-    bridge_mode TEXT NOT NULL,
-    cache_stale INTEGER NOT NULL,
-    stale_reason TEXT NULL,
-    adapter_request_id TEXT NOT NULL,
-    observed_at_utc TEXT NOT NULL
-);
-CREATE TABLE IF NOT EXISTS poll_cursors(
-    key TEXT PRIMARY KEY,
-    value TEXT NOT NULL,
-    observed_at_utc TEXT NOT NULL
-);
-CREATE TABLE IF NOT EXISTS ingest_runs(
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    operation_name TEXT NOT NULL,
-    outcome TEXT NOT NULL,
-    request_id TEXT NULL,
-    started_at_utc TEXT NOT NULL,
-    finished_at_utc TEXT NOT NULL,
-    error_message TEXT NULL
-);";
+        await new SqliteCommand(CreateTablesSql, connection).ExecuteNonQueryAsync();
 
-        await new SqliteCommand(sql, connection).ExecuteNonQueryAsync();
+        await MigrateEventsSchemaAsync(connection);
     }
 
     public async Task UpsertBridgeStatusSnapshotAsync(
@@ -223,12 +149,16 @@ INSERT INTO events(
     bridge_id, global_appointment_id, subject, start_utc, end_utc, location, busy_status,
     meeting_status, is_recurring, sensitivity, organizer, required_attendees_json,
     optional_attendees_json, resources_json, body_preview, protected_fields_available,
-    is_redacted, bridge_mode, cache_stale, stale_reason, adapter_request_id, observed_at_utc)
+    is_redacted, bridge_mode, cache_stale, stale_reason, adapter_request_id, observed_at_utc,
+    last_modified_utc, categories_json, is_organizer, is_online_meeting, allow_new_time_proposals,
+    ical_uid, series_master_id, body_full, sensitivity_label)
 VALUES(
     $bridge_id, $global_appointment_id, $subject, $start_utc, $end_utc, $location, $busy_status,
     $meeting_status, $is_recurring, $sensitivity, $organizer, $required_attendees_json,
     $optional_attendees_json, $resources_json, $body_preview, $protected_fields_available,
-    $is_redacted, $bridge_mode, $cache_stale, $stale_reason, $adapter_request_id, $observed_at_utc)
+    $is_redacted, $bridge_mode, $cache_stale, $stale_reason, $adapter_request_id, $observed_at_utc,
+    $last_modified_utc, $categories_json, $is_organizer, $is_online_meeting, $allow_new_time_proposals,
+    $ical_uid, $series_master_id, $body_full, $sensitivity_label)
 ON CONFLICT(bridge_id) DO UPDATE SET
     global_appointment_id = excluded.global_appointment_id,
     subject = excluded.subject,
@@ -250,7 +180,16 @@ ON CONFLICT(bridge_id) DO UPDATE SET
     cache_stale = excluded.cache_stale,
     stale_reason = excluded.stale_reason,
     adapter_request_id = excluded.adapter_request_id,
-    observed_at_utc = excluded.observed_at_utc;";
+    observed_at_utc = excluded.observed_at_utc,
+    last_modified_utc = excluded.last_modified_utc,
+    categories_json = excluded.categories_json,
+    is_organizer = excluded.is_organizer,
+    is_online_meeting = excluded.is_online_meeting,
+    allow_new_time_proposals = excluded.allow_new_time_proposals,
+    ical_uid = excluded.ical_uid,
+    series_master_id = excluded.series_master_id,
+    body_full = excluded.body_full,
+    sensitivity_label = excluded.sensitivity_label;";
             AddEventParameters(command, evt, bridgeStatus, requestId, observedAtUtc);
             await command.ExecuteNonQueryAsync();
         }
@@ -586,6 +525,53 @@ LIMIT 1;";
             "$observed_at_utc",
             observedAtUtc.UtcDateTime.ToString("O")
         );
+        command.Parameters.AddWithValue("$last_modified_utc", ToDbValue(evt.LastModifiedDateTime));
+        command.Parameters.AddWithValue("$categories_json", CategoriesToDbValue(evt.Categories));
+        command.Parameters.AddWithValue("$is_organizer", evt.IsOrganizer ? 1 : 0);
+        command.Parameters.AddWithValue("$is_online_meeting", evt.IsOnlineMeeting ? 1 : 0);
+        command.Parameters.AddWithValue(
+            "$allow_new_time_proposals",
+            evt.AllowNewTimeProposals ? 1 : 0
+        );
+        command.Parameters.AddWithValue("$ical_uid", (object?)evt.ICalUId ?? DBNull.Value);
+        command.Parameters.AddWithValue(
+            "$series_master_id",
+            (object?)evt.SeriesMasterId ?? DBNull.Value
+        );
+        command.Parameters.AddWithValue("$body_full", (object?)evt.BodyFull ?? DBNull.Value);
+        command.Parameters.AddWithValue(
+            "$sensitivity_label",
+            (object?)evt.SensitivityLabel ?? DBNull.Value
+        );
+    }
+
+    /// <summary>
+    /// Serializes the optional <c>Categories</c> array to a JSON array column value, consistent
+    /// with the existing attendee/resource JSON columns. A null array stores SQL NULL.
+    /// </summary>
+    private static object CategoriesToDbValue(string[]? categories) =>
+        categories is null ? DBNull.Value : JsonSerializer.Serialize(categories);
+
+    /// <summary>
+    /// Deserializes the <c>categories_json</c> column to a string array. A NULL or unparseable
+    /// value yields null, matching the optional <see cref="EventDto.Categories"/> default.
+    /// </summary>
+    private static string[]? ReadCategories(SqliteDataReader reader, string name)
+    {
+        var json = ReadString(reader, name);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<string[]>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     private static async Task<int> CountAsync(SqliteConnection connection, string sql)
@@ -657,7 +643,17 @@ LIMIT 1;";
             ReadString(reader, "resources_json"),
             ReadString(reader, "body_preview"),
             ReadBoolean(reader, "protected_fields_available"),
-            ReadBoolean(reader, "is_redacted")
+            ReadBoolean(reader, "is_redacted"),
+            ResponseStatus: null,
+            Categories: ReadCategories(reader, "categories_json"),
+            IsOrganizer: ReadBoolean(reader, "is_organizer"),
+            IsOnlineMeeting: ReadBoolean(reader, "is_online_meeting"),
+            AllowNewTimeProposals: ReadBoolean(reader, "allow_new_time_proposals"),
+            ICalUId: ReadString(reader, "ical_uid"),
+            SeriesMasterId: ReadString(reader, "series_master_id"),
+            LastModifiedDateTime: ReadDateTimeOffset(reader, "last_modified_utc"),
+            BodyFull: ReadString(reader, "body_full"),
+            SensitivityLabel: ReadString(reader, "sensitivity_label")
         );
 
     private static object ToDbValue(DateTimeOffset? value) =>

--- a/src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs
+++ b/src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs
@@ -109,7 +109,16 @@ public sealed record EventDto(
     string? BodyPreview,
     bool ProtectedFieldsAvailable,
     bool IsRedacted,
-    int? ResponseStatus = null
+    int? ResponseStatus = null,
+    string[]? Categories = null,
+    bool IsOrganizer = false,
+    bool IsOnlineMeeting = false,
+    bool AllowNewTimeProposals = false,
+    string? ICalUId = null,
+    string? SeriesMasterId = null,
+    DateTimeOffset? LastModifiedDateTime = null,
+    string? BodyFull = null,
+    string? SensitivityLabel = null
 );
 
 public sealed record BridgeSettings(

--- a/src/OpenClaw.MailBridge.Contracts/Models/EventSensitivityLabel.cs
+++ b/src/OpenClaw.MailBridge.Contracts/Models/EventSensitivityLabel.cs
@@ -1,0 +1,41 @@
+namespace OpenClaw.MailBridge.Contracts.Models;
+
+/// <summary>
+/// Maps the Outlook <c>Sensitivity</c> integer to the Graph-shaped sensitivity label string
+/// carried by <see cref="EventDto.SensitivityLabel"/>. Mirrors the
+/// <c>SchedulingDtoMapper.MapSensitivity</c> switch (0=normal, 1=personal, 2=private,
+/// 3=confidential) so the bridge and the downstream agent agree on the label vocabulary.
+/// </summary>
+public static class EventSensitivityLabel
+{
+    /// <summary>The Outlook <c>olNormal</c> sensitivity.</summary>
+    public const string Normal = "normal";
+
+    /// <summary>The Outlook <c>olPersonal</c> sensitivity.</summary>
+    public const string Personal = "personal";
+
+    /// <summary>The Outlook <c>olPrivate</c> sensitivity.</summary>
+    public const string Private = "private";
+
+    /// <summary>The Outlook <c>olConfidential</c> sensitivity.</summary>
+    public const string Confidential = "confidential";
+
+    /// <summary>
+    /// Maps an Outlook <c>Sensitivity</c> integer to its label string.
+    /// </summary>
+    /// <param name="sensitivity">
+    /// The Outlook sensitivity value: 0=normal, 1=personal, 2=private, 3=confidential.
+    /// </param>
+    /// <returns>
+    /// The matching label, or <c>null</c> for a null input or an unrecognized value.
+    /// </returns>
+    public static string? FromSensitivity(int? sensitivity) =>
+        sensitivity switch
+        {
+            0 => Normal,
+            1 => Personal,
+            2 => Private,
+            3 => Confidential,
+            _ => null,
+        };
+}

--- a/src/OpenClaw.MailBridge/CacheRepository.Readers.cs
+++ b/src/OpenClaw.MailBridge/CacheRepository.Readers.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using OpenClaw.MailBridge.Contracts.Models;
 
@@ -50,8 +51,39 @@ internal sealed partial class CacheRepository
             GetString(reader, "body_preview"),
             GetBoolean(reader, "protected_fields_available"),
             GetBoolean(reader, "is_redacted"),
-            GetNullableInt(reader, "response_status")
+            GetNullableInt(reader, "response_status"),
+            Categories: GetCategories(reader, "categories_json"),
+            IsOrganizer: GetBoolean(reader, "is_organizer"),
+            IsOnlineMeeting: GetBoolean(reader, "is_online_meeting"),
+            AllowNewTimeProposals: GetBoolean(reader, "allow_new_time_proposals"),
+            ICalUId: GetString(reader, "ical_uid"),
+            SeriesMasterId: GetString(reader, "series_master_id"),
+            LastModifiedDateTime: GetDateTimeOffset(reader, "last_modified_utc"),
+            BodyFull: GetString(reader, "body_full"),
+            SensitivityLabel: GetString(reader, "sensitivity_label")
         );
+
+    /// <summary>
+    /// Deserializes the <c>categories_json</c> column to a string array. A NULL or unparseable
+    /// value yields null, matching the optional <see cref="EventDto.Categories"/> default.
+    /// </summary>
+    private static string[]? GetCategories(SqliteDataReader reader, string name)
+    {
+        var json = GetString(reader, name);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<string[]>(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
 
     private static object ToDbValue(DateTimeOffset? value) =>
         value is null ? DBNull.Value : value.Value.UtcDateTime.ToString("O");

--- a/src/OpenClaw.MailBridge/CacheRepository.Schema.cs
+++ b/src/OpenClaw.MailBridge/CacheRepository.Schema.cs
@@ -1,0 +1,80 @@
+using Microsoft.Data.Sqlite;
+
+namespace OpenClaw.MailBridge;
+
+/// <summary>
+/// Schema DDL and idempotent migration helpers for <see cref="CacheRepository"/>. Split into a
+/// partial-class file to keep <c>CacheRepository.cs</c> within the repository 500-line cap after
+/// the issue-#72 column additions.
+/// </summary>
+internal sealed partial class CacheRepository
+{
+    private const string CreateTablesSql =
+        @"
+CREATE TABLE IF NOT EXISTS messages(bridge_id TEXT PRIMARY KEY,entry_id TEXT NOT NULL,store_id TEXT NULL,item_kind TEXT NOT NULL,subject TEXT NULL,received_utc TEXT NULL,sent_utc TEXT NULL,importance INTEGER NULL,sensitivity INTEGER NULL,unread INTEGER NOT NULL,has_attachments INTEGER NOT NULL,message_class TEXT NULL,sender_name TEXT NULL,sender_email TEXT NULL,to_json TEXT NULL,cc_json TEXT NULL,body_preview TEXT NULL,protected_fields_available INTEGER NOT NULL,is_redacted INTEGER NOT NULL,last_seen_utc TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS events(bridge_id TEXT PRIMARY KEY,entry_id TEXT NULL,store_id TEXT NULL,global_appointment_id TEXT NULL,item_kind TEXT NOT NULL,subject TEXT NULL,start_utc TEXT NOT NULL,end_utc TEXT NOT NULL,location TEXT NULL,busy_status INTEGER NULL,meeting_status INTEGER NULL,is_recurring INTEGER NOT NULL,sensitivity INTEGER NULL,organizer TEXT NULL,required_attendees_json TEXT NULL,optional_attendees_json TEXT NULL,resources_json TEXT NULL,body_preview TEXT NULL,protected_fields_available INTEGER NOT NULL,is_redacted INTEGER NOT NULL,last_modified_utc TEXT NULL,last_seen_utc TEXT NOT NULL,response_status INTEGER NULL,categories_json TEXT NULL,is_organizer INTEGER NOT NULL DEFAULT 0,is_online_meeting INTEGER NOT NULL DEFAULT 0,allow_new_time_proposals INTEGER NOT NULL DEFAULT 0,ical_uid TEXT NULL,series_master_id TEXT NULL,body_full TEXT NULL,sensitivity_label TEXT NULL);
+CREATE TABLE IF NOT EXISTS scan_state(key TEXT PRIMARY KEY,value TEXT NOT NULL);";
+
+    /// <summary>
+    /// The issue-#72 columns added to the <c>events</c> table on existing databases via guarded
+    /// ALTER. <c>last_modified_utc</c> already exists in the original schema and is not listed here
+    /// (only its write path is newly wired). Each entry is a column name plus its column definition.
+    /// </summary>
+    private static readonly (string Name, string Definition)[] GraphFieldColumns =
+    [
+        ("categories_json", "categories_json TEXT NULL"),
+        ("is_organizer", "is_organizer INTEGER NOT NULL DEFAULT 0"),
+        ("is_online_meeting", "is_online_meeting INTEGER NOT NULL DEFAULT 0"),
+        ("allow_new_time_proposals", "allow_new_time_proposals INTEGER NOT NULL DEFAULT 0"),
+        ("ical_uid", "ical_uid TEXT NULL"),
+        ("series_master_id", "series_master_id TEXT NULL"),
+        ("body_full", "body_full TEXT NULL"),
+        ("sensitivity_label", "sensitivity_label TEXT NULL"),
+    ];
+
+    /// <summary>
+    /// Idempotent schema migration for the <c>events</c> table. Adds the <c>response_status</c>
+    /// column and the eight issue-#72 Graph-field columns when absent on an existing database.
+    /// Running this twice is safe: each ALTER is guarded by a <c>PRAGMA table_info</c> check so no
+    /// "duplicate column" error occurs.
+    /// </summary>
+    private static async Task MigrateEventsSchemaAsync(SqliteConnection conn)
+    {
+        if (!await EventsColumnExistsAsync(conn, "response_status"))
+        {
+            await AddEventsColumnAsync(conn, "response_status INTEGER NULL");
+        }
+
+        foreach (var (name, definition) in GraphFieldColumns)
+        {
+            if (!await EventsColumnExistsAsync(conn, name))
+            {
+                await AddEventsColumnAsync(conn, definition);
+            }
+        }
+    }
+
+    private static async Task AddEventsColumnAsync(SqliteConnection conn, string columnDefinition)
+    {
+        var alter = conn.CreateCommand();
+        alter.CommandText = $"ALTER TABLE events ADD COLUMN {columnDefinition};";
+        await alter.ExecuteNonQueryAsync();
+    }
+
+    private static async Task<bool> EventsColumnExistsAsync(SqliteConnection conn, string column)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "PRAGMA table_info(events);";
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            // table_info column index 1 is the column name.
+            var name = reader.GetString(1);
+            if (string.Equals(name, column, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/OpenClaw.MailBridge/CacheRepository.cs
+++ b/src/OpenClaw.MailBridge/CacheRepository.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Data.Sqlite;
 using OpenClaw.MailBridge.Contracts.Models;
 
@@ -87,48 +88,9 @@ internal sealed partial class CacheRepository : IBridgeRepository, IDisposable
         await using var conn = Open();
         await conn.OpenAsync();
 
-        var sql =
-            @"
-CREATE TABLE IF NOT EXISTS messages(bridge_id TEXT PRIMARY KEY,entry_id TEXT NOT NULL,store_id TEXT NULL,item_kind TEXT NOT NULL,subject TEXT NULL,received_utc TEXT NULL,sent_utc TEXT NULL,importance INTEGER NULL,sensitivity INTEGER NULL,unread INTEGER NOT NULL,has_attachments INTEGER NOT NULL,message_class TEXT NULL,sender_name TEXT NULL,sender_email TEXT NULL,to_json TEXT NULL,cc_json TEXT NULL,body_preview TEXT NULL,protected_fields_available INTEGER NOT NULL,is_redacted INTEGER NOT NULL,last_seen_utc TEXT NOT NULL);
-CREATE TABLE IF NOT EXISTS events(bridge_id TEXT PRIMARY KEY,entry_id TEXT NULL,store_id TEXT NULL,global_appointment_id TEXT NULL,item_kind TEXT NOT NULL,subject TEXT NULL,start_utc TEXT NOT NULL,end_utc TEXT NOT NULL,location TEXT NULL,busy_status INTEGER NULL,meeting_status INTEGER NULL,is_recurring INTEGER NOT NULL,sensitivity INTEGER NULL,organizer TEXT NULL,required_attendees_json TEXT NULL,optional_attendees_json TEXT NULL,resources_json TEXT NULL,body_preview TEXT NULL,protected_fields_available INTEGER NOT NULL,is_redacted INTEGER NOT NULL,last_modified_utc TEXT NULL,last_seen_utc TEXT NOT NULL,response_status INTEGER NULL);
-CREATE TABLE IF NOT EXISTS scan_state(key TEXT PRIMARY KEY,value TEXT NOT NULL);";
-        await new SqliteCommand(sql, conn).ExecuteNonQueryAsync();
+        await new SqliteCommand(CreateTablesSql, conn).ExecuteNonQueryAsync();
 
         await MigrateEventsSchemaAsync(conn);
-    }
-
-    /// <summary>
-    /// Idempotent schema migration for the <c>events</c> table. Adds the <c>response_status</c>
-    /// column when it is absent on an existing database. Running this twice is safe: the
-    /// <c>PRAGMA table_info</c> check guards the ALTER so no "duplicate column" error occurs.
-    /// </summary>
-    private static async Task MigrateEventsSchemaAsync(SqliteConnection conn)
-    {
-        if (await EventsColumnExistsAsync(conn, "response_status"))
-        {
-            return;
-        }
-
-        var alter = conn.CreateCommand();
-        alter.CommandText = "ALTER TABLE events ADD COLUMN response_status INTEGER NULL;";
-        await alter.ExecuteNonQueryAsync();
-    }
-
-    private static async Task<bool> EventsColumnExistsAsync(SqliteConnection conn, string column)
-    {
-        var cmd = conn.CreateCommand();
-        cmd.CommandText = "PRAGMA table_info(events);";
-        await using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
-        {
-            // table_info column index 1 is the column name.
-            var name = reader.GetString(1);
-            if (string.Equals(name, column, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-        return false;
     }
 
     public async Task TouchScanStateAsync(string key, DateTimeOffset value)
@@ -265,12 +227,16 @@ INSERT INTO events(
     bridge_id, entry_id, store_id, global_appointment_id, item_kind, subject, start_utc, end_utc,
     location, busy_status, meeting_status, is_recurring, sensitivity, organizer,
     required_attendees_json, optional_attendees_json, resources_json, body_preview,
-    protected_fields_available, is_redacted, last_modified_utc, last_seen_utc, response_status
+    protected_fields_available, is_redacted, last_modified_utc, last_seen_utc, response_status,
+    categories_json, is_organizer, is_online_meeting, allow_new_time_proposals, ical_uid,
+    series_master_id, body_full, sensitivity_label
 ) VALUES(
     $bridge_id, $entry_id, $store_id, $global_appointment_id, $item_kind, $subject, $start_utc, $end_utc,
     $location, $busy_status, $meeting_status, $is_recurring, $sensitivity, $organizer,
     $required_attendees_json, $optional_attendees_json, $resources_json, $body_preview,
-    $protected_fields_available, $is_redacted, $last_modified_utc, $last_seen_utc, $response_status
+    $protected_fields_available, $is_redacted, $last_modified_utc, $last_seen_utc, $response_status,
+    $categories_json, $is_organizer, $is_online_meeting, $allow_new_time_proposals, $ical_uid,
+    $series_master_id, $body_full, $sensitivity_label
 )
 ON CONFLICT(bridge_id) DO UPDATE SET
     entry_id = excluded.entry_id,
@@ -294,7 +260,15 @@ ON CONFLICT(bridge_id) DO UPDATE SET
     is_redacted = excluded.is_redacted,
     last_modified_utc = excluded.last_modified_utc,
     last_seen_utc = excluded.last_seen_utc,
-    response_status = excluded.response_status;";
+    response_status = excluded.response_status,
+    categories_json = excluded.categories_json,
+    is_organizer = excluded.is_organizer,
+    is_online_meeting = excluded.is_online_meeting,
+    allow_new_time_proposals = excluded.allow_new_time_proposals,
+    ical_uid = excluded.ical_uid,
+    series_master_id = excluded.series_master_id,
+    body_full = excluded.body_full,
+    sensitivity_label = excluded.sensitivity_label;";
 
         AddEventParameters(cmd, entryId, storeId, globalAppointmentId, evt);
         await cmd.ExecuteNonQueryAsync();
@@ -455,11 +429,32 @@ LIMIT $limit;";
             evt.ProtectedFieldsAvailable ? 1 : 0
         );
         cmd.Parameters.AddWithValue("$is_redacted", evt.IsRedacted ? 1 : 0);
-        cmd.Parameters.AddWithValue("$last_modified_utc", DBNull.Value);
+        cmd.Parameters.AddWithValue("$last_modified_utc", ToDbValue(evt.LastModifiedDateTime));
         cmd.Parameters.AddWithValue(
             "$last_seen_utc",
             DateTimeOffset.UtcNow.UtcDateTime.ToString("O")
         );
         cmd.Parameters.AddWithValue("$response_status", ToDbValue(evt.ResponseStatus));
+        cmd.Parameters.AddWithValue("$categories_json", CategoriesToDbValue(evt.Categories));
+        cmd.Parameters.AddWithValue("$is_organizer", evt.IsOrganizer ? 1 : 0);
+        cmd.Parameters.AddWithValue("$is_online_meeting", evt.IsOnlineMeeting ? 1 : 0);
+        cmd.Parameters.AddWithValue("$allow_new_time_proposals", evt.AllowNewTimeProposals ? 1 : 0);
+        cmd.Parameters.AddWithValue("$ical_uid", (object?)evt.ICalUId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue(
+            "$series_master_id",
+            (object?)evt.SeriesMasterId ?? DBNull.Value
+        );
+        cmd.Parameters.AddWithValue("$body_full", (object?)evt.BodyFull ?? DBNull.Value);
+        cmd.Parameters.AddWithValue(
+            "$sensitivity_label",
+            (object?)evt.SensitivityLabel ?? DBNull.Value
+        );
     }
+
+    /// <summary>
+    /// Serializes the optional <c>Categories</c> array to a JSON array column value, consistent
+    /// with the existing attendee/resource JSON columns. A null array stores SQL NULL.
+    /// </summary>
+    private static object CategoriesToDbValue(string[]? categories) =>
+        categories is null ? DBNull.Value : JsonSerializer.Serialize(categories);
 }

--- a/src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs
+++ b/src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs
@@ -1,0 +1,104 @@
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.MailBridge;
+
+/// <summary>
+/// Graph-field derivation helpers and event construction for <see cref="OutlookScanner"/>
+/// (issue #72). These live in a partial-class file separate from <c>OutlookScanner.cs</c> so the
+/// latter (already at the repository 500-line cap) does not grow further. The derivation helpers
+/// are pure transforms over already-read COM values; <see cref="BuildEventDto"/> performs the COM
+/// reads for the nine new Graph-shaped fields, reading <c>Body</c> exactly once.
+/// </summary>
+internal sealed partial class OutlookScanner
+{
+    /// <summary>
+    /// Builds the <see cref="EventDto"/> for a calendar item, reading the COM <c>Body</c> once and
+    /// reusing it for both the redacted preview and the raw <c>BodyFull</c> value (spec "Limits"),
+    /// and populating the nine issue-#72 Graph-shaped fields from their COM analogs/derivations.
+    /// </summary>
+    private EventDto BuildEventDto(
+        object item,
+        string bridgeId,
+        string? globalAppointmentId,
+        DateTimeOffset startUtc,
+        DateTimeOffset endUtc
+    )
+    {
+        var body = OutlookComHelpers.GetOptionalString(item, "Body");
+        var sensitivity = OutlookComHelpers.GetOptionalInt(item, "Sensitivity");
+        var recurrenceState = OutlookComHelpers.GetOptionalInt(item, "RecurrenceState");
+        var responseStatus = OutlookComHelpers.GetOptionalInt(item, "ResponseStatus");
+
+        return new EventDto(
+            bridgeId,
+            globalAppointmentId,
+            OutlookComHelpers.GetOptionalString(item, "Subject"),
+            startUtc,
+            endUtc,
+            OutlookComHelpers.GetOptionalString(item, "Location"),
+            OutlookComHelpers.GetOptionalInt(item, "BusyStatus"),
+            OutlookComHelpers.GetOptionalInt(item, "MeetingStatus"),
+            OutlookComHelpers.GetOptionalBool(item, "IsRecurring"),
+            sensitivity,
+            OutlookComHelpers.GetOptionalString(item, "Organizer"),
+            null,
+            null,
+            null,
+            ResponseShaper.ShapePreview(body, _settings),
+            !string.IsNullOrWhiteSpace(body),
+            false,
+            responseStatus,
+            Categories: SplitCategories(OutlookComHelpers.GetOptionalString(item, "Categories")),
+            IsOrganizer: responseStatus == 1,
+            IsOnlineMeeting: OutlookComHelpers.GetOptionalBool(item, "IsOnlineMeeting"),
+            AllowNewTimeProposals: OutlookComHelpers.GetOptionalBool(item, "AllowNewTimeProposal"),
+            ICalUId: globalAppointmentId,
+            SeriesMasterId: DeriveSeriesMasterId(recurrenceState, globalAppointmentId),
+            LastModifiedDateTime: OutlookComHelpers.GetOptionalUtcDateTimeOffset(
+                item,
+                "LastModificationTime"
+            ),
+            BodyFull: body,
+            SensitivityLabel: EventSensitivityLabel.FromSensitivity(sensitivity)
+        );
+    }
+
+    /// <summary>
+    /// Splits the Outlook <c>Categories</c> string (comma-space delimited) into a category array.
+    /// Each token is trimmed and empty tokens are dropped. Returns an empty array (never null) for
+    /// null or whitespace input, satisfying the <c>categories</c> non-null invariant.
+    /// </summary>
+    private static string[] SplitCategories(string? categories)
+    {
+        if (string.IsNullOrWhiteSpace(categories))
+        {
+            return Array.Empty<string>();
+        }
+
+        return categories
+            .Split(", ", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(token => token.Length > 0)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Derives <c>seriesMasterId</c> from the Outlook <c>RecurrenceState</c>
+    /// (<c>OlRecurrenceState</c>) value (OQ-1): olApptNotRecurring=0 and olApptMaster=1 yield
+    /// null; olApptOccurrence=2 and olApptException=3 yield the supplied
+    /// <paramref name="globalAppointmentId"/>. Any other or null state yields null. The logic
+    /// returns null for the master and non-recurring cases and the global appointment id for the
+    /// occurrence and exception cases, so it is insensitive to alternate non-master integer
+    /// assignments as long as 0/1 mean non-recurring/master.
+    /// </summary>
+    private static string? DeriveSeriesMasterId(
+        int? recurrenceState,
+        string? globalAppointmentId
+    ) =>
+        recurrenceState switch
+        {
+            // 0 = olApptNotRecurring, 1 = olApptMaster -> no series-master pointer.
+            null or 0 or 1 => null,
+            // 2 = olApptOccurrence, 3 = olApptException -> point at the master via GlobalAppointmentID.
+            _ => globalAppointmentId,
+        };
+}

--- a/src/OpenClaw.MailBridge/OutlookScanner.cs
+++ b/src/OpenClaw.MailBridge/OutlookScanner.cs
@@ -444,29 +444,7 @@ internal sealed partial class OutlookScanner : IOutlookScanner
 
         var globalAppointmentId = OutlookComHelpers.GetOptionalString(item, "GlobalAppointmentID");
         var bridgeId = BridgeIdCodec.EventId(globalAppointmentId, entryId, startUtc.Value);
-        var dto = new EventDto(
-            bridgeId,
-            globalAppointmentId,
-            OutlookComHelpers.GetOptionalString(item, "Subject"),
-            startUtc.Value,
-            endUtc.Value,
-            OutlookComHelpers.GetOptionalString(item, "Location"),
-            OutlookComHelpers.GetOptionalInt(item, "BusyStatus"),
-            OutlookComHelpers.GetOptionalInt(item, "MeetingStatus"),
-            OutlookComHelpers.GetOptionalBool(item, "IsRecurring"),
-            OutlookComHelpers.GetOptionalInt(item, "Sensitivity"),
-            OutlookComHelpers.GetOptionalString(item, "Organizer"),
-            null,
-            null,
-            null,
-            ResponseShaper.ShapePreview(
-                OutlookComHelpers.GetOptionalString(item, "Body"),
-                _settings
-            ),
-            !string.IsNullOrWhiteSpace(OutlookComHelpers.GetOptionalString(item, "Body")),
-            false,
-            OutlookComHelpers.GetOptionalInt(item, "ResponseStatus")
-        );
+        var dto = BuildEventDto(item, bridgeId, globalAppointmentId, startUtc.Value, endUtc.Value);
 
         return new NormalizedEvent(entryId, GetStoreId(item), globalAppointmentId, dto);
     }

--- a/src/OpenClaw.MailBridge/ResponseShaper.cs
+++ b/src/OpenClaw.MailBridge/ResponseShaper.cs
@@ -40,6 +40,10 @@ internal static class ResponseShaper
         );
         var preview = ShapePreview(evt.BodyPreview, settings);
 
+        // Enhanced mode returns the full untruncated COM Body verbatim in BodyFull; it is NOT
+        // routed through BodySanitizer.NormalizePreview (which truncates/collapses whitespace).
+        // Safe mode nulls BodyFull alongside BodyPreview to preserve redaction parity, otherwise
+        // the full body text would leak in safe mode.
         return enhancedMode
             ? evt with
             {
@@ -49,6 +53,7 @@ internal static class ResponseShaper
             : evt with
             {
                 BodyPreview = null,
+                BodyFull = null,
                 IsRedacted = true,
             };
     }

--- a/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingDtoMapperTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingDtoMapperTests.cs
@@ -48,7 +48,14 @@ public sealed class SchedulingDtoMapperTests
         string? optional = null,
         string? resources = null,
         int? sensitivity = null,
-        bool isRecurring = false
+        bool isRecurring = false,
+        string[]? categories = null,
+        bool isOrganizer = false,
+        bool isOnlineMeeting = false,
+        bool allowNewTimeProposals = false,
+        string? iCalUId = "global-1",
+        string? seriesMasterId = null,
+        DateTimeOffset? lastModifiedDateTime = null
     ) =>
         new(
             BridgeId: "evt-1",
@@ -67,7 +74,15 @@ public sealed class SchedulingDtoMapperTests
             ResourcesJson: resources,
             BodyPreview: "Agenda",
             ProtectedFieldsAvailable: true,
-            IsRedacted: false
+            IsRedacted: false,
+            ResponseStatus: null,
+            Categories: categories,
+            IsOrganizer: isOrganizer,
+            IsOnlineMeeting: isOnlineMeeting,
+            AllowNewTimeProposals: allowNewTimeProposals,
+            ICalUId: iCalUId,
+            SeriesMasterId: seriesMasterId,
+            LastModifiedDateTime: lastModifiedDateTime
         );
 
     [TestMethod]
@@ -180,8 +195,10 @@ public sealed class SchedulingDtoMapperTests
     }
 
     [TestMethod]
-    public void MapEvent_DeferredFields_AreNullOrEmpty()
+    public void MapEvent_DefaultGraphFields_MapThroughAsNullOrEmpty()
     {
+        // With an EventDto carrying default (unset) graph fields, the mapper passes the defaults
+        // through: null seriesMasterId, empty categories, false flags, null last-modified.
         var result = mapper.MapEvent(Event());
 
         result.SeriesMasterId.Should().BeNull();
@@ -189,6 +206,62 @@ public sealed class SchedulingDtoMapperTests
         result.IsOnlineMeeting.Should().BeFalse();
         result.AllowNewTimeProposals.Should().BeFalse();
         result.LastModifiedDateTime.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void MapEvent_PopulatedGraphFields_MapThroughDirectly()
+    {
+        // #72: the mapper wires the populated EventDto graph fields into the SchedulingEventDto
+        // in place of the former hardcoded placeholders.
+        var lastModified = new DateTimeOffset(2026, 6, 5, 8, 0, 0, TimeSpan.Zero);
+        var result = mapper.MapEvent(
+            Event(
+                categories: ["Customer", "Critical"],
+                isOrganizer: true,
+                isOnlineMeeting: true,
+                allowNewTimeProposals: true,
+                seriesMasterId: "series-1",
+                lastModifiedDateTime: lastModified
+            )
+        );
+
+        result.Categories.Should().Equal("Customer", "Critical");
+        result.IsOrganizer.Should().BeTrue();
+        result.IsOnlineMeeting.Should().BeTrue();
+        result.AllowNewTimeProposals.Should().BeTrue();
+        result.SeriesMasterId.Should().Be("series-1");
+        result.LastModifiedDateTime.Should().Be(lastModified);
+    }
+
+    [TestMethod]
+    public void MapEvent_NullCategories_MapToEmptyArray()
+    {
+        var result = mapper.MapEvent(Event(categories: null));
+
+        result.Categories.Should().NotBeNull();
+        result.Categories.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void MapEvent_RecurringOnlineMeeting_MapsExpectedGraphFields()
+    {
+        // AC5: a recurring online meeting occurrence maps to a SchedulingEventDto with non-null
+        // ICalUId, IsOnlineMeeting=true, private sensitivity, and the occurrence seriesMasterId.
+        var result = mapper.MapEvent(
+            Event(
+                sensitivity: 2,
+                isRecurring: true,
+                isOnlineMeeting: true,
+                iCalUId: "gid-recurring",
+                seriesMasterId: "gid-recurring"
+            )
+        );
+
+        result.ICalUId.Should().Be("gid-recurring");
+        result.IsOnlineMeeting.Should().BeTrue();
+        result.Sensitivity.Should().Be("private");
+        result.SeriesMasterId.Should().Be("gid-recurring");
+        result.Type.Should().Be("seriesMaster");
     }
 
     [TestMethod]

--- a/tests/OpenClaw.Core.Tests/CoreCacheRepositoryGraphFieldsTests.cs
+++ b/tests/OpenClaw.Core.Tests/CoreCacheRepositoryGraphFieldsTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.Core.Tests;
+
+/// <summary>
+/// Round-trip persistence tests for issue #72 (AC4, AC6): the Core
+/// <see cref="OpenClaw.Core.CoreCacheRepository"/> must write and read back all nine new
+/// <see cref="EventDto"/> Graph-shaped fields identically, and its new schema migration must be
+/// idempotent across two <c>InitializeAsync</c> calls. Uses in-memory shared-cache SQLite so no
+/// temp files are created.
+/// </summary>
+[TestClass]
+public sealed class CoreCacheRepositoryGraphFieldsTests
+{
+    private static readonly BridgeStatusDto ReadyBridge = new(
+        BridgeState.ready.ToString(),
+        BridgeMode.enhanced.ToString(),
+        true,
+        false,
+        null,
+        null,
+        null
+    );
+
+    private static EventDto BuildEvent(string bridgeId, string[]? categories)
+    {
+        var start = new DateTimeOffset(2026, 5, 3, 15, 0, 0, TimeSpan.Zero);
+        return new EventDto(
+            BridgeId: bridgeId,
+            GlobalAppointmentId: $"gid-{bridgeId}",
+            Subject: "Core graph round-trip",
+            StartUtc: start,
+            EndUtc: start.AddHours(1),
+            Location: "Test Room",
+            BusyStatus: 2,
+            MeetingStatus: 1,
+            IsRecurring: true,
+            Sensitivity: 2,
+            Organizer: "organizer@test",
+            RequiredAttendeesJson: null,
+            OptionalAttendeesJson: null,
+            ResourcesJson: null,
+            BodyPreview: "preview",
+            ProtectedFieldsAvailable: true,
+            IsRedacted: false,
+            ResponseStatus: null,
+            Categories: categories,
+            IsOrganizer: true,
+            IsOnlineMeeting: true,
+            AllowNewTimeProposals: true,
+            ICalUId: $"gid-{bridgeId}",
+            SeriesMasterId: $"gid-{bridgeId}",
+            LastModifiedDateTime: new DateTimeOffset(2026, 5, 2, 10, 15, 0, TimeSpan.Zero),
+            BodyFull: "the full untruncated body",
+            SensitivityLabel: "private"
+        );
+    }
+
+    [TestMethod]
+    public async Task UpsertEvents_then_GetEvent_should_round_trip_all_nine_graph_fields_populated()
+    {
+        // Arrange
+        using var repo = new OpenClaw.Core.CoreCacheRepository(
+            $"Data Source=core-graph-pop-{Guid.NewGuid():N};Mode=Memory;Cache=Shared"
+        );
+        await repo.InitializeAsync();
+        var evt = BuildEvent("core-graph-pop", categories: ["Red", "Blue Sky", "Green"]);
+
+        // Act
+        await repo.UpsertEventsAsync(
+            [evt],
+            ReadyBridge,
+            "req-1",
+            new DateTimeOffset(2026, 5, 3, 15, 5, 0, TimeSpan.Zero)
+        );
+        var loaded = await repo.GetEventAsync("core-graph-pop");
+
+        // Assert
+        loaded.Should().NotBeNull();
+        loaded!.Categories.Should().Equal("Red", "Blue Sky", "Green");
+        loaded.IsOrganizer.Should().BeTrue();
+        loaded.IsOnlineMeeting.Should().BeTrue();
+        loaded.AllowNewTimeProposals.Should().BeTrue();
+        loaded.ICalUId.Should().Be("gid-core-graph-pop");
+        loaded.SeriesMasterId.Should().Be("gid-core-graph-pop");
+        loaded
+            .LastModifiedDateTime.Should()
+            .Be(new DateTimeOffset(2026, 5, 2, 10, 15, 0, TimeSpan.Zero));
+        loaded.BodyFull.Should().Be("the full untruncated body");
+        loaded.SensitivityLabel.Should().Be("private");
+    }
+
+    [TestMethod]
+    public async Task UpsertEvents_then_GetEvent_should_round_trip_empty_categories()
+    {
+        // Arrange
+        using var repo = new OpenClaw.Core.CoreCacheRepository(
+            $"Data Source=core-graph-empty-{Guid.NewGuid():N};Mode=Memory;Cache=Shared"
+        );
+        await repo.InitializeAsync();
+        var evt = BuildEvent("core-graph-empty", categories: Array.Empty<string>());
+
+        // Act
+        await repo.UpsertEventsAsync(
+            [evt],
+            ReadyBridge,
+            "req-2",
+            new DateTimeOffset(2026, 5, 3, 15, 6, 0, TimeSpan.Zero)
+        );
+        var loaded = await repo.GetEventAsync("core-graph-empty");
+
+        // Assert
+        loaded.Should().NotBeNull();
+        loaded!.Categories.Should().NotBeNull();
+        loaded.Categories.Should().BeEmpty("an empty categories array round-trips as empty");
+    }
+
+    [TestMethod]
+    public async Task InitializeAsync_should_be_idempotent_across_two_calls()
+    {
+        // Arrange
+        using var repo = new OpenClaw.Core.CoreCacheRepository(
+            $"Data Source=core-graph-idem-{Guid.NewGuid():N};Mode=Memory;Cache=Shared"
+        );
+
+        // Act: initializing twice must not raise a "duplicate column" error.
+        await repo.InitializeAsync();
+        var secondInit = async () => await repo.InitializeAsync();
+
+        // Assert
+        await secondInit
+            .Should()
+            .NotThrowAsync("the Core events schema migration must be idempotent");
+
+        // A round-trip still works after the second migration.
+        var evt = BuildEvent("core-graph-idem", categories: ["X"]);
+        await repo.UpsertEventsAsync(
+            [evt],
+            ReadyBridge,
+            "req-3",
+            new DateTimeOffset(2026, 5, 3, 15, 7, 0, TimeSpan.Zero)
+        );
+        var loaded = await repo.GetEventAsync("core-graph-idem");
+        loaded.Should().NotBeNull();
+        loaded!.Categories.Should().Equal("X");
+    }
+}

--- a/tests/OpenClaw.MailBridge.Tests/CacheRepositoryGraphFieldsTests.cs
+++ b/tests/OpenClaw.MailBridge.Tests/CacheRepositoryGraphFieldsTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.MailBridge;
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.MailBridge.Tests;
+
+/// <summary>
+/// Round-trip persistence tests for issue #72 (AC4, AC6): the bridge
+/// <see cref="CacheRepository"/> must write and read back all nine new
+/// <see cref="EventDto"/> Graph-shaped fields identically, and its schema migration must be
+/// idempotent. Uses in-memory shared-cache SQLite so no temp files are created.
+/// </summary>
+[TestClass]
+public sealed class CacheRepositoryGraphFieldsTests
+{
+    private static EventDto BuildEvent(string bridgeId, string[]? categories)
+    {
+        var start = new DateTimeOffset(2026, 5, 2, 14, 0, 0, TimeSpan.Zero);
+        return new EventDto(
+            BridgeId: bridgeId,
+            GlobalAppointmentId: $"gid-{bridgeId}",
+            Subject: "Graph round-trip",
+            StartUtc: start,
+            EndUtc: start.AddHours(1),
+            Location: "Test Room",
+            BusyStatus: 2,
+            MeetingStatus: 1,
+            IsRecurring: true,
+            Sensitivity: 2,
+            Organizer: "organizer@test",
+            RequiredAttendeesJson: null,
+            OptionalAttendeesJson: null,
+            ResourcesJson: null,
+            BodyPreview: "preview",
+            ProtectedFieldsAvailable: true,
+            IsRedacted: false,
+            ResponseStatus: 3,
+            Categories: categories,
+            IsOrganizer: true,
+            IsOnlineMeeting: true,
+            AllowNewTimeProposals: true,
+            ICalUId: $"gid-{bridgeId}",
+            SeriesMasterId: $"gid-{bridgeId}",
+            LastModifiedDateTime: new DateTimeOffset(2026, 5, 1, 9, 30, 0, TimeSpan.Zero),
+            BodyFull: "the full untruncated body",
+            SensitivityLabel: "private"
+        );
+    }
+
+    [TestMethod]
+    public async Task UpsertEvent_then_GetEvent_should_round_trip_all_nine_graph_fields_populated()
+    {
+        // Arrange
+        using var repo = new CacheRepository(
+            $"Data Source=graph-pop-{Guid.NewGuid():N};Mode=Memory;Cache=Shared"
+        );
+        await repo.InitializeAsync();
+        var evt = BuildEvent("bridge-graph-pop", categories: ["Red", "Blue Sky", "Green"]);
+
+        // Act
+        await repo.UpsertEventAsync("entry-1", "store-1", "gid-1", evt);
+        var loaded = await repo.GetEventAsync("bridge-graph-pop");
+
+        // Assert
+        loaded.Should().NotBeNull();
+        loaded!.Categories.Should().Equal("Red", "Blue Sky", "Green");
+        loaded.IsOrganizer.Should().BeTrue();
+        loaded.IsOnlineMeeting.Should().BeTrue();
+        loaded.AllowNewTimeProposals.Should().BeTrue();
+        loaded.ICalUId.Should().Be("gid-bridge-graph-pop");
+        loaded.SeriesMasterId.Should().Be("gid-bridge-graph-pop");
+        loaded
+            .LastModifiedDateTime.Should()
+            .Be(new DateTimeOffset(2026, 5, 1, 9, 30, 0, TimeSpan.Zero));
+        loaded.BodyFull.Should().Be("the full untruncated body");
+        loaded.SensitivityLabel.Should().Be("private");
+    }
+
+    [TestMethod]
+    public async Task UpsertEvent_then_GetEvent_should_round_trip_empty_categories()
+    {
+        // Arrange
+        using var repo = new CacheRepository(
+            $"Data Source=graph-empty-{Guid.NewGuid():N};Mode=Memory;Cache=Shared"
+        );
+        await repo.InitializeAsync();
+        var evt = BuildEvent("bridge-graph-empty", categories: Array.Empty<string>());
+
+        // Act
+        await repo.UpsertEventAsync("entry-2", "store-2", "gid-2", evt);
+        var loaded = await repo.GetEventAsync("bridge-graph-empty");
+
+        // Assert
+        loaded.Should().NotBeNull();
+        loaded!.Categories.Should().NotBeNull();
+        loaded.Categories.Should().BeEmpty("an empty categories array round-trips as empty");
+    }
+
+    [TestMethod]
+    public async Task InitializeAsync_should_be_idempotent_across_two_calls()
+    {
+        // Arrange
+        using var repo = new CacheRepository(
+            $"Data Source=graph-idem-{Guid.NewGuid():N};Mode=Memory;Cache=Shared"
+        );
+
+        // Act: initializing twice must not raise a "duplicate column" error.
+        await repo.InitializeAsync();
+        var secondInit = async () => await repo.InitializeAsync();
+
+        // Assert
+        await secondInit.Should().NotThrowAsync("the events schema migration must be idempotent");
+
+        // And a round-trip still works after the second migration.
+        var evt = BuildEvent("bridge-graph-idem", categories: ["X"]);
+        await repo.UpsertEventAsync("entry-3", "store-3", "gid-3", evt);
+        var loaded = await repo.GetEventAsync("bridge-graph-idem");
+        loaded.Should().NotBeNull();
+        loaded!.Categories.Should().Equal("X");
+    }
+}

--- a/tests/OpenClaw.MailBridge.Tests/EventSensitivityLabelTests.cs
+++ b/tests/OpenClaw.MailBridge.Tests/EventSensitivityLabelTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.MailBridge.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="EventSensitivityLabel.FromSensitivity"/> (issue #72, AC1/AC6).
+/// Covers the four recognized Outlook sensitivity integers, the null input, and an
+/// out-of-range value, asserting the documented 0=normal/1=personal/2=private/3=confidential
+/// mapping with null for anything else.
+/// </summary>
+[TestClass]
+public sealed class EventSensitivityLabelTests
+{
+    [DataTestMethod]
+    [DataRow(0, "normal")]
+    [DataRow(1, "personal")]
+    [DataRow(2, "private")]
+    [DataRow(3, "confidential")]
+    public void FromSensitivity_should_map_recognized_values(int sensitivity, string expected)
+    {
+        // Arrange / Act
+        var label = EventSensitivityLabel.FromSensitivity(sensitivity);
+
+        // Assert
+        label.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void FromSensitivity_should_return_null_for_null_input()
+    {
+        // Arrange / Act
+        var label = EventSensitivityLabel.FromSensitivity(null);
+
+        // Assert
+        label.Should().BeNull("a null sensitivity has no label");
+    }
+
+    [TestMethod]
+    public void FromSensitivity_should_return_null_for_out_of_range_value()
+    {
+        // Arrange / Act
+        var label = EventSensitivityLabel.FromSensitivity(99);
+
+        // Assert
+        label.Should().BeNull("unrecognized sensitivity integers map to null");
+    }
+}

--- a/tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs
+++ b/tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs
@@ -112,7 +112,7 @@ internal sealed class FakeMeetingItem
     public FakeOutlookParent Parent { get; init; } = new();
 }
 
-internal sealed class FakeAppointmentItem
+internal sealed record FakeAppointmentItem
 {
     public required string EntryID { get; init; }
     public string? GlobalAppointmentID { get; init; }
@@ -126,6 +126,14 @@ internal sealed class FakeAppointmentItem
     public string? Organizer { get; init; }
     public string? Body { get; init; }
     public int? ResponseStatus { get; init; }
+
+    // Issue #72 Graph-shaped COM analogs.
+    public int? Sensitivity { get; init; }
+    public string? Categories { get; init; }
+    public bool IsOnlineMeeting { get; init; }
+    public bool AllowNewTimeProposal { get; init; }
+    public int? RecurrenceState { get; init; }
+    public DateTime? LastModificationTime { get; init; }
     public FakeOutlookParent Parent { get; init; } = new();
 }
 

--- a/tests/OpenClaw.MailBridge.Tests/OutlookScannerGraphFieldsTests.cs
+++ b/tests/OpenClaw.MailBridge.Tests/OutlookScannerGraphFieldsTests.cs
@@ -1,0 +1,232 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.MailBridge;
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.MailBridge.Tests;
+
+/// <summary>
+/// Scanner population tests for issue #72 (AC2, AC5): <see cref="OutlookScanner.NormalizeEvent"/>
+/// must populate the nine new <see cref="EventDto"/> Graph-shaped fields from their Outlook COM
+/// analogs. Uses the shared COM-double pattern (no live COM, no temp files, deterministic clock).
+/// </summary>
+[TestClass]
+public sealed class OutlookScannerGraphFieldsTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static OutlookScanner BuildScanner(BridgeSettings settings, FakeComActiveObject com) =>
+        new(
+            settings,
+            new BridgeStateStore(settings),
+            NullLogger<OutlookScanner>.Instance,
+            com,
+            _ => 0,
+            () => FixedNow
+        );
+
+    private static FakeOutlookApplication BuildOutlookWithCalendar(FakeOutlookFolder calendar)
+    {
+        var outlook = new FakeOutlookApplication();
+        outlook.Namespace.DefaultFolders[9] = calendar;
+        outlook.Namespace.DefaultFolders[6] = new FakeOutlookFolder();
+        return outlook;
+    }
+
+    private static async Task<EventDto> ScanSingleEventAsync(FakeAppointmentItem appointment)
+    {
+        var settings = BridgeSettings.Default with
+        {
+            CalendarPastDays = 7,
+            CalendarFutureDays = 30,
+        };
+        var calendar = new FakeOutlookFolder();
+        calendar.Items.Add(appointment);
+        var com = new FakeComActiveObject { RunningObject = BuildOutlookWithCalendar(calendar) };
+        var repo = new FakeScanStateRepository();
+        var scanner = BuildScanner(settings, com);
+
+        await scanner.ScanCalendarAsync(repo);
+
+        repo.Events.Should().HaveCount(1);
+        return repo.Events.Values.Single();
+    }
+
+    private static FakeAppointmentItem BaseAppointment() =>
+        new()
+        {
+            EntryID = "entry-graph",
+            GlobalAppointmentID = "gid-graph",
+            Subject = "Graph fields",
+            Start = FixedNow.AddDays(1),
+            End = FixedNow.AddDays(1).AddHours(1),
+        };
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_split_categories_on_comma_space()
+    {
+        var evt = await ScanSingleEventAsync(
+            BaseAppointment() with
+            {
+                Categories = "Red Category, Blue Category, Green Category",
+            }
+        );
+
+        evt.Categories.Should().Equal("Red Category", "Blue Category", "Green Category");
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_yield_empty_categories_for_null_source()
+    {
+        var evt = await ScanSingleEventAsync(BaseAppointment() with { Categories = null });
+
+        evt.Categories.Should().NotBeNull();
+        evt.Categories.Should()
+            .BeEmpty("a null Categories string maps to an empty array, not null");
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_set_isOrganizer_true_when_response_status_is_organized()
+    {
+        var evt = await ScanSingleEventAsync(BaseAppointment() with { ResponseStatus = 1 });
+
+        evt.IsOrganizer.Should().BeTrue("ResponseStatus 1 (olResponseOrganized) means organizer");
+    }
+
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(2)]
+    [DataRow(3)]
+    public async Task NormalizeEvent_should_set_isOrganizer_false_for_non_organized_status(
+        int responseStatus
+    )
+    {
+        var evt = await ScanSingleEventAsync(
+            BaseAppointment() with
+            {
+                ResponseStatus = responseStatus,
+            }
+        );
+
+        evt.IsOrganizer.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_populate_isOnlineMeeting_from_com()
+    {
+        var evt = await ScanSingleEventAsync(BaseAppointment() with { IsOnlineMeeting = true });
+
+        evt.IsOnlineMeeting.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_populate_allowNewTimeProposals_from_singular_com_name()
+    {
+        var evt = await ScanSingleEventAsync(
+            BaseAppointment() with
+            {
+                AllowNewTimeProposal = true,
+            }
+        );
+
+        evt.AllowNewTimeProposals.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_set_iCalUId_to_global_appointment_id()
+    {
+        var evt = await ScanSingleEventAsync(BaseAppointment());
+
+        evt.ICalUId.Should().Be("gid-graph", "iCalUId reuses GlobalAppointmentID per spec");
+    }
+
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    public async Task NormalizeEvent_should_set_seriesMasterId_null_for_non_recurring_and_master(
+        int recurrenceState
+    )
+    {
+        var evt = await ScanSingleEventAsync(
+            BaseAppointment() with
+            {
+                RecurrenceState = recurrenceState,
+            }
+        );
+
+        evt.SeriesMasterId.Should().BeNull();
+    }
+
+    [DataTestMethod]
+    [DataRow(2)]
+    [DataRow(3)]
+    public async Task NormalizeEvent_should_set_seriesMasterId_to_gid_for_occurrence_and_exception(
+        int recurrenceState
+    )
+    {
+        var evt = await ScanSingleEventAsync(
+            BaseAppointment() with
+            {
+                RecurrenceState = recurrenceState,
+            }
+        );
+
+        evt.SeriesMasterId.Should().Be("gid-graph");
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_populate_lastModifiedDateTime_from_com()
+    {
+        var modified = new DateTime(2026, 4, 30, 8, 30, 0, DateTimeKind.Utc);
+        var evt = await ScanSingleEventAsync(
+            BaseAppointment() with
+            {
+                LastModificationTime = modified,
+            }
+        );
+
+        evt.LastModifiedDateTime.Should().Be(new DateTimeOffset(modified));
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_carry_bodyFull_raw_untruncated()
+    {
+        var longBody = new string('x', BridgeSettings.Default.BodyPreviewMaxChars + 250);
+        var evt = await ScanSingleEventAsync(BaseAppointment() with { Body = longBody });
+
+        evt.BodyFull.Should()
+            .Be(longBody, "bodyFull is the raw COM Body, not the truncated preview");
+        evt.BodyFull!.Length.Should().BeGreaterThan(BridgeSettings.Default.BodyPreviewMaxChars);
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_should_map_sensitivityLabel_from_sensitivity_int()
+    {
+        var evt = await ScanSingleEventAsync(BaseAppointment() with { Sensitivity = 2 });
+
+        evt.SensitivityLabel.Should().Be("private");
+        evt.Sensitivity.Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task NormalizeEvent_recurring_online_meeting_yields_expected_graph_fields()
+    {
+        // AC5: a recurring online meeting occurrence yields non-null iCalUId, isOnlineMeeting true,
+        // and the correct sensitivityLabel.
+        var evt = await ScanSingleEventAsync(
+            BaseAppointment() with
+            {
+                IsRecurring = true,
+                IsOnlineMeeting = true,
+                RecurrenceState = 2,
+                Sensitivity = 2,
+            }
+        );
+
+        evt.ICalUId.Should().Be("gid-graph");
+        evt.IsOnlineMeeting.Should().BeTrue();
+        evt.SensitivityLabel.Should().Be("private");
+        evt.SeriesMasterId.Should().Be("gid-graph");
+    }
+}

--- a/tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs
+++ b/tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs
@@ -1,0 +1,85 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.MailBridge.Tests;
+
+/// <summary>
+/// Redaction tests for issue #72 (AC3): <see cref="ResponseShaper.ShapeEvent"/> must null
+/// <see cref="EventDto.BodyFull"/> in safe mode (parity with <c>BodyPreview</c>), and return the
+/// full untruncated body verbatim in enhanced mode (NOT routed through
+/// <c>BodySanitizer.NormalizePreview</c>).
+/// </summary>
+[TestClass]
+public sealed class ResponseShaperEventBodyFullTests
+{
+    private static readonly DateTimeOffset FixedTimestamp = DateTimeOffset.Parse(
+        "2026-05-01T12:00:00Z"
+    );
+
+    private static EventDto CreateEvent(string? bodyFull, string? bodyPreview = "Preview") =>
+        new(
+            BridgeId: BridgeIdCodec.EventId("gid", "entry-bodyfull", FixedTimestamp),
+            GlobalAppointmentId: "gid",
+            Subject: "Subject",
+            StartUtc: FixedTimestamp,
+            EndUtc: FixedTimestamp.AddHours(1),
+            Location: "Room 1",
+            BusyStatus: null,
+            MeetingStatus: null,
+            IsRecurring: false,
+            Sensitivity: null,
+            Organizer: "Organizer",
+            RequiredAttendeesJson: null,
+            OptionalAttendeesJson: null,
+            ResourcesJson: null,
+            BodyPreview: bodyPreview,
+            ProtectedFieldsAvailable: true,
+            IsRedacted: false,
+            BodyFull: bodyFull
+        );
+
+    [TestMethod]
+    public void ShapeEvent_in_safe_mode_should_null_body_full_and_set_redacted()
+    {
+        // Arrange
+        var evt = CreateEvent(bodyFull: "Full confidential appointment body text.");
+        var settings = BridgeSettings.Default with { Mode = "safe" };
+
+        // Act
+        var shaped = ResponseShaper.ShapeEvent(evt, settings);
+
+        // Assert
+        shaped.BodyFull.Should().BeNull("safe mode must null bodyFull alongside BodyPreview");
+        shaped.BodyPreview.Should().BeNull();
+        shaped.IsRedacted.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void ShapeEvent_in_enhanced_mode_should_return_full_untruncated_body_verbatim()
+    {
+        // Arrange: a body longer than the preview cap to prove BodyFull is not truncated.
+        var settings = BridgeSettings.Default with
+        {
+            Mode = "enhanced",
+            BodyPreviewMaxChars = 16,
+        };
+        var longBody =
+            "First line with multiple words.\n"
+            + new string('a', settings.BodyPreviewMaxChars + 200)
+            + "  trailing   whitespace   preserved";
+        var evt = CreateEvent(bodyFull: longBody, bodyPreview: longBody);
+
+        // Act
+        var shaped = ResponseShaper.ShapeEvent(evt, settings);
+
+        // Assert
+        shaped
+            .BodyFull.Should()
+            .Be(longBody, "enhanced mode returns the raw body verbatim, not normalized/truncated");
+        shaped.BodyFull!.Length.Should().BeGreaterThan(settings.BodyPreviewMaxChars);
+        shaped.IsRedacted.Should().BeFalse();
+        // BodyPreview is still shaped/truncated; BodyFull diverges from it intentionally.
+        shaped.BodyFull.Should().NotBe(shaped.BodyPreview);
+    }
+}


### PR DESCRIPTION
# feat(mailbridge): add Graph-shaped event fields to EventDto

## Summary

- Adds nine Graph-shaped calendar fields to `EventDto` (`categories`, `isOrganizer`, `isOnlineMeeting`, `allowNewTimeProposals`, `iCalUId`, `seriesMasterId`, `lastModifiedDateTime`, `bodyFull`, `sensitivityLabel`) and populates them from their Outlook COM analogs in `OutlookScanner.NormalizeEvent`.
- Keeps `EventDto` source-compatible: the new fields are appended as optional positional parameters after `ResponseStatus = null`, so existing call sites compile without changes.
- Preserves the SAFE/ENHANCED redaction boundary: `ResponseShaper.ShapeEvent` nulls `bodyFull` in SAFE mode together with `BodyPreview`; ENHANCED mode returns the full, untruncated body.
- Round-trips all nine fields through both SQLite caches (`CacheRepository`, `CoreCacheRepository`) via idempotent schema migrations.
- Wires the downstream `SchedulingDtoMapper.MapEvent` to read real values instead of hardcoded placeholders.

## Why

`SchedulingDtoMapper.MapEvent` substituted placeholder values (`Array.Empty<string>()`, `false`, `null`) for fields `EventDto` did not carry. Triage signals that depend on these fields — for example `isOnlineMeeting` contributing a dependency point and `categories` matching protected categories — could not be computed on real data. Populating the fields from their Outlook COM analogs is the prerequisite for accurate triage and scoring. This issue was deferred from #70 (OpenClaw agent deterministic core); the deterministic normalizer (master Section 9.2) requires these fields.

## What Changed

### Contract (`OpenClaw.MailBridge.Contracts`)
- `EventDto` gains nine appended optional parameters with defaults (`BridgeContracts.cs`).
- New `EventSensitivityLabel` helper exposing `normal`/`personal`/`private`/`confidential` and a `FromSensitivity(int?)` mapping (0/1/2/3, else null).

### Scanner (`OpenClaw.MailBridge`)
- `OutlookScanner.NormalizeEvent` derives and populates the nine fields from COM analogs; helper methods (categories splitter, `seriesMasterId` derivation, `BuildEventDto`) are placed in a new `OutlookScanner.GraphFields.cs` partial to keep `OutlookScanner.cs` under the 500-line cap (reduced from 507 to 485 lines).
- `ResponseShaper.ShapeEvent` nulls `bodyFull` in SAFE mode (redaction parity).
- The COM `Body` is read once and reused for both `BodyPreview` and `bodyFull` to avoid a redundant COM read.

### Persistence
- `CacheRepository` (bridge): new columns added via the existing idempotent `MigrateEventsSchemaAsync` ALTER-TABLE pattern; the previously-unwired `last_modified_utc` column is now written; reader extended to read the new columns by name. Schema DDL extracted to `CacheRepository.Schema.cs`.
- `CoreCacheRepository` (core): mirroring idempotent migration helper added (`CoreCacheRepository.Schema.cs`); insert/read paths round-trip the new fields. `categories` is serialized as a JSON-array column, consistent with the existing attendee/resources columns.

### Downstream (`OpenClaw.Core`)
- `SchedulingDtoMapper.MapEvent` and `SchedulingEventDto` wire the new fields instead of placeholders; `iCalUId` reads `evt.ICalUId` (populated from `GlobalAppointmentID`).

### Tests
- New: `EventSensitivityLabelTests`, `OutlookScannerGraphFieldsTests`, `ResponseShaperEventBodyFullTests`, `CacheRepositoryGraphFieldsTests`, `CoreCacheRepositoryGraphFieldsTests`. Updated: `SchedulingDtoMapperTests`, `MailBridgeRuntimeTestDoubles`.

## Architecture / How It Fits Together

Data flows `Outlook --COM--> OpenClaw.MailBridge (NormalizeEvent -> ShapeEvent -> CacheRepository)` then over the HTTP boundary to `OpenClaw.Core (CoreCacheRepository -> SchedulingDtoMapper)`. COM reads for the new fields remain confined to `OpenClaw.MailBridge`; `EventDto` and `EventSensitivityLabel` live in the leaf `OpenClaw.MailBridge.Contracts` project. No new project references were introduced.

## Verification

Completed (from context, EXIT_CODE 0 for each):
- Format: `csharpier check .` — pass.
- Lint/analyzers: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` — 0 warnings/errors.
- Type-check (nullable): `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true` — 0 warnings/errors.
- Architecture: project-graph boundaries verified; COM confined to `OpenClaw.MailBridge`.
- Tests: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"` — 459 passed, 0 failed, 3 pre-existing skips.
- Coverage: MailBridge 93.55% line / 85.47% branch; Core 89.09% line / 77.59% branch — both above the line >= 85% / branch >= 75% thresholds; no regression on changed lines.

Recommended:
- Confirm the PR Pipeline required checks are green against the PR head SHA before merge.

## Backward Compatibility / Migration Notes

- `EventDto` remains source-compatible: new parameters are appended with defaults; no existing call site required edits.
- SQLite schema migrations are idempotent (`ALTER TABLE ... ADD COLUMN`), additive, and safe to re-run against existing caches.
- No public API removals or renames.

## Risks and Mitigations

- `isOnlineMeeting` (MEDIUM confidence) may report `false` for some third-party add-in meetings (for example Teams meetings inserted via the add-in). Documented as a known limitation in the spec; no fragile string-parsing fallback was added.
- `iCalUId` reuses `GlobalAppointmentID` rather than a true iCalendar UID; the MAPI `PidLidGlobalObjectId` path was rejected as disproportionate. Documented as a limitation.
- `bodyFull` carries full appointment body text; the SAFE-mode null in `ShapeEvent` is the redaction control and is covered by `ResponseShaperEventBodyFullTests`.

## Review Guide

Suggested order: `BridgeContracts.cs` and `EventSensitivityLabel.cs` (contract) -> `OutlookScanner.GraphFields.cs` and `OutlookScanner.cs` (population) -> `ResponseShaper.cs` (redaction) -> `CacheRepository*.cs` and `CoreCacheRepository*.cs` (persistence) -> `SchedulingDtoMapper.cs` (downstream wiring) -> tests. The schema-partial extractions are mechanical moves to satisfy the file-size cap.

## Follow-ups

- #80 — `CoreCacheRepository` drops `EventDto.ResponseStatus` on round-trip (pre-existing latent gap, deferred from this PR).
- #82 — split `CoreCacheRepository.cs` to satisfy the 500-line file-size cap (pre-existing over-cap, reduced here from 691 to 687 lines).

## GitHub Auto-close

- Closes #72
