### PR TITLE
feat(mailbridge): populate EventDto attendee JSON from COM Recipients

### DIFF
--- a/.claude/agent-memory/orchestrator/MEMORY.md
+++ b/.claude/agent-memory/orchestrator/MEMORY.md
@@ -4,3 +4,4 @@
 - [Harness governance](project_harness-governance.md) — harness is now version-controlled (Issue #66/PR #68); `.claude/rules/*` is canonical; AGENTS.md + .github/instructions match it.
 - [Core agent = namespace not project](project_core-agent-namespace-not-project.md) — new logic for OpenClaw.Core folds into a namespace, not a new project (arch rule 6); enforce with namespace NetArchTest.
 - [Checkpoint validator contract](project_checkpoint-validator-contract.md) — orchestrator-state validator requires hyphen keys, stepN enum (verified not complete), and delegation_receipts as a LIST; differs from prompt.
+- [csharpier local tool manifest broken](project_csharpier-local-tool-manifest-broken.md) — local dotnet-tools csharpier entry misconfigured; use global csharpier with format/check subcommands.

--- a/.claude/agent-memory/orchestrator/project_csharpier-local-tool-manifest-broken.md
+++ b/.claude/agent-memory/orchestrator/project_csharpier-local-tool-manifest-broken.md
@@ -1,0 +1,12 @@
+---
+name: csharpier-local-tool-manifest-broken
+description: Local dotnet-tools csharpier entry is misconfigured; use global csharpier for the C# format gate.
+metadata:
+  type: project
+---
+
+The repo's local dotnet tool manifest references the csharpier command as `csharpier`, but the package exposes `dotnet-csharpier`, so `dotnet tool restore` fails for csharpier. Additionally, csharpier 1.3.0's bare `csharpier .` form prints help; use the `csharpier format .` / `csharpier check .` subcommands.
+
+**Why:** Surfaced during issue #71 execution. The atomic-executor fell back to the verified global csharpier 1.3.0 (the plan permits this alternative) and the format gate passed. It is a pre-existing repo tooling defect, not introduced by feature work.
+
+**How to apply:** When a C# toolchain run hits a csharpier restore failure, do not treat it as a regression in the current change. Use global csharpier with explicit `format`/`check` subcommands and record it in format evidence. A separate fix to `.config/dotnet-tools.json` (correct the command name to `dotnet-csharpier`) would remove the friction. Relates to [[harness-governance]].

--- a/docs/features/active/mailbridge-event-attendees-json-71/code-review.2026-06-13T14-52.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/code-review.2026-06-13T14-52.md
@@ -1,0 +1,115 @@
+# Code Review: mailbridge-event-attendees-json (#71)
+
+**Review Date:** 2026-06-13
+**Reviewer:** feature-review agent
+**Feature Folder:** `docs/features/active/mailbridge-event-attendees-json-71`
+**Feature Folder Selection Rule:** Folder suffix `-71` matches the canonical issue number and holds the material scoping-doc changes (spec.md, user-story.md).
+**Base Branch:** `main` (merge-base `c0fa1024f61eac924331ac3757f1acbc5d724b03`)
+**Head Branch:** `open-claw-bridge-wt-2026-06-13-10-27` (`65a5f8d5a750bf11166d4469ade4d6d7a0921ce8`)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+The change populates the three `EventDto` attendee JSON fields from the COM `AppointmentItem.Recipients` collection and extends safe-mode redaction to null those fields. It is implemented as a new partial-class file (`OutlookScanner.Attendees.cs`) that cleanly separates a pure, COM-free JSON shaping function (`ShapeAttendeeJson`) from the COM enumeration method (`ReadAttendees`), plus a one-line wiring change in `BuildEventDto`, a three-line safe-mode redaction addition in `ResponseShaper.ShapeEvent`, and a small fail-soft COM helper (`GetOptionalIndexedItem`).
+
+**What changed:**
+- `OutlookScanner.Attendees.cs` (new, 179 lines): `AttendeeJsonSet`/`Attendee` records, static `JsonSerializerOptions`, pure `ShapeAttendeeJson`/`SerializeAttendees`, and the COM `ReadAttendees` single-pass enumerator with per-recipient and collection-level deterministic release.
+- `OutlookScanner.GraphFields.cs` (modified): three `null` literals replaced by `attendees.RequiredJson/OptionalJson/ResourcesJson`; XML note clarifying `ProtectedFieldsAvailable` is unchanged.
+- `ResponseShaper.cs` (modified): safe-mode branch nulls the three attendee fields.
+- `OutlookComHelpers.cs` (modified): `GetOptionalIndexedItem` fail-soft 1-based accessor.
+- 4 test files: 12 new tests across pure shaping, scanner path (incl. fail-soft), and redaction.
+
+Scope is C# only. Toolchain (format, analyzers, nullable, architecture, tests + coverage) passed in the executor run and was re-verified here against the diff and the cobertura coverage file. Changed production code is at 100% line/branch.
+
+**Top 3 risks:**
+1. The broad `catch` in `GetOptionalIndexedItem` swallows all exceptions to fail soft. This is consistent with the existing `OutlookComHelpers` idiom and confined to the COM adapter boundary, but it is a deliberate broad catch worth noting.
+2. Email resolution falls back from `Recipient.Address` to `AddressEntry.Address` only; Exchange DN-to-SMTP translation beyond the COM surface is explicitly a non-goal, so some Exchange recipients may yield a non-SMTP address string. This matches the spec non-goal and is acceptable.
+3. Coverage was verified from `tests/**/TestResults/.../coverage.cobertura.xml` rather than the SKILL's nominal `artifacts/csharp/coverage.xml`; the numbers were confirmed by direct parse.
+
+**PR readiness recommendation:** **Go** — implementation matches the spec and AC, toolchain is clean, changed code is fully covered, and architecture/COM/contract boundaries are preserved.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Info | `src/OpenClaw.MailBridge/OutlookComHelpers.cs` | `GetOptionalIndexedItem` (lines ~38–47) | Broad `catch` swallows all exceptions to return `null` (fail soft). | No change required; the catch is intentional, documented, and matches the existing `GetOptional*` idiom for the COM boundary. | A broad catch is normally discouraged, but per spec SP-B3 a single unreadable recipient must not abort the scan; the catch is confined to the COM adapter. | Diff inspection; catch path covered by `ScanCalendar_should_fail_soft_when_a_recipient_read_throws` (cobertura lines 43–45 hit). |
+| Info | `src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs` | `ReadAttendees` email fallback (lines ~151–162) | Email resolution uses `Recipient.Address` then `AddressEntry.Address`; no Exchange DN-to-SMTP translation. | None; this is an explicit spec non-goal. | Some Exchange recipients may carry a legacyExchangeDN-style address; acceptable per user-story Non-Goals. | `user-story.md` Non-Goals; diff inspection. |
+| Info | n/a | coverage artifact path | C# coverage verified from `TestResults/.../coverage.cobertura.xml`, not `artifacts/csharp/coverage.xml`. | None; this is the repo's canonical coverlet output per `csharp.md`. | Documents the evidence source for traceability. | Direct parse of cobertura (line-rate 0.9407, branch-rate 0.8654). |
+
+No Blockers or Major findings.
+
+---
+
+## Implementation Audit
+
+### C# implementation audit
+
+#### What changed well
+
+- Clean separation of a pure, COM-free `ShapeAttendeeJson` (directly unit-testable) from the COM-bound `ReadAttendees`. This follows the repository's "isolate I/O from pure logic" principle and the DI/seam guidance in `csharp.md`.
+- Single-pass enumeration over `Recipients` with a `switch` on `Type` (1/2/3) and explicit exclusion of out-of-range values, matching spec SP-B2.
+- Deterministic COM release: each `Recipient` and any resolved `AddressEntry` are released per-iteration in a `finally`, and the `Recipients` collection is released in the outer `finally`, following the `GetStoreId` idiom and the COM-confinement rule. No RCW accumulation.
+- The null-vs-`"[]"` distinction is deliberate and documented: the scanner emits `"[]"` for a type with no recipients, and null is reserved for safe-mode redaction. This makes "no attendees" distinguishable from "redacted" at the consumer.
+- A single static `JsonSerializerOptions` avoids per-call allocation and guarantees deterministic output; lowercase `name`/`email` keys are enforced via `JsonPropertyName` on the `AttendeeJson` projection, matching the Graph `emailAddress` shape.
+
+#### Type safety and API notes
+
+- Nullable reference types respected: optional COM reads return `string?`/`object?`; missing values coalesce to `string.Empty` so each serialized object always carries both keys. Build with `TreatWarningsAsErrors=true` passed with 0 warnings.
+- New public/cross-boundary surface is minimal and correct: `EventDto` is unchanged (same positional argument count/order), so no contract break. New types are `internal`/`private`; only `ShapeAttendeeJson`/`Attendee`/`AttendeeJsonSet` are `internal` to enable direct unit testing without live COM.
+- No COM types leak across project boundaries; the carrier records are plain managed values.
+
+#### Error handling and logging
+
+- Fail-soft per recipient via `GetOptional*`/`GetOptionalIndexedItem`; the scan completes even when an individual recipient read throws. The broad catch is confined to the COM adapter boundary and is documented.
+- No new logging added, consistent with the spec ("none beyond existing scan logging").
+
+---
+
+## Test Quality Audit
+
+The change adds 12 focused tests across three concerns. They are deterministic (injected clock `() => FixedNow`), isolated (per-test fakes, no shared state), and free of external dependencies or temporary files. The COM boundary is substituted with reflection-readable fakes, avoiding live Outlook.
+
+### Reviewed test and QA artifacts
+
+- `tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesShapeTests.cs` — verifies lowercase keys, order preservation, `"[]"` for empty groups, and both-keys-present on missing values. Asserts exact JSON strings.
+- `tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesTests.cs` — verifies enhanced-mode population, per-type classification with out-of-range exclusion, missing name/email, AddressEntry fallback, empty/absent collection -> `"[]"`, and fail-soft on a throwing collection.
+- `tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs` — verifies safe-mode nulls all three fields and enhanced mode preserves them.
+- `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-test.2026-06-13T14-41.md` — 474 passed, 0 failed; coverage 94.07% line / 86.54% branch.
+- `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/coverage-delta.2026-06-13T14-41.md` — per-file 100% line/branch on changed code; no regression.
+- `tests/OpenClaw.MailBridge.Tests/TestResults/82e0c0f9-12e0-4ea3-9f69-873a62abd6dc/coverage.cobertura.xml` — directly parsed: solution line-rate 0.9407, branch-rate 0.8654; changed prod files at 1.0/1.0.
+
+### Quality assessment prompts
+
+- **Determinism:** Injected fixed clock; static serializer options; no RNG, sleeps, or wall-clock reads (verified by grep on the test diff).
+- **Isolation:** Each test builds its own scanner, COM fake, and repository.
+- **Speed:** In-memory fakes only; solution test gate completed with EXIT 0.
+- **Diagnostics:** FluentAssertions with rationale strings produce actionable failure messages.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | Diff inspection; only attendee display name/email projection, no credentials. |
+| No unsafe subprocess or command construction | ✅ PASS | No process or shell invocation introduced. |
+| Input validation at boundaries | ✅ PASS | COM reads are optional/guarded; out-of-range `Type` excluded; null collection handled. |
+| Error handling remains explicit | ✅ PASS | Fail-soft is intentional and documented; no silent swallowing in pure logic. |
+| Configuration / path handling is safe | ✅ PASS | No new config or path handling; behavior gated by existing `BridgeSettings.Mode`. |
+| PII redaction in safe mode | ✅ PASS | Safe-mode branch nulls all three attendee fields; verified by `ShapeEvent_in_safe_mode_should_null_all_three_attendee_fields`. |
+
+---
+
+## Research Log
+
+No external research was required. All findings are grounded in the branch diff, repository rule files, and the feature-folder evidence artifacts.
+
+---
+
+## Verdict
+
+The implementation is ready for normal PR flow. It satisfies the documented behavior and acceptance criteria, keeps Outlook COM confined to `OpenClaw.MailBridge` with deterministic release, preserves the `EventDto` contract, and is fully covered on changed lines with no coverage regression. The only findings are Informational (a documented fail-soft broad catch, an explicitly out-of-scope Exchange DN-to-SMTP limitation, and the coverage-artifact path note); none block merge. Recommendation: **Go**.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-build.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-build.2026-06-13T14-41.md
@@ -1,0 +1,6 @@
+# Baseline — Build / Analyzers (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). All eight solution projects compiled (Contracts, HostAdapter.Contracts, MailBridge.Client, MailBridge, HostAdapter, Core, and the three test projects). Baseline analyzer state is clean.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-format.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-format.2026-06-13T14-41.md
@@ -1,0 +1,6 @@
+# Baseline — CSharpier Formatting (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: csharpier check .
+EXIT_CODE: 0
+Output Summary: PASS. Checked 158 files in 402ms; no files require formatting. Baseline format state is clean. (Global csharpier 1.3.0; the plan permits `csharpier check .` as an alternative to `dotnet csharpier check .` — the local tool manifest entry is misconfigured, so the verified global install was used.)

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-nullable.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-nullable.2026-06-13T14-41.md
@@ -1,0 +1,6 @@
+# Baseline — Nullable / Type-Check (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). Nullable reference analysis produces no warnings-as-errors. Baseline type-safety state is clean.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-test.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-test.2026-06-13T14-41.md
@@ -1,0 +1,19 @@
+# Baseline — Test + Coverage (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"
+EXIT_CODE: 0
+
+Output Summary:
+- Test result: PASS. Failed: 0, Passed: 462 (MailBridge.Tests 204, Core.Tests 184, HostAdapter.Tests 74), Skipped: 3, Total: 465.
+- Coverage source: tests/OpenClaw.MailBridge.Tests/TestResults/3d4eee58-3dff-4d91-bed2-deeeb54968dd/coverage.cobertura.xml (coverlet XPlat Code Coverage; covers OpenClaw.MailBridge + OpenClaw.MailBridge.Contracts + OpenClaw.MailBridge.Client).
+- Baseline MailBridge solution coverage (pre-change reference for the no-regression check in [P4-T6]):
+  - Line coverage: 93.55% (lines-covered 973 / lines-valid 1040)
+  - Branch coverage: 85.47% (branches-covered 259 / branches-valid 303)
+- Per-file baseline for files to be modified:
+  - OpenClaw.MailBridge\OutlookScanner.GraphFields.cs: line-rate 100%, branch-rate 100%
+  - OpenClaw.MailBridge\ResponseShaper.cs: line-rate 100%, branch-rate 100%
+  - OpenClaw.MailBridge\OutlookScanner.Attendees.cs: not present (new file in this feature)
+- Note: the secondary "Code Coverage" (Vanguard) collector reported "Profiler was not initialized"; the coverlet XPlat collector produced the authoritative cobertura values above.
+
+Baseline thresholds satisfied: line 93.55% >= 85%, branch 85.47% >= 75%.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/phase0-instructions-read.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/phase0-instructions-read.2026-06-13T14-41.md
@@ -1,0 +1,21 @@
+# Phase 0 — Policy Read Evidence (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+
+Policy Order:
+1. CLAUDE.md (standing instructions, auto-loaded)
+2. .claude/rules/general-code-change.md (cross-language code change policy; seven-stage toolchain; 500-line file cap)
+3. .claude/rules/general-unit-test.md (cross-language unit test policy; determinism; no temp files)
+4. .claude/rules/csharp.md (C# toolchain: CSharpier -> SDK analyzers -> nullable -> architecture -> MSTest + coverage)
+5. .claude/rules/architecture-boundaries.md (COM confinement to OpenClaw.MailBridge; deterministic COM release)
+6. .claude/rules/quality-tiers.md (uniform coverage: line >= 85%, branch >= 75%)
+
+Files Read (explicit list):
+- C:\Users\DanMoisan\repos\open-claw-bridge-wt-2026-06-13-10-27\.claude\rules\general-code-change.md
+- C:\Users\DanMoisan\repos\open-claw-bridge-wt-2026-06-13-10-27\.claude\rules\general-unit-test.md
+- C:\Users\DanMoisan\repos\open-claw-bridge-wt-2026-06-13-10-27\.claude\rules\csharp.md
+- C:\Users\DanMoisan\repos\open-claw-bridge-wt-2026-06-13-10-27\.claude\rules\architecture-boundaries.md
+- C:\Users\DanMoisan\repos\open-claw-bridge-wt-2026-06-13-10-27\.claude\rules\quality-tiers.md
+- CLAUDE.md content provided via auto-loaded system context (benchmark-baselines, ci-workflows, general-code-change, general-unit-test, quality-tiers, tonality)
+
+Output Summary: All six policy sources read in required order prior to execution of [P0-T1]. Languages in scope: C# only. Toolchain order confirmed: CSharpier format -> dotnet build with analyzers -> nullable (TreatWarningsAsErrors) -> architecture/COM-confinement review -> dotnet test with coverage. Coverage gates: line >= 85%, branch >= 75%, no regression on changed lines. 500-line file cap applies to all production and test files. COM confined to OpenClaw.MailBridge with deterministic release.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/contract-unchanged.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/contract-unchanged.2026-06-13T14-41.md
@@ -1,0 +1,16 @@
+# EventDto Contract-Shape Verification (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: git diff --stat -- src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs ; git diff --name-only ; git status --short
+EXIT_CODE: 0
+
+Output Summary:
+- BridgeContracts.cs: NO diff. The EventDto record definition (positional argument count and order) is identical to the pre-change state. RequiredAttendeesJson / OptionalAttendeesJson / ResourcesJson remain `string?` positional parameters in the same positions (12th-14th).
+- The only production change to EventDto data flow is in BuildEventDto (OutlookScanner.GraphFields.cs): the three `null` literals at the attendee positions became `attendees.RequiredJson` / `attendees.OptionalJson` / `attendees.ResourcesJson`. Argument count and order are unchanged.
+- Changed/added files (confined to OutlookScanner.* and ResponseShaper.cs, plus the new COM helper and test doubles/tests):
+  - Modified production: src/OpenClaw.MailBridge/OutlookComHelpers.cs, src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs, src/OpenClaw.MailBridge/ResponseShaper.cs
+  - New production: src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs
+  - Test files: MailBridgeRuntimeTestDoubles.cs, ResponseShaperEventBodyFullTests.cs, OutlookScannerAttendeesShapeTests.cs (new), OutlookScannerAttendeesTests.cs (new)
+- No change to BridgeContracts.cs, no SQLite schema change, no CacheRepository column change.
+
+Verdict: US-AC6 contract-shape requirement satisfied — no EventDto contract shape change.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/coverage-delta.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/coverage-delta.2026-06-13T14-41.md
@@ -1,0 +1,29 @@
+# Coverage Delta & Threshold Verdict (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: (analysis of baseline-test.2026-06-13T14-41.md vs final-test.2026-06-13T14-41.md cobertura)
+EXIT_CODE: 0
+
+## Solution Coverage (OpenClaw.MailBridge.Tests cobertura)
+
+| Metric | Baseline ([P0-T5]) | Post-change ([P4-T5]) | Delta | Threshold | Verdict |
+|---|---|---|---|---|---|
+| Line coverage | 93.55% (973/1040) | 94.07% (1064/1131) | +0.52 pp | >= 85% | PASS |
+| Branch coverage | 85.47% (259/303) | 86.54% (283/327) | +1.07 pp | >= 75% | PASS |
+
+Coverage increased on both metrics; no regression.
+
+## Changed-Code Coverage (new/modified files)
+
+| File | Status | Line | Branch |
+|---|---|---|---|
+| OpenClaw.MailBridge\OutlookScanner.Attendees.cs | new | 100% | 100% |
+| OpenClaw.MailBridge\OutlookScanner.GraphFields.cs | modified (3 nulls -> populated) | 100% | 100% |
+| OpenClaw.MailBridge\ResponseShaper.cs | modified (safe-mode attendee nulls) | 100% | 100% |
+| OpenClaw.MailBridge\OutlookComHelpers.cs (GetOptionalIndexedItem) | new method | fully covered | n/a (try/catch) |
+
+Baseline per-file: GraphFields.cs and ResponseShaper.cs were both 100% line/branch at baseline and remain 100% after change — no regression on changed lines. The new Attendees.cs and the new GetOptionalIndexedItem helper method are fully covered, including the fail-soft catch path (exercised by ScanCalendar_should_fail_soft_when_a_recipient_read_throws).
+
+## Verdict
+
+PASS. Line 94.07% >= 85%, branch 86.54% >= 75%, no regression on changed lines (all changed/new code at 100% or fully covered).

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-architecture.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-architecture.2026-06-13T14-41.md
@@ -1,0 +1,14 @@
+# Final QA — Architecture / COM Confinement (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: git diff --name-only -- '*.csproj' ; grep ProjectReference src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj ; git status --short
+EXIT_CODE: 0
+
+Output Summary:
+- Project graph unchanged: `git diff --name-only -- '*.csproj'` returned no results. No new ProjectReference edges were added.
+- OpenClaw.MailBridge.csproj retains a single project reference to OpenClaw.MailBridge.Contracts, consistent with architecture-boundaries rule 2.
+- COM confinement holds: all new/modified Outlook COM access (Recipients collection enumeration, Item(index), Type/Name/Address, AddressEntry resolution) is implemented via late-bound reflection in OutlookComHelpers.GetOptionalIndexedItem and OutlookScanner.ReadAttendees, both located in OpenClaw.MailBridge — the only project permitted to perform Outlook COM (architecture-boundaries COM rule 1).
+- No COM types are exposed across project boundaries: the carrier (AttendeeJsonSet) and projection (Attendee) are plain managed records internal to OpenClaw.MailBridge; EventDto (the cross-boundary contract) carries only string?/JSON values.
+- Deterministic COM release: every wrapper obtained during enumeration (the Recipients collection, each Recipient, and any AddressEntry) is released in a finally via _com.ReleaseAll, following the GetStoreId idiom.
+
+Architecture gate: PASS.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-build.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-build.2026-06-13T14-41.md
@@ -1,0 +1,6 @@
+# Final QA — Build / Analyzers (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). 0 analyzer errors. Lint gate: PASS.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-format.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-format.2026-06-13T14-41.md
@@ -1,0 +1,12 @@
+# Final QA — CSharpier Formatting (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: csharpier format . ; csharpier check .
+EXIT_CODE: 0
+
+Output Summary:
+- csharpier format .: Formatted 161 files in 486ms (EXIT 0). Two new feature files were reflowed by the formatter: src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs (JsonSerializerOptions initializer) and tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesTests.cs (one assertion wrap).
+- csharpier check .: Checked 161 files in 337ms (EXIT 0). No files require formatting; clean pass.
+- Note: the bare `csharpier .` form printed help in csharpier 1.3.0; the documented `csharpier format .` subcommand was used to format and `csharpier check .` to verify, per the plan's allowance of the csharpier CLI.
+
+Format gate: PASS.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-nullable.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-nullable.2026-06-13T14-41.md
@@ -1,0 +1,6 @@
+# Final QA — Nullable / Type-Check (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true
+EXIT_CODE: 0
+Output Summary: Build succeeded. 0 Warning(s), 0 Error(s). 0 nullable warnings-as-errors. Type-check gate: PASS.

--- a/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-test.2026-06-13T14-41.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-test.2026-06-13T14-41.md
@@ -1,0 +1,20 @@
+# Final QA — Test + Coverage (Issue #71)
+
+Timestamp: 2026-06-13T14-41
+Command: dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"
+EXIT_CODE: 0
+
+Output Summary:
+- Test result: PASS. Failed: 0, Passed: 474 (MailBridge.Tests 216, Core.Tests 184, HostAdapter.Tests 74), Skipped: 3, Total: 477.
+- New tests added in this feature (12): OutlookScannerAttendeesShapeTests (3 pure-shaping), OutlookScannerAttendeesTests (7 scanner-path incl. fail-soft), ResponseShaperEventBodyFullTests (2 attendee redaction).
+- Coverage source: tests/OpenClaw.MailBridge.Tests/TestResults/82e0c0f9-12e0-4ea3-9f69-873a62abd6dc/coverage.cobertura.xml (coverlet XPlat Code Coverage).
+- Post-change MailBridge solution coverage:
+  - Line coverage: 94.07% (lines-covered 1064 / lines-valid 1131)
+  - Branch coverage: 86.54% (branches-covered 283 / branches-valid 327)
+- Changed-code per-file coverage:
+  - OpenClaw.MailBridge\OutlookScanner.Attendees.cs (new): line 100%, branch 100%
+  - OpenClaw.MailBridge\OutlookScanner.GraphFields.cs (modified): line 100%, branch 100%
+  - OpenClaw.MailBridge\ResponseShaper.cs (modified): line 100%, branch 100%
+  - OpenClaw.MailBridge\OutlookComHelpers.cs new method GetOptionalIndexedItem: fully covered (catch path exercised by ScanCalendar_should_fail_soft_when_a_recipient_read_throws)
+
+Thresholds satisfied: line 94.07% >= 85%, branch 86.54% >= 75%. Test gate: PASS.

--- a/docs/features/active/mailbridge-event-attendees-json-71/feature-audit.2026-06-13T14-52.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/feature-audit.2026-06-13T14-52.md
@@ -1,0 +1,117 @@
+# Feature Audit: mailbridge-event-attendees-json (#71)
+
+**Audit Date:** 2026-06-13
+**Feature Folder:** `docs/features/active/mailbridge-event-attendees-json-71`
+**Base Branch:** `main`
+**Head Branch:** `open-claw-bridge-wt-2026-06-13-10-27`
+**Work Mode:** `full-feature`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `c0fa1024f61eac924331ac3757f1acbc5d724b03`)
+- **Head branch/commit:** `open-claw-bridge-wt-2026-06-13-10-27` (commit `65a5f8d5a750bf11166d4469ade4d6d7a0921ce8`)
+- **Merge base:** `c0fa1024f61eac924331ac3757f1acbc5d724b03`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt`
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt`
+  - Feature evidence: `docs/features/active/mailbridge-event-attendees-json-71/evidence/**`
+  - Additional evidence: `tests/OpenClaw.MailBridge.Tests/TestResults/82e0c0f9-12e0-4ea3-9f69-873a62abd6dc/coverage.cobertura.xml`
+- **Feature folder used:** `docs/features/active/mailbridge-event-attendees-json-71`
+- **Requirements source:** `spec.md` and `user-story.md`
+- **Work mode resolution note:** No `issue.md` exists in the feature folder, so the work-mode marker is missing. Per the fail-closed rule, the work mode resolves to `full-feature`, making `spec.md` and `user-story.md` the authoritative AC sources. This matches the caller-supplied AC source files.
+- **Scope note:** Audit is feature-vs-base over the full branch diff. C# is the only language with changed files. No scope narrowing was applied.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `docs/features/active/mailbridge-event-attendees-json-71/user-story.md` — primary (checkbox `## Acceptance Criteria`)
+- `docs/features/active/mailbridge-event-attendees-json-71/spec.md` — secondary (`## Definition of Done` checkboxes)
+
+### From user-story.md (## Acceptance Criteria)
+
+1. A scan of a meeting with known attendees returns non-null `RequiredAttendeesJson`, `OptionalAttendeesJson`, and `ResourcesJson` (as applicable) with correct names and emails in enhanced mode.
+2. Each populated field is a JSON array of `{"name","email"}` objects matching the Graph `emailAddress` shape (lowercase `name` and `email` keys, collection order preserved).
+3. A unit test asserts the JSON structure per attendee type: `Type 1` -> required, `Type 2` -> optional, `Type 3` -> resource; recipients with other `Type` values are excluded.
+4. Safe mode (`BridgeSettings.Mode == "safe"`) nulls all three attendee JSON fields via `ResponseShaper.ShapeEvent`, matching the existing redaction of `SenderName`/`SenderEmail`, and a unit test asserts this redaction.
+5. A recipient missing a name or resolvable email emits an empty string for the missing value with both keys still present, covered by a unit test.
+6. No `EventDto` contract shape change; line and branch coverage thresholds hold (line >= 85%, branch >= 75%) with no regression on changed lines.
+
+### From spec.md (## Definition of Done)
+
+DoD-1. Acceptance criteria documented and mapped to tests or demos.
+DoD-2. Behavior matches acceptance criteria in all documented environments.
+DoD-3. Tests updated/added (unit/integration as applicable).
+DoD-4. Edge cases and error handling covered by tests.
+DoD-5. Docs updated (README, docs/features/active/... links) if applicable.
+DoD-6. Telemetry/logging added or updated (if applicable).
+DoD-7. Toolchain pass completed (format → lint → type-check → test).
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| 1 | Enhanced-mode population with correct names/emails | PASS | `ReadAttendees` populates the three fields; `ScanCalendar_should_populate_all_three_attendee_fields_in_enhanced_mode` asserts exact name/email per type. GraphFields.cs diff replaces the three `null` literals. | `dotnet test ... --collect:"XPlat Code Coverage"` | Verified via diff + final-test gate (EXIT 0). |
+| 2 | JSON array of `{"name","email"}`, lowercase keys, order preserved | PASS | `AttendeeJson` uses `JsonPropertyName("name"/"email")`; `ShapeAttendeeJson_should_emit_lowercase_keys_and_preserve_order` asserts the exact JSON string in collection order. | `dotnet test ...` | Graph `emailAddress` shape confirmed. |
+| 3 | Per-type classification (1/2/3) with out-of-range exclusion, asserted by a unit test | PASS | `ReadAttendees` switch on `Type`; `ScanCalendar_should_classify_by_type_and_exclude_out_of_range` asserts only types 1/2/3 land and types 0/4 are excluded. | `dotnet test ...` | Matches spec SP-B2. |
+| 4 | Safe mode nulls all three fields via `ResponseShaper.ShapeEvent`, asserted by a unit test | PASS | ResponseShaper.cs safe-mode branch sets the three fields to null; `ShapeEvent_in_safe_mode_should_null_all_three_attendee_fields` asserts null + `IsRedacted`. Enhanced-mode preservation also asserted. | `dotnet test ...` | Parity with `SenderName`/`SenderEmail` redaction. |
+| 5 | Missing name/email emits empty string, both keys present, unit-tested | PASS | Coalescing to `string.Empty` in `ReadAttendees`/`SerializeAttendees`; `ScanCalendar_should_emit_both_keys_when_name_or_email_missing` and `ShapeAttendeeJson_should_keep_both_keys_when_a_value_is_missing` assert this. | `dotnet test ...` | AddressEntry fallback also covered. |
+| 6 | No `EventDto` contract change; coverage thresholds hold; no regression on changed lines | PASS | `BridgeContracts.cs` no diff (`contract-unchanged.2026-06-13T14-41.md`); solution 94.07% line / 86.54% branch; changed prod files 100% line/branch (cobertura directly parsed). | `git diff -- ...BridgeContracts.cs`; parse `coverage.cobertura.xml` | Baseline 93.55%/85.47% -> +0.52pp/+1.07pp; no regression. |
+| DoD-1 | AC documented and mapped to tests | PASS | AC in user-story.md mapped to named tests in this audit. | n/a | — |
+| DoD-2 | Behavior matches AC in documented environments | PASS | Toolchain green; tests assert documented behavior. | `dotnet test ...` | — |
+| DoD-3 | Tests added | PASS | 12 new tests across 4 test files. | `dotnet test ...` | — |
+| DoD-4 | Edge cases and error handling covered | PASS | Out-of-range type, missing name/email, AddressEntry fallback, empty/absent collection, fail-soft on throw all covered. | `dotnet test ...` | — |
+| DoD-5 | Docs updated | PASS | spec.md, user-story.md, plan, and evidence artifacts present. | n/a | No README change required (internal data flow). |
+| DoD-6 | Telemetry/logging | PASS | None required per spec; none added. | n/a | Correctly N/A handled as PASS (no obligation). |
+| DoD-7 | Toolchain pass (format/lint/type/test) | PASS | All gate artifacts EXIT 0 (`final-format`, `final-build`, `final-nullable`, `final-test`). | see Appendix B of policy audit | — |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+**Criteria summary:**
+- **PASS:** 13 criteria (6 user-story AC + 7 spec DoD)
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 0 criteria
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. None.
+
+**Recommended follow-up verification steps:**
+
+1. On PR creation, confirm CI runs the same `dotnet test ... --collect:"XPlat Code Coverage"` path and reports green against the head SHA (orchestrator S9 gate; no workflow files changed, so `modified-workflow-needs-green-run` does not fire).
+2. None further; all AC verified from existing evidence.
+
+---
+
+## Acceptance Criteria Check-off
+
+Per the acceptance-criteria tracking rules:
+- All six user-story AC and all seven spec DoD checkboxes were already marked `[x]` by the executor in the source files prior to this review.
+- Each was independently re-verified as PASS in this audit; no checkbox state change was required because all delivered items were already checked.
+- No PARTIAL/FAIL/UNVERIFIED criteria exist, so no checkbox needed to be reverted.
+
+### AC Status Summary
+
+- Source: `docs/features/active/mailbridge-event-attendees-json-71/user-story.md`, `docs/features/active/mailbridge-event-attendees-json-71/spec.md`
+- Total AC items: 13 (6 user-story + 7 spec DoD)
+- Checked off (delivered): 13
+- Remaining (unchecked): 0
+- Items remaining: None.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `user-story.md` | 6 | 6 | 0 | Checkbox-backed; all already `[x]` and re-verified PASS. |
+| `spec.md` | 7 | 7 | 0 | Checkbox-backed (Definition of Done); all already `[x]` and re-verified PASS. |
+
+No source-file checkbox change was made: all items were already checked by the executor and every item re-verified as PASS, so no `[ ]` -> `[x]` transition was needed.

--- a/docs/features/active/mailbridge-event-attendees-json-71/plan.2026-06-13T10-31.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/plan.2026-06-13T10-31.md
@@ -1,0 +1,208 @@
+# mailbridge-event-attendees-json — Plan
+
+- **Issue:** #71
+- **Parent (optional):** Track M (MailBridge DTO/scanner): #72 -> #71 -> #73
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-13T10-31
+- **Status:** Draft
+- **Version:** 0.2
+- **Work Mode:** full-feature (no `Work Mode` marker present in `issue.md`; resolves to full-feature per mode-source-precedence fail-closed rule, consistent with the caller directive)
+
+## Required References
+
+Policy compliance is governed by the auto-loaded `.claude/rules/` files. This plan does not duplicate their content. The authoritative policy set for this feature is:
+
+- `CLAUDE.md` (standing instructions)
+- `.claude/rules/general-code-change.md` (cross-language code change policy; seven-stage toolchain; 500-line file cap)
+- `.claude/rules/general-unit-test.md` (cross-language unit test policy; determinism; no temp files)
+- `.claude/rules/csharp.md` (C# toolchain: CSharpier -> SDK analyzers -> nullable -> architecture -> MSTest + coverage)
+- `.claude/rules/architecture-boundaries.md` (COM confinement to `OpenClaw.MailBridge`; deterministic COM release)
+- `.claude/rules/quality-tiers.md` (uniform coverage: line >= 85%, branch >= 75%; T2/T3 surface in scope)
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Requirement Sources (Authoritative Acceptance Criteria)
+
+- `docs/features/active/mailbridge-event-attendees-json-71/spec.md` — Definition of Done (lines 109–116) and Behavior/Constraints sections.
+- `docs/features/active/mailbridge-event-attendees-json-71/user-story.md` — Acceptance Criteria (lines 42–55).
+
+### Acceptance Criteria Identifiers
+
+User-story Acceptance Criteria (US-AC):
+
+- **US-AC1** — A scan of a meeting with known attendees returns non-null `RequiredAttendeesJson`, `OptionalAttendeesJson`, `ResourcesJson` (as applicable) with correct names and emails in enhanced mode.
+- **US-AC2** — Each populated field is a JSON array of `{"name","email"}` objects matching the Graph `emailAddress` shape (lowercase `name`/`email` keys, collection order preserved).
+- **US-AC3** — A unit test asserts per-type classification: `Type 1` -> required, `Type 2` -> optional, `Type 3` -> resource; recipients with other `Type` values are excluded.
+- **US-AC4** — Safe mode (`BridgeSettings.Mode == "safe"`) nulls all three attendee JSON fields via `ResponseShaper.ShapeEvent`, matching the existing redaction of `SenderName`/`SenderEmail`, asserted by a unit test.
+- **US-AC5** — A recipient missing a name or resolvable email emits an empty string for the missing value with both keys still present, covered by a unit test.
+- **US-AC6** — No `EventDto` contract shape change; line and branch coverage thresholds hold (line >= 85%, branch >= 75%) with no regression on changed lines.
+
+Spec Definition-of-Done (SP-DoD), spec lines 109–116:
+
+- **SP-DoD1** — Acceptance criteria documented and mapped to tests or demos.
+- **SP-DoD2** — Behavior matches acceptance criteria in all documented environments.
+- **SP-DoD3** — Tests updated/added (unit/integration as applicable).
+- **SP-DoD4** — Edge cases and error handling covered by tests.
+- **SP-DoD5** — Docs updated if applicable.
+- **SP-DoD6** — Telemetry/logging added or updated (if applicable).
+- **SP-DoD7** — Toolchain pass completed (format -> lint -> type-check -> test).
+
+Spec Behavior/Constraints supplementary criteria:
+
+- **SP-B1** — Empty-collection representation: a type with no recipients yields `[]` (not null); null is reserved for safe-mode redaction / unread state (spec lines 36–39, 88–90).
+- **SP-B2** — Out-of-range `Type` values are ignored (spec line 42).
+- **SP-B3** — Per-recipient COM read failure must not abort the event scan (fail-soft per recipient; spec lines 43–47).
+- **SP-B4** — All COM objects obtained while enumerating `Recipients` (the collection and each `Recipient`) are released deterministically (spec lines 45–47; architecture-boundaries COM confinement).
+- **SP-B5** — `ProtectedFieldsAvailable` decision: attendee readability must not weaken the existing body-derived signal (spec lines 83–85).
+
+## Verified Current State (confirmed by reading)
+
+- `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` — `BuildEventDto` hardcodes the three attendee JSON fields to `null` at positional arguments on lines 44 (RequiredAttendeesJson), 45 (OptionalAttendeesJson), 46 (ResourcesJson). File is 104 lines.
+- `src/OpenClaw.MailBridge/OutlookScanner.cs` — 485 lines. The `GetStoreId` enumerate-then-release idiom (lines 463–484) uses `try/finally` with `_com.ReleaseAll(store, parent)`. The `_com` field is a `ComActiveObject` (line 23).
+- `src/OpenClaw.MailBridge/OutlookComHelpers.cs` — 133 lines. Provides `GetOptionalString`, `GetOptionalInt`, `GetOptionalMemberValue`, `GetMemberValue`, `InvokeMember`, all internal static, fail-soft (catch -> null/default).
+- `src/OpenClaw.MailBridge/ComActiveObject.cs` — `ReleaseAll(params object?[])` releases in reverse acquisition order (lines 118–124).
+- `src/OpenClaw.MailBridge/ResponseShaper.cs` — `ShapeEvent` safe-mode branch (lines 53–58) currently nulls `BodyPreview` and `BodyFull` and sets `IsRedacted = true`. It does NOT null the three attendee JSON fields. `ShapeMessage` safe-mode branch (lines 25–31) is the parity reference: it nulls `SenderName`/`SenderEmail`.
+- `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` — `EventDto` (lines 94–122); the three fields are `string?` at lines 106–108. NO contract shape change is permitted.
+- `tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs` — `FakeAppointmentItem` (record, lines 115–138) is read by reflection in `BuildEventDto`; `FakeComActiveObject` (lines 7–31) subclasses `ComActiveObject`. A `Recipients` analog must be added to `FakeAppointmentItem` so the helper can enumerate without live COM.
+- `tests/OpenClaw.MailBridge.Tests/OutlookScannerGraphFieldsTests.cs` — established scanner-population test pattern (scan -> single event assertion).
+- `tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs` — established `ShapeEvent` redaction test pattern.
+- `mailbridge.runsettings` — present at repo root; coverage collected via `coverlet.collector`.
+
+## Design Decisions Encoded in This Plan
+
+1. **Recipient enumeration + grouping helper** is implemented as a new partial-class file `src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs` (rather than growing `OutlookScanner.GraphFields.cs` to risk, or `OutlookScanner.cs` already at 485 lines). The helper performs a single pass over the COM `Recipients` collection, classifies each recipient by `Type` (1=required, 2=optional, 3=resource), and releases every COM wrapper (the collection and each `Recipient`, plus any `AddressEntry` obtained) deterministically via `_com.ReleaseAll` in a `try/finally`, following the `GetStoreId` idiom.
+2. **Pure/COM separation.** The COM-reading method extracts each recipient into a small immutable in-memory record (display name + email + classified type) and delegates JSON shaping to a pure static function that accepts three ordered lists and returns three JSON strings. The pure function is unit-testable without COM.
+3. **Carrier.** The COM method returns a small immutable carrier (e.g., a `readonly record struct` holding `RequiredJson`, `OptionalJson`, `ResourcesJson` strings) consumed by `BuildEventDto`, which substitutes its three results for the three `null` literals at lines 44–46.
+4. **Email source.** Email is resolved from the simplest reliable SMTP source available on the COM `Recipient` surface, attempted in order: `Recipient.Address`, then `Recipient.AddressEntry` resolution when `Address` is unavailable. When no value is resolvable, emit empty string `""`. Both `name` and `email` keys are always present in every object (US-AC5, SP behavior).
+5. **Empty-collection representation (SP-B1, resolves spec open question).** A type with zero recipients serializes to the empty array string `"[]"`, NOT null. Null is reserved for safe-mode redaction and unread/unpopulated state, so a consumer can distinguish "no attendees of this type" (`"[]"`) from "redacted" (`null`).
+6. **Safe-mode parity (US-AC4, SP security).** `ResponseShaper.ShapeEvent` safe-mode branch additionally nulls `RequiredAttendeesJson`, `OptionalAttendeesJson`, and `ResourcesJson`, matching the message-path redaction of `SenderName`/`SenderEmail`.
+7. **`ProtectedFieldsAvailable` decision (SP-B5).** The existing `ProtectedFieldsAvailable` signal remains derived solely from body availability (`!string.IsNullOrWhiteSpace(body)` at line 48). Attendee readability does NOT contribute to or gate that flag. Rationale: weakening or broadening the body-derived signal would change existing #72 behavior outside this issue's scope; attendee PII protection is enforced by safe-mode redaction (decision 6), which is the established mechanism. This decision is recorded in the helper/`BuildEventDto` XML doc and verified by a non-regression assertion.
+8. **Serialization.** `System.Text.Json` with explicit lowercase property names `name` and `email` and a fixed (deterministic) property order; no culture-dependent formatting. Serialization options are constructed once (static) to avoid per-call allocation and to guarantee determinism.
+
+## Constraints
+
+- Languages in scope: **C# only**. Tiers: T2 (MailBridge managed surface) / T3 (Outlook-COM-confined surface).
+- All Outlook COM stays in `OpenClaw.MailBridge`; release COM deterministically (architecture-boundaries).
+- 500-line file cap for every production and test file.
+- Tests: MSTest + Moq + FluentAssertions under `tests/OpenClaw.MailBridge.Tests/`; no temp files; no live COM; deterministic clock seam already present (`() => FixedNow`).
+- Coverage gates: line >= 85%, branch >= 75%; no regression on changed lines.
+
+## Evidence Location Invariant
+
+All evidence artifacts produced by executing this plan MUST be written under the canonical scheme `docs/features/active/mailbridge-event-attendees-json-71/evidence/<kind>/`. Baseline evidence -> `evidence/baseline/`; QA-gate evidence -> `evidence/qa-gates/`; regression-testing evidence -> `evidence/regression-testing/`. Non-canonical paths such as `artifacts/baselines/`, `artifacts/qa/`, or `artifacts/coverage/` are forbidden and will be rejected by the `enforce-evidence-locations.ps1` PreToolUse hook. If a caller supplies a non-canonical path, substitute the canonical path and record `EVIDENCE_LOCATION_OVERRIDE_REJECTED: <supplied> replaced with <canonical>`.
+
+Timestamp format for all evidence artifacts: `yyyy-MM-ddTHH-mm` (ISO-8601). Each command-step artifact MUST include `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`. Baseline and final-QC test-step artifacts MUST record numeric coverage values (line %, branch %, and changed-code %), not placeholders.
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Baseline Capture & Policy Read
+
+- [x] [P0-T1] Read the policy files in the required order (`CLAUDE.md`, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/csharp.md`, `.claude/rules/architecture-boundaries.md`, `.claude/rules/quality-tiers.md`) and record a Phase 0 policy-read evidence artifact.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/phase0-instructions-read.<timestamp>.md` exists and contains `Timestamp:`, `Policy Order:`, and the explicit list of files read.
+- [x] [P0-T2] Capture the baseline CSharpier formatting state by running `dotnet csharpier check .` (or `csharpier check .`) from repo root.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-format.<timestamp>.md` records `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` (pass/fail and any files needing formatting).
+- [x] [P0-T3] Capture the baseline build/analyzer state by running `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-build.<timestamp>.md` records `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` (warning/error counts).
+- [x] [P0-T4] Capture the baseline nullable/type-check state by running `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-nullable.<timestamp>.md` records `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:`.
+- [x] [P0-T5] Capture the baseline test + coverage state by running `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-test.<timestamp>.md` records `Timestamp:`, `Command:`, `EXIT_CODE:`, and `Output Summary:` including numeric baseline line coverage % and branch coverage % for the MailBridge solution (the pre-change reference for the no-regression check in [P4-T6]).
+
+### Phase 1 — Pure JSON Shaping (COM-free, test-first)
+
+- [x] [P1-T1] Create the pure attendee model and JSON-shaping function in a new file `src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs`: define an internal immutable record carrier (`AttendeeJsonSet` with `RequiredJson`, `OptionalJson`, `ResourcesJson`) and a pure static method that accepts three ordered `IReadOnlyList<(string Name, string Email)>` inputs and serializes each to a JSON array of `{"name","email"}` objects using a single static `JsonSerializerOptions` with lowercase `name`/`email` keys and deterministic property order.
+  - Acceptance: file compiles; the pure method has no COM dependency; an empty input list serializes to `"[]"`; file is under 500 lines. (US-AC2, SP-B1, design decisions 2/5/8)
+- [x] [P1-T2] Add a unit test file `tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesShapeTests.cs` asserting the pure shaping function emits lowercase `name`/`email` keys, preserves input order, and matches the Graph `emailAddress` shape for a multi-attendee list.
+  - Acceptance: test passes; assertion verifies exact JSON string for a two-element list. (US-AC2)
+- [x] [P1-T3] Add a unit test to `OutlookScannerAttendeesShapeTests.cs` asserting an empty input list serializes to `"[]"` (not null) for each of the three groups.
+  - Acceptance: test passes. (US-AC2, SP-B1)
+- [x] [P1-T4] Add a unit test to `OutlookScannerAttendeesShapeTests.cs` asserting a recipient with a missing name emits `"name":""` with the `email` key present, and a recipient with a missing email emits `"email":""` with the `name` key present.
+  - Acceptance: test passes; both keys always present. (US-AC5, SP behavior)
+
+### Phase 2 — COM Recipient Enumeration & BuildEventDto Wiring
+
+- [x] [P2-T1] Implement a private instance method on the `OutlookScanner` partial in `src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs` that reads the COM `Recipients` collection from `item`, enumerates it in a single pass (`Count` + 1-based `Item(index)` via `OutlookComHelpers`), reads each recipient's `Type`, `Name`, and email (from `Address`, falling back to `AddressEntry` resolution), classifies into required/optional/resource lists by `Type` (1/2/3), and ignores out-of-range `Type` values. Use `OutlookComHelpers.GetOptional*` for fail-soft per-recipient reads.
+  - Acceptance: method compiles; per-recipient read failures do not throw (fail-soft); out-of-range `Type` values are excluded. (US-AC1, US-AC3, SP-B2, SP-B3)
+- [x] [P2-T2] In the same method, release every COM wrapper obtained during enumeration — the `Recipients` collection, each `Recipient`, and any `AddressEntry` — deterministically in a `try/finally` using `_com.ReleaseAll`, following the `GetStoreId` idiom (`OutlookScanner.cs` lines 463–484).
+  - Acceptance: every acquired COM object is released in the `finally`; no RCW accumulation path remains. (SP-B4, architecture-boundaries COM confinement)
+- [x] [P2-T3] Have the COM method delegate to the Phase 1 pure shaping function and return the `AttendeeJsonSet` carrier; a `Recipients` collection that is null or empty yields `"[]"` for all three fields.
+  - Acceptance: method returns three non-null JSON strings; null/empty `Recipients` yields three `"[]"` values. (US-AC1, SP-B1)
+- [x] [P2-T4] Update `BuildEventDto` in `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` to call the COM enumeration method once and replace the three `null` positional arguments at lines 44–46 with `RequiredJson`, `OptionalJson`, `ResourcesJson` from the carrier. Do not change argument count or order.
+  - Acceptance: `EventDto` construction passes the three attendee JSON strings; positional argument count/order unchanged; solution builds. (US-AC1, US-AC6)
+- [x] [P2-T5] Confirm and document (in the method/`BuildEventDto` XML doc) that `ProtectedFieldsAvailable` remains derived solely from body availability (`!string.IsNullOrWhiteSpace(body)`, line 48) and is not altered by attendee readability.
+  - Acceptance: line 48 logic is unchanged; XML doc states the decision. (SP-B5, design decision 7)
+- [x] [P2-T6] Extend `FakeAppointmentItem` in `tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs` with a `Recipients` analog that supports reflection-based COM-style enumeration (`Count` and 1-based `Item(index)`), where each recipient exposes `Type`, `Name`, and `Address`/`AddressEntry`, so the COM enumeration method can be exercised without live COM.
+  - Acceptance: the double is reflection-readable by `OutlookComHelpers`; no live COM; no temp files; file remains under 500 lines (split into a sibling doubles file if the cap is approached). (csharp testing standards)
+- [x] [P2-T7] Add a unit test to `tests/OpenClaw.MailBridge.Tests/OutlookScannerGraphFieldsTests.cs` (or a new sibling `OutlookScannerAttendeesTests.cs` if the file nears 500 lines) asserting that a scanned meeting with required, optional, and resource recipients yields non-null `RequiredAttendeesJson`/`OptionalAttendeesJson`/`ResourcesJson` with correct names and emails in enhanced mode.
+  - Acceptance: test passes; emails and names match the input recipients. (US-AC1)
+- [x] [P2-T8] Add a unit test asserting per-type classification: a recipient with `Type 1` appears only in required, `Type 2` only in optional, `Type 3` only in resource, and a recipient with an out-of-range `Type` (e.g., 0 or 4) appears in none of the three fields.
+  - Acceptance: test passes; out-of-range recipient is excluded from all three. (US-AC3, SP-B2)
+- [x] [P2-T9] Add a unit test asserting a recipient with a missing name and a recipient with a missing email each produce objects with both `name` and `email` keys present and the missing value as `""`, via the scanner path.
+  - Acceptance: test passes. (US-AC5)
+- [x] [P2-T10] Add a unit test asserting a meeting with no recipients of a given type yields `"[]"` (not null) for that field in enhanced mode, and a meeting with an empty/absent `Recipients` collection yields `"[]"` for all three.
+  - Acceptance: test passes; distinguishes `"[]"` (no attendees) from `null` (redacted). (SP-B1)
+
+### Phase 3 — Safe-Mode Redaction Parity
+
+- [x] [P3-T1] Update the safe-mode branch of `ResponseShaper.ShapeEvent` in `src/OpenClaw.MailBridge/ResponseShaper.cs` (lines 53–58) to additionally null `RequiredAttendeesJson`, `OptionalAttendeesJson`, and `ResourcesJson`, alongside the existing `BodyPreview`/`BodyFull` nulling and `IsRedacted = true`. Update the method comment to state attendee-PII redaction parity with `ShapeMessage`.
+  - Acceptance: safe-mode branch nulls all three attendee fields; enhanced-mode branch leaves them intact. (US-AC4, SP security)
+- [x] [P3-T2] Add a unit test to `tests/OpenClaw.MailBridge.Tests/ResponseShaperTests.cs` (or `ResponseShaperEventBodyFullTests.cs`) asserting that `ShapeEvent` in safe mode nulls all three attendee JSON fields and sets `IsRedacted = true`, using an `EventDto` whose three fields are populated.
+  - Acceptance: test passes; all three fields null in safe mode. (US-AC4)
+- [x] [P3-T3] Add a unit test asserting that `ShapeEvent` in enhanced mode preserves all three populated attendee JSON fields unchanged.
+  - Acceptance: test passes; enhanced mode does not null the attendee fields. (US-AC4 non-regression)
+
+### Phase 4 — Final QA Loop & Coverage Verification
+
+Run the full C# toolchain in order. If any step fails or changes files, restart from [P4-T1].
+
+- [x] [P4-T1] Run formatting: `dotnet csharpier .` (or `csharpier .`) from repo root, then re-run `dotnet csharpier check .` to confirm a clean pass.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-format.<timestamp>.md` records `Timestamp:`, `Command:`, `EXIT_CODE:` (0), and `Output Summary:` (no files need formatting). If files changed, restart from [P4-T1]. (SP-DoD7)
+- [x] [P4-T2] Run linting/analyzers: `dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-build.<timestamp>.md` records `Timestamp:`, `Command:`, `EXIT_CODE:` (0), and `Output Summary:` (0 analyzer errors). (SP-DoD7)
+- [x] [P4-T3] Run type checking (nullable): `dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true`.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-nullable.<timestamp>.md` records `Timestamp:`, `Command:`, `EXIT_CODE:` (0), and `Output Summary:` (0 nullable warnings-as-errors). (SP-DoD7)
+- [x] [P4-T4] Verify architecture/COM-confinement: confirm no new `ProjectReference` edges were added and all Outlook COM access remains inside `OpenClaw.MailBridge` (the new partial is in that project; no COM types leaked to other projects).
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-architecture.<timestamp>.md` records the project-graph review result and confirms COM confinement holds. (architecture-boundaries)
+- [x] [P4-T5] Run tests with coverage: `dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`.
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-test.<timestamp>.md` records `Timestamp:`, `Command:`, `EXIT_CODE:` (0), and `Output Summary:` with numeric post-change line coverage % and branch coverage %, and the total/passed test counts. All tests pass. (SP-DoD3, SP-DoD7)
+- [x] [P4-T6] Compute and record the coverage delta and threshold verdict: compare baseline coverage ([P0-T5]) against post-change coverage ([P4-T5]); report changed-code coverage for the new/modified files (`OutlookScanner.Attendees.cs`, `OutlookScanner.GraphFields.cs`, `ResponseShaper.cs`).
+  - Acceptance: `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/coverage-delta.<timestamp>.md` reports baseline %, post-change %, changed-code %; confirms line >= 85%, branch >= 75%, and no regression on changed lines. If any threshold fails, outcome is remediation-required (not PASS). (US-AC6)
+- [x] [P4-T7] Confirm `EventDto` contract shape is unchanged: verify `src/OpenClaw.MailBridge.Contracts/Models/BridgeContracts.cs` `EventDto` positional argument count and order are identical to the pre-change state (only the three `null` literals in `BuildEventDto` became populated expressions).
+  - Acceptance: `evidence/qa-gates/contract-unchanged.<timestamp>.md` records the verification (diff scope confined to `OutlookScanner.*` and `ResponseShaper.cs`; no change to `BridgeContracts.cs`). (US-AC6, SP versioning)
+
+## Acceptance-Criteria → Task Map
+
+| Criterion | Tasks |
+|---|---|
+| US-AC1 (non-null correct attendees, enhanced mode) | P2-T1, P2-T3, P2-T4, P2-T7 |
+| US-AC2 (Graph `{"name","email"}` shape, lowercase keys, order) | P1-T1, P1-T2, P1-T3 |
+| US-AC3 (per-type classification; out-of-range excluded) | P2-T1, P2-T8 |
+| US-AC4 (safe-mode nulls all three; enhanced preserves) | P3-T1, P3-T2, P3-T3 |
+| US-AC5 (missing name/email -> empty string, both keys) | P1-T4, P2-T9 |
+| US-AC6 (no contract change; coverage thresholds; no regression) | P2-T4, P4-T6, P4-T7 |
+| SP-DoD1 (AC mapped to tests) | this map; Phase 1–3 test tasks |
+| SP-DoD2 (behavior matches AC) | P2-T7, P2-T8, P2-T9, P2-T10, P3-T2, P3-T3 |
+| SP-DoD3 (tests added) | P1-T2..T4, P2-T7..T10, P3-T2, P3-T3, P4-T5 |
+| SP-DoD4 (edge/error cases tested) | P1-T3, P1-T4, P2-T8, P2-T9, P2-T10 |
+| SP-DoD5 (docs updated if applicable) | P2-T5 (XML doc); README/feature-doc N/A (no public-surface change) |
+| SP-DoD6 (telemetry/logging) | N/A per spec line 104 (no telemetry change); covered by no-op confirmation in P4-T2 |
+| SP-DoD7 (toolchain pass) | P4-T1, P4-T2, P4-T3, P4-T5 |
+| SP-B1 (empty -> `[]`, not null) | P1-T1, P1-T3, P2-T3, P2-T10 |
+| SP-B2 (out-of-range Type ignored) | P2-T1, P2-T8 |
+| SP-B3 (per-recipient fail-soft) | P2-T1 |
+| SP-B4 (deterministic COM release) | P2-T2 |
+| SP-B5 (ProtectedFieldsAvailable unchanged) | P2-T5 |
+
+## Test Plan
+
+- **Unit (pure):** JSON shaping — Graph shape/lowercase keys/order (P1-T2), empty -> `"[]"` (P1-T3), missing name/email -> `""` with both keys (P1-T4).
+- **Unit (scanner/COM seam):** enhanced-mode population with correct names/emails (P2-T7), per-type classification + out-of-range exclusion (P2-T8), missing values via scanner path (P2-T9), empty/absent collection -> `"[]"` (P2-T10). COM enumeration exercised through the reflection-readable `FakeAppointmentItem.Recipients` double (P2-T6); no live COM, no temp files.
+- **Unit (redaction):** safe mode nulls all three (P3-T2), enhanced mode preserves all three (P3-T3).
+- **Integration:** none required; behavior is verifiable through the existing scanner test seam. No new external-system interaction is introduced.
+- **Coverage evidence:** baseline `evidence/baseline/baseline-test.<timestamp>.md` (P0-T5); post-change `evidence/qa-gates/final-test.<timestamp>.md` (P4-T5); comparison `evidence/qa-gates/coverage-delta.<timestamp>.md` (P4-T6).
+
+## Open Questions / Notes
+
+- The spec open question (empty array vs null) is resolved in design decision 5 / SP-B1: `"[]"` for a type with no recipients; `null` reserved for safe-mode redaction and unread state. Confirm during P2-T10 that downstream consumers can distinguish these two states.
+- The `ProtectedFieldsAvailable` question (SP-B5) is resolved in design decision 7: the body-derived signal is preserved unchanged; attendee PII is protected by safe-mode redaction only.
+- If `OutlookScanner.GraphFields.cs` or any test file approaches the 500-line cap during implementation, split into the named sibling partial/test file rather than exceeding the cap.

--- a/docs/features/active/mailbridge-event-attendees-json-71/policy-audit.2026-06-13T14-52.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/policy-audit.2026-06-13T14-52.md
@@ -1,0 +1,430 @@
+# Policy Compliance Audit: mailbridge-event-attendees-json (Issue #71)
+
+**Audit Date:** 2026-06-13
+**Code Under Test:** C# only — production: `src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs` (new), `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` (modified), `src/OpenClaw.MailBridge/ResponseShaper.cs` (modified), `src/OpenClaw.MailBridge/OutlookComHelpers.cs` (modified); tests: `tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesShapeTests.cs` (new), `tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesTests.cs` (new), `tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs` (modified), `tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs` (modified).
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| C# | 8 files (4 prod, 4 test) | 216 (MailBridge.Tests); 474 solution-wide | ✅ 474 pass, 0 fail, 3 skipped | 93.55% lines, 85.47% branch | 94.07% lines, 86.54% branch | 100% line/branch on changed prod files |
+
+**Note:** C# is the only language with changed files in the branch diff. No Python, PowerShell, TypeScript, Bash, or JSON production files changed; those rows are omitted because those languages have zero changed files on the branch.
+
+### Coverage Evidence Checklist
+
+- TypeScript baseline coverage artifact: `N/A - out of scope` (no TypeScript files changed on the branch)
+- TypeScript post-change coverage artifact: `N/A - out of scope` (no TypeScript files changed on the branch)
+- PowerShell baseline coverage artifact: `N/A - out of scope` (no PowerShell files changed on the branch)
+- PowerShell post-change coverage artifact: `N/A - out of scope` (no PowerShell files changed on the branch)
+- C# baseline coverage artifact: `docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/baseline-test.2026-06-13T14-41.md`
+- C# post-change coverage artifact: `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/final-test.2026-06-13T14-41.md` (cobertura source: `tests/OpenClaw.MailBridge.Tests/TestResults/82e0c0f9-12e0-4ea3-9f69-873a62abd6dc/coverage.cobertura.xml`)
+- Per-language comparison summary: `docs/features/active/mailbridge-event-attendees-json-71/evidence/qa-gates/coverage-delta.2026-06-13T14-41.md`
+
+**Non-negotiable verdict rule:** Numeric baseline and post-change coverage are present for the only in-scope language (C#), plus per-file changed/new-code coverage. Coverage was verified directly against the cobertura artifact, not re-run.
+
+**Coverage-artifact-path note:** The feature-review SKILL lists the canonical C# coverage artifact path as `artifacts/csharp/coverage.xml`. That path is absent. A valid cobertura XML produced by `coverlet.collector` during the executor run exists at `tests/OpenClaw.MailBridge.Tests/TestResults/82e0c0f9-12e0-4ea3-9f69-873a62abd6dc/coverage.cobertura.xml` and was parsed directly to confirm the numbers. The repository toolchain (`csharp.md` step 5) produces coverage under `tests/**/TestResults/**` via `mailbridge.runsettings`, so this is the project's canonical coverage output location. Coverage verification is therefore satisfied from an existing artifact; this is recorded as an informational note, not a FAIL.
+
+---
+
+## Executive Summary
+
+This branch populates the three `EventDto` attendee JSON fields (`RequiredAttendeesJson`, `OptionalAttendeesJson`, `ResourcesJson`) from the COM `AppointmentItem.Recipients` collection and extends safe-mode redaction to null those fields. The change is confined to `OpenClaw.MailBridge` (the only COM-permitted project) plus its test project. The full C# toolchain (format, build/analyzers, nullable, architecture, tests + coverage) passed in the executor run, evidenced by canonical QA-gate artifacts and verified here by direct inspection of the diff and the cobertura coverage file.
+
+All four production changes carry 100% line and branch coverage. Solution coverage rose from 93.55%/85.47% to 94.07%/86.54%. No `EventDto` contract shape change. No workflow, benchmark, or GitHub Actions files changed.
+
+**Policy documents evaluated:**
+- ✅ `CLAUDE.md` (standing instructions)
+- ✅ `.claude/rules/general-code-change.md`
+- ✅ `.claude/rules/general-unit-test.md`
+- ✅ `.claude/rules/csharp.md`
+- ✅ `.claude/rules/architecture-boundaries.md`
+- ✅ `.claude/rules/quality-tiers.md`
+
+**Language-specific policies evaluated:**
+- ✅ C#: `.claude/rules/csharp.md` (code change + unit test)
+- N/A Python / PowerShell / Bash / JSON / TypeScript — no changed files on the branch.
+
+**Temporary artifacts cleanup:**
+- ✅ No temporary or one-time scripts were created by this review.
+- ✅ No throwaway scripts present in the branch diff.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** | ✅ PASS | Each `[TestMethod]` constructs its own `FakeComActiveObject`, `FakeScanStateRepository`, and scanner via `BuildScanner`/`ScanSingleEventAsync`; no shared mutable state across tests. |
+| **Isolation** | ✅ PASS | Pure-shaping tests (`OutlookScannerAttendeesShapeTests`) target `ShapeAttendeeJson` directly; scanner-path tests target `ReadAttendees` through the scan seam; redaction tests target `ResponseShaper.ShapeEvent`. |
+| **Fast execution** | ✅ PASS | Pure in-memory fakes, no live COM, no I/O. Solution test run completed in the executor's final-test gate (EXIT 0). |
+| **Determinism** | ✅ PASS | Deterministic clock injected via `() => FixedNow` (`new(2026,5,1,...)`); JSON serialization uses a single static `JsonSerializerOptions`. No wall-clock reads, no RNG, no temp files. |
+| **Readability & maintainability** | ✅ PASS | Descriptive test names, AAA comments, FluentAssertions with rationale strings. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | ✅ PASS | Baseline 93.55% lines / 85.47% branch (`evidence/baseline/baseline-test.2026-06-13T14-41.md`). Command: `dotnet test ... --collect:"XPlat Code Coverage"`. |
+| **No Coverage Regression** | ✅ PASS | Post-change 94.07% lines (+0.52pp) / 86.54% branch (+1.07pp). Changed prod files at 100% line/branch; no regression on changed lines. |
+| **New Code Coverage** | ✅ PASS | `OutlookScanner.Attendees.cs` (new): 100% line, 100% branch (verified directly from cobertura). New method `GetOptionalIndexedItem` fully line-covered incl. catch path (lines 43–45 hit). Exceeds the >= 85% line / >= 75% branch thresholds and the >= 90% new-code guidance. |
+| **Comprehensive Coverage** | ✅ PASS | `ShapeAttendeeJson`, `SerializeAttendees`, `ReadAttendees`, and the safe-mode `ShapeEvent` branch are all exercised; out-of-range type, missing name/email, AddressEntry fallback, empty/absent collection, and fail-soft paths are covered. |
+| **Positive Flows** | ✅ PASS | `ScanCalendar_should_populate_all_three_attendee_fields_in_enhanced_mode`; `ShapeAttendeeJson_should_emit_lowercase_keys_and_preserve_order`. |
+| **Negative Flows** | ✅ PASS | `ScanCalendar_should_emit_both_keys_when_name_or_email_missing`; `ShapeAttendeeJson_should_keep_both_keys_when_a_value_is_missing`. |
+| **Edge Cases** | ✅ PASS | `ScanCalendar_should_classify_by_type_and_exclude_out_of_range`; `ScanCalendar_should_emit_empty_array_for_type_with_no_recipients`; `ScanCalendar_should_emit_empty_arrays_when_recipients_absent`. |
+| **Error Handling** | ✅ PASS | `ScanCalendar_should_fail_soft_when_a_recipient_read_throws` exercises the fail-soft per-recipient path. |
+| **Concurrency** | N/A | No new concurrency surface; COM scan runs on the existing single STA thread. |
+| **State Transitions** | N/A | No new stateful component. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- C#: Baseline: 93.55% line, 85.47% branch (MailBridge) -> Post-change: 94.07% line, 86.54% branch (MailBridge). Change: +0.52% line, +1.07% branch. New/changed-code coverage: 100% (all four changed production files at 100% line/branch). Disposition: PASS. Evidence: `evidence/qa-gates/coverage-delta.2026-06-13T14-41.md`, `evidence/qa-gates/final-test.2026-06-13T14-41.md`, `tests/OpenClaw.MailBridge.Tests/TestResults/82e0c0f9-12e0-4ea3-9f69-873a62abd6dc/coverage.cobertura.xml`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | ✅ PASS | FluentAssertions with rationale strings (e.g., "safe mode must redact attendee PII"). |
+| **Arrange-Act-Assert Pattern** | ✅ PASS | Each test carries explicit Arrange/Act/Assert comments. |
+| **Document Intent** | ✅ PASS | Class-level XML summaries map tests to AC identifiers (US-AC1..US-AC6, SP-B1..SP-B5). |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | ✅ PASS | No network, no live Outlook, no live processes; COM seam replaced by reflection-readable fakes. |
+| **Use Mocks/Stubs** | ✅ PASS | `FakeRecipients`, `FakeRecipient`, `FakeAddressEntry`, `FakeThrowingRecipients`, `FakeComActiveObject` substitute the COM boundary. |
+| **Environment Stability** | ✅ PASS | No temporary files created; no mutable global state; deterministic clock. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | ✅ PASS | This audit document fulfills the required policy review. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | ✅ PASS | Objective documented in `spec.md` / `user-story.md` for issue #71. |
+| **Read existing change plans** | ✅ PASS | `plan.2026-06-13T10-31.md` present with Phase 0 policy-read evidence. |
+| **Document the plan** | ✅ PASS | Plan + evidence artifacts under `evidence/`. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | ✅ PASS | Single-pass enumeration over `Recipients`; a `switch` classifies by `Type`; pure shaping is a small static method. |
+| **Reusability** | ✅ PASS | Reuses `OutlookComHelpers.GetOptional*` and `_com.ReleaseAll`; adds one reusable helper `GetOptionalIndexedItem`. |
+| **Extensibility** | ✅ PASS | `AttendeeJsonSet` carrier and pure `ShapeAttendeeJson` separate shaping from COM read, allowing direct unit testing. |
+| **Separation of concerns** | ✅ PASS | Pure JSON shaping is COM-free; COM read is isolated in `ReadAttendees`; redaction stays in `ResponseShaper`. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | ✅ PASS | New `OutlookScanner.Attendees.cs` partial holds only attendee enumeration/shaping. |
+| **Under 500 lines** | ✅ PASS | Attendees.cs 179, GraphFields.cs 117, ResponseShaper.cs 77, OutlookComHelpers.cs 150, shape tests 87, scanner tests 279, test doubles 477, body-full tests 128. All < 500. |
+| **Public vs internal** | ✅ PASS | New types are `internal`/`private`; only the test-visible `ShapeAttendeeJson`/`Attendee`/`AttendeeJsonSet` are `internal` for direct unit testing. |
+| **No circular dependencies** | ✅ PASS | No new `ProjectReference` edges (`evidence/qa-gates/final-architecture.2026-06-13T14-41.md`). |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | ✅ PASS | `ReadAttendees`, `ShapeAttendeeJson`, `AttendeeJsonSet`, `GetOptionalIndexedItem`. |
+| **Docs/docstrings** | ✅ PASS | XML doc comments on new types/methods, including the `ProtectedFieldsAvailable` design note. |
+| **Comment why, not what** | ✅ PASS | Comments explain the null-vs-`"[]"` redaction signal and the SP-B5 design decision. |
+
+### 2.5 After Making Changes - Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | ✅ PASS | `csharpier format . ; csharpier check .` EXIT 0 (`evidence/qa-gates/final-format.2026-06-13T14-41.md`). |
+| **2. Linting** | ✅ PASS | `dotnet build ... -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` EXIT 0, 0 warnings/errors (`final-build.2026-06-13T14-41.md`). |
+| **3. Type checking** | ✅ PASS | `dotnet build ... -p:TreatWarningsAsErrors=true` EXIT 0, 0 nullable warnings (`final-nullable.2026-06-13T14-41.md`). |
+| **4. Testing** | ✅ PASS | `dotnet test ... --collect:"XPlat Code Coverage"` EXIT 0, 474 passed (`final-test.2026-06-13T14-41.md`). |
+| **Full toolchain loop** | ✅ PASS | Format -> build -> nullable -> architecture -> test all green in the executor run. |
+| **Explicit reporting** | ✅ PASS | Commands and results recorded in QA-gate evidence artifacts. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | ✅ PASS | Documented in spec/user-story and this audit. |
+| **Design choices explained** | ✅ PASS | Null-vs-empty and `ProtectedFieldsAvailable` decisions documented in code and spec. |
+| **Update supporting documents** | ✅ PASS | spec.md and user-story.md present with AC. |
+| **Provide next steps** | ✅ PASS | See Compliance Verdict below. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3D-equivalent: C# Code Change Policy Compliance
+
+#### 3.C.1 Tooling & Baseline
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting with CSharpier** | ✅ PASS | `csharpier check .` EXIT 0. |
+| **Linting / .NET analyzers** | ✅ PASS | Build with analyzers EXIT 0, 0 diagnostics. |
+| **Type checking — nullable** | ✅ PASS | `TreatWarningsAsErrors=true` build EXIT 0. |
+| **Testing — MSTest** | ✅ PASS | `dotnet test` EXIT 0. |
+
+#### 3.C.2 Design & Type-Safety
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Strong contracts / explicit APIs** | ✅ PASS | `internal` records `AttendeeJsonSet`, `Attendee`; private `AttendeeJson` projection with explicit `JsonPropertyName`. |
+| **Null-safety by default** | ✅ PASS | Nullable enabled; optional COM reads return `object?`/`string?`; missing values coalesce to `string.Empty`. |
+| **Composition / focused types** | ✅ PASS | Immutable `record struct` carriers; no inheritance added. |
+| **Resource safety (COM)** | ✅ PASS | `_com.ReleaseAll(addressEntry, recipient)` per iteration in `finally`; `_com.ReleaseAll(recipients)` in outer `finally`. |
+
+#### 3.C.3 Error Handling
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Fail fast vs fail soft** | ✅ PASS | Per-recipient COM reads fail soft via `GetOptional*`/`GetOptionalIndexedItem` so one unreadable recipient does not abort the scan (spec SP-B3). The broad `catch` in `GetOptionalIndexedItem` is a narrow, documented COM-boundary fail-soft consistent with the existing `OutlookComHelpers` idiom. |
+| **No silent error swallowing in domain logic** | ✅ PASS | The catch is confined to the COM adapter boundary; pure shaping has no catch. |
+| **Logging** | N/A | No new logging required; spec calls for none beyond existing scan logging. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+### Section 4.C: C# Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Use MSTest** | ✅ PASS | `[TestClass]`/`[TestMethod]` with `Microsoft.VisualStudio.TestTools.UnitTesting`. |
+| **Moq / FluentAssertions** | ✅ PASS | FluentAssertions used; hand-rolled reflection-readable fakes used for the COM seam (appropriate for late-bound COM). |
+| **Coverage expectation** | ✅ PASS | Repo-wide 94.07% line / 86.54% branch; changed prod files 100%. |
+| **No external dependencies / temp files** | ✅ PASS | No network, live Outlook, processes, or temp files. |
+| **Determinism** | ✅ PASS | Injected clock; no `Thread.Sleep`/`Task.Delay`/wall-clock reads (verified by grep on the test diff). |
+
+---
+
+## Architecture & COM Confinement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **No new ProjectReference edges** | ✅ PASS | `git diff --name-only -- '*.csproj'` empty (`final-architecture.2026-06-13T14-41.md`). |
+| **COM confined to OpenClaw.MailBridge** | ✅ PASS | All new COM access (`Recipients` enumeration, `Item(index)`, `Type`/`Name`/`Address`, `AddressEntry`) is in `OutlookComHelpers` and `OutlookScanner.ReadAttendees`, both in `OpenClaw.MailBridge` (the only COM-permitted project). |
+| **No COM types crossing boundaries** | ✅ PASS | `AttendeeJsonSet`/`Attendee` are managed records internal to the host; `EventDto` carries only `string?` JSON. |
+| **Deterministic COM release** | ✅ PASS | `_com.ReleaseAll` in nested `finally` blocks; follows the `GetStoreId` idiom. |
+
+Architecture gate: PASS.
+
+---
+
+## Contract Stability
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **No EventDto contract shape change** | ✅ PASS | `BridgeContracts.cs` has no diff; the three positional `null` literals became populated expressions at the same positions/order (`contract-unchanged.2026-06-13T14-41.md` and the GraphFields.cs diff). No SQLite schema or `CacheRepository` column change. |
+
+---
+
+## Evidence Location Compliance
+
+The reviewer scanned the branch diff for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`.
+
+- Result: **none found.** All feature evidence is correctly under `docs/features/active/mailbridge-event-attendees-json-71/evidence/baseline/` and `.../evidence/qa-gates/`, matching the canonical `<FEATURE>/evidence/<kind>/` layout.
+- No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` events: no caller instruction specified a non-canonical evidence path.
+
+No evidence-location violations.
+
+---
+
+## modified-workflow-needs-green-run
+
+- Branch diff contains no paths matching `.github/workflows/**`, `scripts/benchmarks/**`, or `.github/actions/**` (verified by `git diff --name-only`).
+- Rule does not fire. No green-run evidence required.
+
+---
+
+## 5. Test Coverage Detail
+
+### OutlookScanner.ShapeAttendeeJson / SerializeAttendees (3 pure-shaping tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| ShapeAttendeeJson_should_emit_lowercase_keys_and_preserve_order | Positive | ✅ |
+| ShapeAttendeeJson_should_emit_empty_array_for_each_empty_group | Edge Case | ✅ |
+| ShapeAttendeeJson_should_keep_both_keys_when_a_value_is_missing | Negative | ✅ |
+
+**Coverage:** 100% line, 100% branch (`OutlookScanner.Attendees.cs`).
+
+### OutlookScanner.ReadAttendees (scanner-path, 7 tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| ScanCalendar_should_populate_all_three_attendee_fields_in_enhanced_mode | Positive | ✅ |
+| ScanCalendar_should_classify_by_type_and_exclude_out_of_range | Edge Case | ✅ |
+| ScanCalendar_should_emit_both_keys_when_name_or_email_missing | Negative | ✅ |
+| ScanCalendar_should_resolve_email_from_address_entry_fallback | Edge Case | ✅ |
+| ScanCalendar_should_emit_empty_array_for_type_with_no_recipients | Edge Case | ✅ |
+| ScanCalendar_should_emit_empty_arrays_when_recipients_absent | Edge Case | ✅ |
+| ScanCalendar_should_fail_soft_when_a_recipient_read_throws | Error Handling | ✅ |
+
+**Coverage:** 100% line/branch on `OutlookScanner.GraphFields.cs` changed lines and the new `GetOptionalIndexedItem` helper (catch path exercised by the fail-soft test).
+
+### ResponseShaper.ShapeEvent attendee redaction (2 tests)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| ShapeEvent_in_safe_mode_should_null_all_three_attendee_fields | Positive (redaction) | ✅ |
+| ShapeEvent_in_enhanced_mode_should_preserve_all_three_attendee_fields | Negative (non-regression) | ✅ |
+
+**Coverage:** 100% line/branch on `ResponseShaper.cs`.
+
+**Not covered:** None on changed production code.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (solution) | 477 (474 run, 3 skipped) | ✅ |
+| Tests Passed | 474 (100% of run) | ✅ |
+| Tests Failed | 0 | ✅ |
+| New tests added | 12 | ✅ |
+| Code Coverage (solution) | 94.07% lines, 86.54% branch | ✅ |
+| Changed-code coverage | 100% line/branch | ✅ |
+
+---
+
+## 7. Code Quality Checks
+
+**For C#:**
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| CSharpier Formatting | `csharpier check .` | EXIT 0, clean | ✅ |
+| .NET Analyzers | `dotnet build ... -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true` | EXIT 0, 0 diagnostics | ✅ |
+| Nullable / Type check | `dotnet build ... -p:TreatWarningsAsErrors=true` | EXIT 0, 0 warnings | ✅ |
+| MSTest Tests | `dotnet test ... --collect:"XPlat Code Coverage"` | EXIT 0, 474 pass | ✅ |
+
+**Notes:** No pre-existing failures introduced. The 3 skipped tests are pre-existing and unrelated to this feature.
+
+---
+
+## Architecture & COM Confinement (detail)
+
+See the Architecture & COM Confinement section above. Architecture gate: PASS.
+
+---
+
+## Evidence Location Compliance (detail)
+
+See the Evidence Location Compliance section above. No violations.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+- **C# coverage artifact path:** the SKILL's canonical path `artifacts/csharp/coverage.xml` is absent; coverage was verified from the project's actual coverlet output at `tests/OpenClaw.MailBridge.Tests/TestResults/.../coverage.cobertura.xml`. This is the repository's standard coverage location per `csharp.md` step 5 and `mailbridge.runsettings`; verification is satisfied. Informational, not blocking.
+
+### Approved Exceptions
+- **None.**
+
+### Removed/Skipped Tests
+- **None.** No test removal in the branch diff. The 3 solution-wide skipped tests are pre-existing and unrelated to this feature.
+
+---
+
+## 9. Summary of Changes
+
+### Files Modified
+
+1. `src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs` (NEW) — pure JSON shaping (`ShapeAttendeeJson`) + COM `Recipients` enumeration (`ReadAttendees`); `AttendeeJsonSet`/`Attendee` carriers.
+2. `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` (MODIFIED) — replaced three `null` literals with `attendees.RequiredJson/OptionalJson/ResourcesJson`; added `ProtectedFieldsAvailable` design note.
+3. `src/OpenClaw.MailBridge/ResponseShaper.cs` (MODIFIED) — safe-mode branch nulls the three attendee JSON fields for redaction parity.
+4. `src/OpenClaw.MailBridge/OutlookComHelpers.cs` (MODIFIED) — added `GetOptionalIndexedItem` fail-soft 1-based collection accessor.
+5. `tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesShapeTests.cs` (NEW) — 3 pure-shaping tests.
+6. `tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesTests.cs` (NEW) — 7 scanner-path tests incl. fail-soft.
+7. `tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs` (MODIFIED) — added `FakeRecipients`/`FakeRecipient`/`FakeAddressEntry`/`FakeThrowingRecipients`.
+8. `tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs` (MODIFIED) — 2 attendee redaction tests.
+
+Plus 15 feature-doc/evidence files under `docs/features/active/mailbridge-event-attendees-json-71/`.
+
+---
+
+## Rejected Scope Narrowing
+
+None. The caller instruction explicitly directed the reviewer to determine scope from the full branch diff against the merge-base and did not attempt to narrow scope to any plan, task, phase, file subset, or to mark any in-scope language as out of scope. The audit covers the full feature-vs-base diff (C# is the only language with changed files).
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ✅ FULLY COMPLIANT
+
+All cross-language and C#-specific code-change and unit-test policy requirements are met. The toolchain passed in a single clean pass (format, analyzers, nullable, architecture, tests + coverage). Coverage thresholds hold with no regression on changed lines; all four changed production files are at 100% line/branch. Architecture and COM-confinement boundaries are preserved, the `EventDto` contract is unchanged, and evidence is in canonical locations.
+
+**Fail-closed reminder:** No required baseline, QA, or coverage artifact is missing. The only path note (coverage artifact location) is satisfied by the project's actual coverlet output and is recorded as informational.
+
+### Recommendation
+
+**Ready for merge.** No blocking findings.
+
+---
+
+## Appendix A: Test Inventory
+
+New tests added by this feature (12):
+
+1. OutlookScannerAttendeesShapeTests › ShapeAttendeeJson_should_emit_lowercase_keys_and_preserve_order
+2. OutlookScannerAttendeesShapeTests › ShapeAttendeeJson_should_emit_empty_array_for_each_empty_group
+3. OutlookScannerAttendeesShapeTests › ShapeAttendeeJson_should_keep_both_keys_when_a_value_is_missing
+4. OutlookScannerAttendeesTests › ScanCalendar_should_populate_all_three_attendee_fields_in_enhanced_mode
+5. OutlookScannerAttendeesTests › ScanCalendar_should_classify_by_type_and_exclude_out_of_range
+6. OutlookScannerAttendeesTests › ScanCalendar_should_emit_both_keys_when_name_or_email_missing
+7. OutlookScannerAttendeesTests › ScanCalendar_should_resolve_email_from_address_entry_fallback
+8. OutlookScannerAttendeesTests › ScanCalendar_should_emit_empty_array_for_type_with_no_recipients
+9. OutlookScannerAttendeesTests › ScanCalendar_should_emit_empty_arrays_when_recipients_absent
+10. OutlookScannerAttendeesTests › ScanCalendar_should_fail_soft_when_a_recipient_read_throws
+11. ResponseShaperEventBodyFullTests › ShapeEvent_in_safe_mode_should_null_all_three_attendee_fields
+12. ResponseShaperEventBodyFullTests › ShapeEvent_in_enhanced_mode_should_preserve_all_three_attendee_fields
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+**For C#:**
+```bash
+# Formatting
+csharpier format .
+csharpier check .
+
+# Linting / analyzers
+dotnet build OpenClaw.MailBridge.sln -c Debug -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true
+
+# Type checking (nullable as errors)
+dotnet build OpenClaw.MailBridge.sln -c Debug -p:TreatWarningsAsErrors=true
+
+# Testing + coverage
+dotnet test OpenClaw.MailBridge.sln -c Debug --settings mailbridge.runsettings --collect:"XPlat Code Coverage"
+```
+
+**Review-only verification commands used in this audit:**
+```bash
+git diff --name-status c0fa1024..65a5f8d5
+git diff c0fa1024..65a5f8d5 -- src/OpenClaw.MailBridge/
+git diff --name-only c0fa1024..65a5f8d5 | grep -E '(\.github/workflows/|scripts/benchmarks/|\.github/actions/)'
+# parse line-rate/branch-rate and per-file coverage from coverage.cobertura.xml
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-06-13
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/mailbridge-event-attendees-json-71/spec.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/spec.md
@@ -1,0 +1,115 @@
+# mailbridge-event-attendees-json — Spec
+
+- **Issue:** #71
+- **Parent (optional):** Track M (MailBridge DTO/scanner): #72 -> #71 -> #73
+- **Owner:** drmoisan
+- **Last Updated:** 2026-06-13T10-31
+- **Status:** Draft
+- **Version:** 0.1
+
+## Overview
+
+`OutlookScanner.BuildEventDto` (`src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs`) currently
+hardcodes `RequiredAttendeesJson`, `OptionalAttendeesJson`, and `ResourcesJson` to `null`
+(positional arguments at lines 44–46). The `EventDto` contract already carries these three nullable
+`string?` fields (`BridgeContracts.cs` lines 106–108); they are persisted by `CacheRepository` but
+never populated. Downstream agents (deferred from #70) need attendee data on calendar events.
+
+This feature populates the three fields from the COM `AppointmentItem.Recipients` collection,
+emitting each as a JSON array of `{"name","email"}` objects matching the Graph `emailAddress`
+shape, and extends safe-mode redaction so the attendee PII is nulled in safe mode for parity with
+the existing message-path redaction of `SenderName`/`SenderEmail`.
+
+- Target users/personas and primary use cases: the OpenClaw agent consuming normalized calendar
+  events over the HostAdapter HTTP surface; it requires required/optional/resource attendee lists.
+- Success metrics or expected impact: a scan of a meeting with known attendees returns non-null
+  attendee JSON with correct names and emails in enhanced mode; safe mode returns null.
+
+## Behavior
+
+- Main user flow (happy path): During calendar normalization, `BuildEventDto` enumerates the COM
+  `Recipients` collection of the appointment item. Each recipient is classified by its `Type`
+  property (`OlMeetingRecipientType`: `1 = olRequired`, `2 = olOptional`, `3 = olResource`).
+  Recipients are grouped by type and each group is serialized to a JSON array of
+  `{"name","email"}` objects, in collection order. The three serialized strings populate
+  `RequiredAttendeesJson`, `OptionalAttendeesJson`, and `ResourcesJson`.
+- Alternate/edge flows:
+  - A meeting with no recipients of a given type yields an empty JSON array `[]` for that field
+    (not null), so the absence of a type is distinguishable from an unread field. (Final null-vs-
+    empty decision is an open question for planning; see Constraints & Risks.)
+  - A recipient missing a name or resolvable SMTP address emits the available value and an empty
+    string for the missing one; both fields are always present in each object.
+  - `Type` values outside `{1,2,3}` are ignored (not placed in any of the three fields).
+- Error handling and recovery behavior: COM access failures while reading an individual recipient
+  must not abort the scan of the event. The scanner follows the existing optional-read pattern
+  (`OutlookComHelpers.GetOptional*`) and fails soft per recipient. All COM objects obtained while
+  enumerating `Recipients` (the collection and each `Recipient`) are released deterministically
+  per the COM-confinement rule.
+
+## Inputs / Outputs
+
+- Inputs: the COM `AppointmentItem` (`object item`) passed to `BuildEventDto`; the active
+  `BridgeSettings` (for mode/redaction).
+- Outputs: the populated `EventDto` with three attendee JSON strings; persisted by
+  `CacheRepository` to the existing `required_attendees_json` / `optional_attendees_json` /
+  `resources_json` columns (no schema change).
+- Config keys and defaults: existing `BridgeSettings.Mode` (`safe` | `enhanced`). No new config.
+- Versioning or backward-compatibility constraints: no contract shape change. `EventDto`
+  positional arguments are unchanged in count and order; only the three `null` literals become
+  populated expressions.
+
+## API / CLI Surface
+
+- No public-API shape change. `EventDto` record is unchanged.
+- JSON contract per field: `[{"name":"<display name>","email":"<smtp address>"}, ...]`. Property
+  names are lowercase `name` and `email` to match the Graph `emailAddress` shape used elsewhere.
+- Serialization must be deterministic (stable property order, no culture-dependent formatting).
+
+## Data & State
+
+- Data transformations and invariants: COM `Recipients` -> grouped by `Type` -> JSON arrays.
+  Each emitted object always has both `name` and `email` keys. Collection order is preserved.
+- Caching or persistence details: values flow through the existing `CacheRepository` event-insert
+  path (`required_attendees_json`, `optional_attendees_json`, `resources_json`); no migration.
+- Migration or backfill requirements: none.
+
+## Constraints & Risks
+
+- Limits: recipient enumeration adds COM round-trips per event; reuse a single pass over the
+  `Recipients` collection and release wrappers deterministically to avoid RCW accumulation.
+- Security/privacy considerations: attendee names and emails are PII. Safe mode MUST null all
+  three attendee JSON fields in `ResponseShaper.ShapeEvent`, matching the existing message-path
+  redaction of `SenderName`/`SenderEmail`. Enhanced mode returns the populated values.
+- `ProtectedFieldsAvailable`: attendee details are protected fields. The existing event value is
+  derived from body availability; planning must decide whether attendee readability contributes to
+  or is gated by `ProtectedFieldsAvailable` without weakening the existing body-based signal.
+- Operational/rollout risks and mitigations: COM read failure on a single recipient must not fail
+  the event scan (fail-soft per recipient).
+- Open question (for planning): empty-collection representation — empty array `[]` versus `null`.
+  Recommendation: empty array for type-with-no-recipients, reserving `null` for safe-mode redaction
+  and unread state, so consumers can distinguish "no attendees of this type" from "redacted".
+
+## Implementation Strategy
+
+- Implementation scope:
+  1. `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` (or a new `OutlookScanner.*.cs`
+     partial if the 500-line cap is at risk) — add a recipient-enumeration + JSON-serialization
+     helper and replace the three `null` literals at lines 44–46 with its results.
+  2. `src/OpenClaw.MailBridge/ResponseShaper.cs` — null the three attendee JSON fields in the
+     safe-mode branch of `ShapeEvent` for redaction parity.
+- New classes/functions: a private helper on the `OutlookScanner` partial that returns the three
+  serialized strings (or a small immutable carrier) from the COM `Recipients` collection; reuse
+  `OutlookComHelpers` for optional reads and `_com.ReleaseAll` for deterministic release.
+- Dependency changes: none. Use `System.Text.Json` already in use by the contracts/host.
+- Logging/telemetry additions: none beyond existing scan logging.
+- Rollout plan: no feature flag; behavior is gated by existing `safe`/`enhanced` mode.
+
+## Definition of Done
+
+- [x] Acceptance criteria documented and mapped to tests or demos
+- [x] Behavior matches acceptance criteria in all documented environments
+- [x] Tests updated/added (unit/integration as applicable)
+- [x] Edge cases and error handling covered by tests
+- [x] Docs updated (README, docs/features/active/... links) if applicable
+- [x] Telemetry/logging added or updated (if applicable)
+- [x] Toolchain pass completed (format → lint → type-check → test)

--- a/docs/features/active/mailbridge-event-attendees-json-71/user-story.md
+++ b/docs/features/active/mailbridge-event-attendees-json-71/user-story.md
@@ -1,0 +1,62 @@
+# `mailbridge-event-attendees-json` — User Story
+
+- Issue: #71
+- Owner: drmoisan
+- Status: Draft
+- Last Updated: 2026-06-13T10-31
+
+## Story Statement
+
+- As the OpenClaw agent consuming normalized calendar events, I want each event to carry its
+  required, optional, and resource attendees as Graph-shaped JSON, so that I can reason about
+  meeting participants without a separate Outlook round-trip.
+- As an operator running the bridge in safe mode, I want attendee names and emails redacted, so
+  that PII is not exposed when protected fields are disabled.
+
+## Problem / Why
+
+`EventDto` carries `RequiredAttendeesJson`, `OptionalAttendeesJson`, and `ResourcesJson`, but
+`OutlookScanner.BuildEventDto` hardcodes all three to `null`. Downstream consumers (deferred from
+#70) cannot see who is invited to a meeting. The fields must be populated from the COM
+`AppointmentItem.Recipients` collection while respecting the bridge's redaction model.
+
+## Personas & Scenarios
+
+- Persona: OpenClaw agent (programmatic consumer)
+  - who: an automated agent reading cached calendar events over HostAdapter HTTP.
+  - what they care about: accurate, deterministic attendee data in a stable JSON shape.
+  - constraints: consumes contract-shaped data only; never calls Outlook directly.
+  - goals: classify attendees as required/optional/resource and read each name and email.
+- Scenario: scanning a meeting with known attendees
+  - who is acting: the bridge calendar scan on the dedicated STA thread.
+  - trigger: a calendar poll normalizes an `AppointmentItem` that has recipients.
+  - steps: enumerate `Recipients`, classify each by `Type` (1/2/3), serialize each group to
+    `[{"name","email"}]`, populate the three `EventDto` fields.
+  - obstacles/decisions: a recipient missing a name or SMTP address; a recipient with an
+    out-of-range `Type`; safe mode requiring redaction.
+  - expected outcome: in enhanced mode the three fields contain correct JSON; in safe mode they
+    are null.
+
+## Acceptance Criteria
+
+- [x] A scan of a meeting with known attendees returns non-null `RequiredAttendeesJson`,
+  `OptionalAttendeesJson`, and `ResourcesJson` (as applicable) with correct names and emails in
+  enhanced mode.
+- [x] Each populated field is a JSON array of `{"name","email"}` objects matching the Graph
+  `emailAddress` shape (lowercase `name` and `email` keys, collection order preserved).
+- [x] A unit test asserts the JSON structure per attendee type: `Type 1` -> required,
+  `Type 2` -> optional, `Type 3` -> resource; recipients with other `Type` values are excluded.
+- [x] Safe mode (`BridgeSettings.Mode == "safe"`) nulls all three attendee JSON fields via
+  `ResponseShaper.ShapeEvent`, matching the existing redaction of `SenderName`/`SenderEmail`, and a
+  unit test asserts this redaction.
+- [x] A recipient missing a name or resolvable email emits an empty string for the missing value
+  with both keys still present, covered by a unit test.
+- [x] No `EventDto` contract shape change; line and branch coverage thresholds hold
+  (line >= 85%, branch >= 75%) with no regression on changed lines.
+
+## Non-Goals
+
+- Reshaping `EventDto` or any contract record (covered by #72).
+- Populating message `ToJson`/`CcJson` recipient fields (out of scope for this issue).
+- Changing the SQLite schema or `CacheRepository` column set.
+- Resolving Exchange DN-to-SMTP address translation beyond what the COM recipient surface provides.

--- a/src/OpenClaw.MailBridge/OutlookComHelpers.cs
+++ b/src/OpenClaw.MailBridge/OutlookComHelpers.cs
@@ -29,6 +29,23 @@ internal static class OutlookComHelpers
         }
     }
 
+    /// <summary>
+    /// Retrieves an item from a COM collection by its 1-based index via the collection's
+    /// <c>Item(index)</c> accessor, failing soft (returns <see langword="null"/>) on any COM error so
+    /// a single unreadable element does not abort enumeration.
+    /// </summary>
+    internal static object? GetOptionalIndexedItem(object collection, int index)
+    {
+        try
+        {
+            return InvokeMember(collection, "Item", index);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     internal static void SetMemberValue(object target, string memberName, object? value) =>
         target
             .GetType()

--- a/src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs
+++ b/src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace OpenClaw.MailBridge;
+
+/// <summary>
+/// Recipient enumeration and attendee-JSON shaping for <see cref="OutlookScanner"/> (issue #71).
+/// These live in a partial-class file separate from <c>OutlookScanner.cs</c> (already at the
+/// repository 500-line cap) and <c>OutlookScanner.GraphFields.cs</c>. The pure shaping function
+/// (<see cref="ShapeAttendeeJson"/>) has no COM dependency and is unit-testable directly; the COM
+/// enumeration method (<c>ReadAttendees</c>) reads the <c>Recipients</c> collection and delegates
+/// to it.
+/// </summary>
+internal sealed partial class OutlookScanner
+{
+    /// <summary>
+    /// Immutable carrier for the three serialized attendee-JSON strings produced from a single pass
+    /// over the COM <c>Recipients</c> collection. Each value is a non-null JSON array string; a type
+    /// with no recipients is the empty array <c>"[]"</c> (never null). Null is reserved for safe-mode
+    /// redaction and unread/unpopulated state (spec SP-B1).
+    /// </summary>
+    internal readonly record struct AttendeeJsonSet(
+        string RequiredJson,
+        string OptionalJson,
+        string ResourcesJson
+    );
+
+    /// <summary>
+    /// A single attendee projected from a COM <c>Recipient</c>: the display name and resolved SMTP
+    /// email. Both values are non-null; a missing source value is the empty string so the serialized
+    /// object always carries both <c>name</c> and <c>email</c> keys (spec US-AC5). Internal so the
+    /// pure shaping function can be unit-tested directly without live COM.
+    /// </summary>
+    internal readonly record struct Attendee(string Name, string Email);
+
+    /// <summary>
+    /// Shared, immutable serializer options: lowercase <c>name</c>/<c>email</c> property names via the
+    /// <see cref="AttendeeJson"/> contract, no indentation, and culture-invariant defaults. Constructed
+    /// once (static) to avoid per-call allocation and to guarantee deterministic output (spec design
+    /// decision 8).
+    /// </summary>
+    private static readonly JsonSerializerOptions AttendeeJsonOptions = new(
+        JsonSerializerDefaults.Web
+    )
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    /// <summary>
+    /// The Graph <c>emailAddress</c>-shaped projection of an attendee: lowercase <c>name</c> and
+    /// <c>email</c> keys in a fixed, deterministic order.
+    /// </summary>
+    private sealed record AttendeeJson(
+        [property: JsonPropertyName("name")] string Name,
+        [property: JsonPropertyName("email")] string Email
+    );
+
+    /// <summary>
+    /// Pure JSON shaping: serializes three ordered attendee lists to three JSON-array strings of
+    /// <c>{"name","email"}</c> objects. Input order is preserved; an empty list serializes to
+    /// <c>"[]"</c> (never null). Has no COM dependency. (spec US-AC2, SP-B1, design decisions 2/5/8)
+    /// </summary>
+    internal static AttendeeJsonSet ShapeAttendeeJson(
+        IReadOnlyList<Attendee> required,
+        IReadOnlyList<Attendee> optional,
+        IReadOnlyList<Attendee> resources
+    ) =>
+        new(
+            SerializeAttendees(required),
+            SerializeAttendees(optional),
+            SerializeAttendees(resources)
+        );
+
+    /// <summary>
+    /// Serializes a single ordered attendee list to a JSON array string of <c>{"name","email"}</c>
+    /// objects, preserving order. An empty list yields <c>"[]"</c>.
+    /// </summary>
+    private static string SerializeAttendees(IReadOnlyList<Attendee> attendees)
+    {
+        var shaped = new AttendeeJson[attendees.Count];
+        for (var i = 0; i < attendees.Count; i++)
+        {
+            shaped[i] = new AttendeeJson(attendees[i].Name, attendees[i].Email);
+        }
+
+        return JsonSerializer.Serialize(shaped, AttendeeJsonOptions);
+    }
+
+    /// <summary>
+    /// Reads the COM <c>Recipients</c> collection from the appointment <paramref name="item"/> in a
+    /// single pass, classifies each recipient by its <c>Type</c> (<c>OlMeetingRecipientType</c>:
+    /// 1 = required, 2 = optional, 3 = resource), and returns the three serialized JSON-array strings
+    /// via <see cref="ShapeAttendeeJson"/>. Out-of-range <c>Type</c> values are ignored (spec SP-B2);
+    /// per-recipient COM read failures fail soft and do not abort the scan (spec SP-B3). A null or
+    /// empty <c>Recipients</c> collection yields <c>"[]"</c> for all three fields (spec SP-B1).
+    ///
+    /// All COM wrappers obtained while enumerating — the <c>Recipients</c> collection, each
+    /// <c>Recipient</c>, and any <c>AddressEntry</c> resolved for the email fallback — are released
+    /// deterministically in a <c>finally</c> via <c>_com.ReleaseAll</c>, following the
+    /// <c>GetStoreId</c> idiom (spec SP-B4; architecture-boundaries COM confinement).
+    ///
+    /// This method does not read or alter the <c>ProtectedFieldsAvailable</c> signal; that value
+    /// remains derived solely from body availability in <see cref="BuildEventDto"/> (spec SP-B5,
+    /// design decision 7). Attendee PII protection is enforced separately by safe-mode redaction in
+    /// <c>ResponseShaper.ShapeEvent</c>.
+    /// </summary>
+    private AttendeeJsonSet ReadAttendees(object item)
+    {
+        var required = new List<Attendee>();
+        var optional = new List<Attendee>();
+        var resources = new List<Attendee>();
+
+        object? recipients = OutlookComHelpers.GetOptionalMemberValue(item, "Recipients");
+        if (recipients is null)
+        {
+            return ShapeAttendeeJson(required, optional, resources);
+        }
+
+        try
+        {
+            var count = OutlookComHelpers.GetOptionalInt(recipients, "Count") ?? 0;
+            for (var index = 1; index <= count; index++)
+            {
+                object? recipient = null;
+                object? addressEntry = null;
+                try
+                {
+                    recipient = OutlookComHelpers.GetOptionalIndexedItem(recipients, index);
+                    if (recipient is null)
+                    {
+                        continue;
+                    }
+
+                    var type = OutlookComHelpers.GetOptionalInt(recipient, "Type");
+                    var target = type switch
+                    {
+                        1 => required,
+                        2 => optional,
+                        3 => resources,
+                        _ => null,
+                    };
+                    if (target is null)
+                    {
+                        // Type values outside {1,2,3} are ignored (spec SP-B2).
+                        continue;
+                    }
+
+                    var name =
+                        OutlookComHelpers.GetOptionalString(recipient, "Name") ?? string.Empty;
+                    var email = OutlookComHelpers.GetOptionalString(recipient, "Address");
+                    if (string.IsNullOrEmpty(email))
+                    {
+                        addressEntry = OutlookComHelpers.GetOptionalMemberValue(
+                            recipient,
+                            "AddressEntry"
+                        );
+                        if (addressEntry is not null)
+                        {
+                            email = OutlookComHelpers.GetOptionalString(addressEntry, "Address");
+                        }
+                    }
+
+                    target.Add(new Attendee(name, email ?? string.Empty));
+                }
+                finally
+                {
+                    _com.ReleaseAll(addressEntry, recipient);
+                }
+            }
+        }
+        finally
+        {
+            _com.ReleaseAll(recipients);
+        }
+
+        return ShapeAttendeeJson(required, optional, resources);
+    }
+}

--- a/src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs
+++ b/src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs
@@ -16,6 +16,18 @@ internal sealed partial class OutlookScanner
     /// reusing it for both the redacted preview and the raw <c>BodyFull</c> value (spec "Limits"),
     /// and populating the nine issue-#72 Graph-shaped fields from their COM analogs/derivations.
     /// </summary>
+    /// <remarks>
+    /// Issue #71: the three attendee JSON fields (<c>RequiredAttendeesJson</c>,
+    /// <c>OptionalAttendeesJson</c>, <c>ResourcesJson</c>) are populated from a single pass over the
+    /// COM <c>Recipients</c> collection via <see cref="ReadAttendees"/>; a type with no recipients
+    /// serializes to <c>"[]"</c> (never null), reserving null for safe-mode redaction.
+    ///
+    /// <c>ProtectedFieldsAvailable</c> remains derived solely from body availability
+    /// (<c>!string.IsNullOrWhiteSpace(body)</c>); attendee readability does NOT contribute to or gate
+    /// that signal (spec SP-B5, design decision 7). Weakening or broadening the body-derived signal
+    /// would change existing issue-#72 behavior outside this issue's scope. Attendee-PII protection is
+    /// enforced separately by safe-mode redaction in <c>ResponseShaper.ShapeEvent</c>.
+    /// </remarks>
     private EventDto BuildEventDto(
         object item,
         string bridgeId,
@@ -28,6 +40,7 @@ internal sealed partial class OutlookScanner
         var sensitivity = OutlookComHelpers.GetOptionalInt(item, "Sensitivity");
         var recurrenceState = OutlookComHelpers.GetOptionalInt(item, "RecurrenceState");
         var responseStatus = OutlookComHelpers.GetOptionalInt(item, "ResponseStatus");
+        var attendees = ReadAttendees(item);
 
         return new EventDto(
             bridgeId,
@@ -41,9 +54,9 @@ internal sealed partial class OutlookScanner
             OutlookComHelpers.GetOptionalBool(item, "IsRecurring"),
             sensitivity,
             OutlookComHelpers.GetOptionalString(item, "Organizer"),
-            null,
-            null,
-            null,
+            attendees.RequiredJson,
+            attendees.OptionalJson,
+            attendees.ResourcesJson,
             ResponseShaper.ShapePreview(body, _settings),
             !string.IsNullOrWhiteSpace(body),
             false,

--- a/src/OpenClaw.MailBridge/ResponseShaper.cs
+++ b/src/OpenClaw.MailBridge/ResponseShaper.cs
@@ -43,7 +43,11 @@ internal static class ResponseShaper
         // Enhanced mode returns the full untruncated COM Body verbatim in BodyFull; it is NOT
         // routed through BodySanitizer.NormalizePreview (which truncates/collapses whitespace).
         // Safe mode nulls BodyFull alongside BodyPreview to preserve redaction parity, otherwise
-        // the full body text would leak in safe mode.
+        // the full body text would leak in safe mode. Issue #71: safe mode also nulls the three
+        // attendee JSON fields (RequiredAttendeesJson/OptionalAttendeesJson/ResourcesJson) because
+        // attendee names and emails are PII; this matches the message-path redaction of
+        // SenderName/SenderEmail in ShapeMessage. Null here is the redaction signal, distinct from
+        // the empty array "[]" the scanner emits for a type with no attendees.
         return enhancedMode
             ? evt with
             {
@@ -54,6 +58,9 @@ internal static class ResponseShaper
             {
                 BodyPreview = null,
                 BodyFull = null,
+                RequiredAttendeesJson = null,
+                OptionalAttendeesJson = null,
+                ResourcesJson = null,
                 IsRedacted = true,
             };
     }

--- a/tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs
+++ b/tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs
@@ -135,6 +135,65 @@ internal sealed record FakeAppointmentItem
     public int? RecurrenceState { get; init; }
     public DateTime? LastModificationTime { get; init; }
     public FakeOutlookParent Parent { get; init; } = new();
+
+    // Issue #71: COM Recipients collection analog, read reflectively by the scanner. Typed as object
+    // so a test can supply either a FakeRecipients or a fail-soft FakeThrowingRecipients double. Null
+    // models an appointment whose Recipients member is unavailable; the enumeration helper must treat
+    // that as "no attendees" ("[]").
+    public object? Recipients { get; init; }
+}
+
+/// <summary>
+/// Reflection-readable analog of the COM <c>Recipients</c> collection (issue #71): exposes a
+/// <c>Count</c> property and a 1-based <c>Item(index)</c> accessor matching the late-bound surface the
+/// scanner enumerates. No live COM.
+/// </summary>
+internal sealed class FakeRecipients
+{
+    private readonly List<FakeRecipient> recipients;
+
+    public FakeRecipients(params FakeRecipient[] recipients) =>
+        this.recipients = recipients.ToList();
+
+    public int Count => recipients.Count;
+
+    // 1-based indexer matching the Outlook Recipients.Item(index) method surface.
+    public FakeRecipient Item(int index) => recipients[index - 1];
+}
+
+/// <summary>
+/// Recipients analog whose <c>Item(index)</c> accessor throws (issue #71): models a COM read failure
+/// on an individual recipient so the scanner's per-recipient fail-soft path (spec SP-B3) and the
+/// fail-soft catch in <c>OutlookComHelpers.GetOptionalIndexedItem</c> are exercised. <c>Count</c> is
+/// non-zero so the enumeration loop enters.
+/// </summary>
+internal sealed class FakeThrowingRecipients
+{
+    public int Count => 1;
+
+    public FakeRecipient Item(int index) =>
+        throw new InvalidOperationException("Simulated COM read failure on recipient.");
+}
+
+/// <summary>
+/// Reflection-readable analog of a COM <c>Recipient</c> (issue #71): exposes <c>Type</c>, <c>Name</c>,
+/// <c>Address</c>, and an optional <c>AddressEntry</c> used for the email fallback path.
+/// </summary>
+internal sealed class FakeRecipient
+{
+    public int Type { get; init; }
+    public string? Name { get; init; }
+    public string? Address { get; init; }
+    public FakeAddressEntry? AddressEntry { get; init; }
+}
+
+/// <summary>
+/// Reflection-readable analog of a COM <c>AddressEntry</c> (issue #71): exposes the resolved SMTP
+/// <c>Address</c> used when the recipient's own <c>Address</c> is unavailable.
+/// </summary>
+internal sealed class FakeAddressEntry
+{
+    public string? Address { get; init; }
 }
 
 internal sealed class FakeOutlookParent

--- a/tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesShapeTests.cs
+++ b/tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesShapeTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.MailBridge;
+
+namespace OpenClaw.MailBridge.Tests;
+
+/// <summary>
+/// Pure JSON-shaping tests for issue #71 (US-AC2, SP-B1, US-AC5):
+/// <see cref="OutlookScanner.ShapeAttendeeJson"/> serializes ordered attendee lists to JSON arrays of
+/// <c>{"name","email"}</c> objects with lowercase keys, preserved order, <c>"[]"</c> for empty lists,
+/// and both keys always present even when a value is missing. No COM, no temp files, deterministic.
+/// </summary>
+[TestClass]
+public sealed class OutlookScannerAttendeesShapeTests
+{
+    private static OutlookScanner.Attendee Attendee(string name, string email) => new(name, email);
+
+    [TestMethod]
+    public void ShapeAttendeeJson_should_emit_lowercase_keys_and_preserve_order()
+    {
+        // Arrange: a two-element required list; the others empty to isolate the shape assertion.
+        var required = new[]
+        {
+            Attendee("Alice Example", "alice@example.com"),
+            Attendee("Bob Example", "bob@example.com"),
+        };
+
+        // Act
+        var set = OutlookScanner.ShapeAttendeeJson(
+            required,
+            Array.Empty<OutlookScanner.Attendee>(),
+            Array.Empty<OutlookScanner.Attendee>()
+        );
+
+        // Assert: exact JSON string, lowercase name/email keys, Graph emailAddress shape, order kept.
+        set.RequiredJson.Should()
+            .Be(
+                "[{\"name\":\"Alice Example\",\"email\":\"alice@example.com\"},"
+                    + "{\"name\":\"Bob Example\",\"email\":\"bob@example.com\"}]",
+                "the required list must serialize in collection order with lowercase name/email keys"
+            );
+    }
+
+    [TestMethod]
+    public void ShapeAttendeeJson_should_emit_empty_array_for_each_empty_group()
+    {
+        // Arrange / Act: all three groups empty.
+        var set = OutlookScanner.ShapeAttendeeJson(
+            Array.Empty<OutlookScanner.Attendee>(),
+            Array.Empty<OutlookScanner.Attendee>(),
+            Array.Empty<OutlookScanner.Attendee>()
+        );
+
+        // Assert: each group is "[]" (not null), so "no attendees of this type" is distinguishable
+        // from safe-mode redaction (which uses null).
+        set.RequiredJson.Should().Be("[]");
+        set.OptionalJson.Should().Be("[]");
+        set.ResourcesJson.Should().Be("[]");
+    }
+
+    [TestMethod]
+    public void ShapeAttendeeJson_should_keep_both_keys_when_a_value_is_missing()
+    {
+        // Arrange: one recipient missing a name, one missing an email (empty string for missing).
+        var required = new[] { Attendee(string.Empty, "noname@example.com") };
+        var optional = new[] { Attendee("No Email Person", string.Empty) };
+
+        // Act
+        var set = OutlookScanner.ShapeAttendeeJson(
+            required,
+            optional,
+            Array.Empty<OutlookScanner.Attendee>()
+        );
+
+        // Assert: both name and email keys are always present; the missing value is "".
+        set.RequiredJson.Should()
+            .Be(
+                "[{\"name\":\"\",\"email\":\"noname@example.com\"}]",
+                "a missing name emits an empty string with the name key still present"
+            );
+        set.OptionalJson.Should()
+            .Be(
+                "[{\"name\":\"No Email Person\",\"email\":\"\"}]",
+                "a missing email emits an empty string with the email key still present"
+            );
+    }
+}

--- a/tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesTests.cs
+++ b/tests/OpenClaw.MailBridge.Tests/OutlookScannerAttendeesTests.cs
@@ -1,0 +1,279 @@
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.MailBridge;
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.MailBridge.Tests;
+
+/// <summary>
+/// Scanner-path attendee population tests for issue #71 (US-AC1, US-AC3, US-AC5, SP-B1, SP-B2):
+/// <see cref="OutlookScanner"/> must populate <see cref="EventDto.RequiredAttendeesJson"/>,
+/// <see cref="EventDto.OptionalAttendeesJson"/>, and <see cref="EventDto.ResourcesJson"/> from the COM
+/// <c>Recipients</c> collection in enhanced mode. Exercised through the reflection-readable
+/// <c>FakeAppointmentItem.Recipients</c> double — no live COM, no temp files, deterministic clock.
+/// </summary>
+[TestClass]
+public sealed class OutlookScannerAttendeesTests
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static OutlookScanner BuildScanner(BridgeSettings settings, FakeComActiveObject com) =>
+        new(
+            settings,
+            new BridgeStateStore(settings),
+            NullLogger<OutlookScanner>.Instance,
+            com,
+            _ => 0,
+            () => FixedNow
+        );
+
+    private static FakeOutlookApplication BuildOutlookWithCalendar(FakeOutlookFolder calendar)
+    {
+        var outlook = new FakeOutlookApplication();
+        outlook.Namespace.DefaultFolders[9] = calendar;
+        outlook.Namespace.DefaultFolders[6] = new FakeOutlookFolder();
+        return outlook;
+    }
+
+    private static async Task<EventDto> ScanSingleEventAsync(
+        FakeAppointmentItem appointment,
+        string mode = "enhanced"
+    )
+    {
+        var settings = BridgeSettings.Default with
+        {
+            Mode = mode,
+            CalendarPastDays = 7,
+            CalendarFutureDays = 30,
+        };
+        var calendar = new FakeOutlookFolder();
+        calendar.Items.Add(appointment);
+        var com = new FakeComActiveObject { RunningObject = BuildOutlookWithCalendar(calendar) };
+        var repo = new FakeScanStateRepository();
+        var scanner = BuildScanner(settings, com);
+
+        await scanner.ScanCalendarAsync(repo);
+
+        repo.Events.Should().HaveCount(1);
+        return repo.Events.Values.Single();
+    }
+
+    private static FakeAppointmentItem BaseAppointment(FakeRecipients? recipients) =>
+        new()
+        {
+            EntryID = "entry-att",
+            GlobalAppointmentID = "gid-att",
+            Subject = "Attendees",
+            Start = FixedNow.AddDays(1),
+            End = FixedNow.AddDays(1).AddHours(1),
+            Recipients = recipients,
+        };
+
+    private static IReadOnlyList<(string Name, string Email)> Parse(string? json)
+    {
+        json.Should().NotBeNull();
+        using var doc = JsonDocument.Parse(json!);
+        return doc
+            .RootElement.EnumerateArray()
+            .Select(e => (e.GetProperty("name").GetString()!, e.GetProperty("email").GetString()!))
+            .ToArray();
+    }
+
+    [TestMethod]
+    public async Task ScanCalendar_should_populate_all_three_attendee_fields_in_enhanced_mode()
+    {
+        // Arrange: one required, one optional, one resource recipient.
+        var recipients = new FakeRecipients(
+            new FakeRecipient
+            {
+                Type = 1,
+                Name = "Req Person",
+                Address = "req@example.com",
+            },
+            new FakeRecipient
+            {
+                Type = 2,
+                Name = "Opt Person",
+                Address = "opt@example.com",
+            },
+            new FakeRecipient
+            {
+                Type = 3,
+                Name = "Room A",
+                Address = "rooma@example.com",
+            }
+        );
+
+        // Act
+        var evt = await ScanSingleEventAsync(BaseAppointment(recipients));
+
+        // Assert: each field non-null with the correct name and email.
+        Parse(evt.RequiredAttendeesJson).Should().Equal(("Req Person", "req@example.com"));
+        Parse(evt.OptionalAttendeesJson).Should().Equal(("Opt Person", "opt@example.com"));
+        Parse(evt.ResourcesJson).Should().Equal(("Room A", "rooma@example.com"));
+    }
+
+    [TestMethod]
+    public async Task ScanCalendar_should_classify_by_type_and_exclude_out_of_range()
+    {
+        // Arrange: types 1/2/3 plus two out-of-range types (0 and 4) that must be excluded.
+        var recipients = new FakeRecipients(
+            new FakeRecipient
+            {
+                Type = 1,
+                Name = "R",
+                Address = "r@example.com",
+            },
+            new FakeRecipient
+            {
+                Type = 2,
+                Name = "O",
+                Address = "o@example.com",
+            },
+            new FakeRecipient
+            {
+                Type = 3,
+                Name = "Res",
+                Address = "res@example.com",
+            },
+            new FakeRecipient
+            {
+                Type = 0,
+                Name = "Unknown0",
+                Address = "zero@example.com",
+            },
+            new FakeRecipient
+            {
+                Type = 4,
+                Name = "Unknown4",
+                Address = "four@example.com",
+            }
+        );
+
+        // Act
+        var evt = await ScanSingleEventAsync(BaseAppointment(recipients));
+
+        // Assert: each list holds only its own type; out-of-range recipients appear nowhere.
+        Parse(evt.RequiredAttendeesJson).Should().ContainSingle().Which.Name.Should().Be("R");
+        Parse(evt.OptionalAttendeesJson).Should().ContainSingle().Which.Name.Should().Be("O");
+        Parse(evt.ResourcesJson).Should().ContainSingle().Which.Name.Should().Be("Res");
+
+        var allNames = Parse(evt.RequiredAttendeesJson)
+            .Concat(Parse(evt.OptionalAttendeesJson))
+            .Concat(Parse(evt.ResourcesJson))
+            .Select(a => a.Name)
+            .ToArray();
+        allNames.Should().NotContain("Unknown0");
+        allNames.Should().NotContain("Unknown4");
+    }
+
+    [TestMethod]
+    public async Task ScanCalendar_should_emit_both_keys_when_name_or_email_missing()
+    {
+        // Arrange: a required recipient with no name, an optional recipient with no resolvable email.
+        var recipients = new FakeRecipients(
+            new FakeRecipient
+            {
+                Type = 1,
+                Name = null,
+                Address = "noname@example.com",
+            },
+            new FakeRecipient
+            {
+                Type = 2,
+                Name = "No Email",
+                Address = null,
+            }
+        );
+
+        // Act
+        var evt = await ScanSingleEventAsync(BaseAppointment(recipients));
+
+        // Assert: both keys present, missing value is empty string.
+        Parse(evt.RequiredAttendeesJson).Should().Equal((string.Empty, "noname@example.com"));
+        Parse(evt.OptionalAttendeesJson).Should().Equal(("No Email", string.Empty));
+    }
+
+    [TestMethod]
+    public async Task ScanCalendar_should_resolve_email_from_address_entry_fallback()
+    {
+        // Arrange: recipient with no direct Address but a resolvable AddressEntry.Address.
+        var recipients = new FakeRecipients(
+            new FakeRecipient
+            {
+                Type = 1,
+                Name = "Fallback Person",
+                Address = null,
+                AddressEntry = new FakeAddressEntry { Address = "fallback@example.com" },
+            }
+        );
+
+        // Act
+        var evt = await ScanSingleEventAsync(BaseAppointment(recipients));
+
+        // Assert: email resolved from the AddressEntry fallback.
+        Parse(evt.RequiredAttendeesJson)
+            .Should()
+            .Equal(("Fallback Person", "fallback@example.com"));
+    }
+
+    [TestMethod]
+    public async Task ScanCalendar_should_emit_empty_array_for_type_with_no_recipients()
+    {
+        // Arrange: only a required recipient; optional and resource types are absent.
+        var recipients = new FakeRecipients(
+            new FakeRecipient
+            {
+                Type = 1,
+                Name = "Only Required",
+                Address = "only@example.com",
+            }
+        );
+
+        // Act
+        var evt = await ScanSingleEventAsync(BaseAppointment(recipients));
+
+        // Assert: empty types are "[]" (not null); distinguishes "no attendees" from "redacted".
+        evt.OptionalAttendeesJson.Should().Be("[]");
+        evt.ResourcesJson.Should().Be("[]");
+        Parse(evt.RequiredAttendeesJson).Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task ScanCalendar_should_emit_empty_arrays_when_recipients_absent()
+    {
+        // Arrange: appointment with no Recipients collection at all.
+        var evt = await ScanSingleEventAsync(BaseAppointment(recipients: null));
+
+        // Assert: all three fields are "[]" (not null).
+        evt.RequiredAttendeesJson.Should().Be("[]");
+        evt.OptionalAttendeesJson.Should().Be("[]");
+        evt.ResourcesJson.Should().Be("[]");
+    }
+
+    [TestMethod]
+    public async Task ScanCalendar_should_fail_soft_when_a_recipient_read_throws()
+    {
+        // Arrange (spec SP-B3): a Recipients collection whose Item(index) throws must not abort the
+        // event scan; the unreadable recipient is skipped and the scan completes.
+        var appointment = new FakeAppointmentItem
+        {
+            EntryID = "entry-att",
+            GlobalAppointmentID = "gid-att",
+            Subject = "Attendees",
+            Start = FixedNow.AddDays(1),
+            End = FixedNow.AddDays(1).AddHours(1),
+            Recipients = new FakeThrowingRecipients(),
+        };
+
+        // Act
+        var evt = await ScanSingleEventAsync(appointment);
+
+        // Assert: the event was still produced; the unreadable recipient yields no attendees ("[]").
+        evt.RequiredAttendeesJson.Should().Be("[]");
+        evt.OptionalAttendeesJson.Should().Be("[]");
+        evt.ResourcesJson.Should().Be("[]");
+    }
+}

--- a/tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs
+++ b/tests/OpenClaw.MailBridge.Tests/ResponseShaperEventBodyFullTests.cs
@@ -55,6 +55,49 @@ public sealed class ResponseShaperEventBodyFullTests
         shaped.IsRedacted.Should().BeTrue();
     }
 
+    private static EventDto CreateEventWithAttendees() =>
+        CreateEvent(bodyFull: "Body") with
+        {
+            RequiredAttendeesJson = "[{\"name\":\"Req\",\"email\":\"req@example.com\"}]",
+            OptionalAttendeesJson = "[{\"name\":\"Opt\",\"email\":\"opt@example.com\"}]",
+            ResourcesJson = "[{\"name\":\"Room\",\"email\":\"room@example.com\"}]",
+        };
+
+    [TestMethod]
+    public void ShapeEvent_in_safe_mode_should_null_all_three_attendee_fields()
+    {
+        // Arrange (issue #71 US-AC4): populated attendee JSON fields must be redacted in safe mode,
+        // matching the message-path redaction of SenderName/SenderEmail.
+        var evt = CreateEventWithAttendees();
+        var settings = BridgeSettings.Default with { Mode = "safe" };
+
+        // Act
+        var shaped = ResponseShaper.ShapeEvent(evt, settings);
+
+        // Assert
+        shaped.RequiredAttendeesJson.Should().BeNull("safe mode must redact attendee PII");
+        shaped.OptionalAttendeesJson.Should().BeNull("safe mode must redact attendee PII");
+        shaped.ResourcesJson.Should().BeNull("safe mode must redact attendee PII");
+        shaped.IsRedacted.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void ShapeEvent_in_enhanced_mode_should_preserve_all_three_attendee_fields()
+    {
+        // Arrange (issue #71 US-AC4 non-regression): enhanced mode leaves attendee JSON intact.
+        var evt = CreateEventWithAttendees();
+        var settings = BridgeSettings.Default with { Mode = "enhanced" };
+
+        // Act
+        var shaped = ResponseShaper.ShapeEvent(evt, settings);
+
+        // Assert
+        shaped.RequiredAttendeesJson.Should().Be(evt.RequiredAttendeesJson);
+        shaped.OptionalAttendeesJson.Should().Be(evt.OptionalAttendeesJson);
+        shaped.ResourcesJson.Should().Be(evt.ResourcesJson);
+        shaped.IsRedacted.Should().BeFalse();
+    }
+
     [TestMethod]
     public void ShapeEvent_in_enhanced_mode_should_return_full_untruncated_body_verbatim()
     {


### PR DESCRIPTION
# feat(mailbridge): populate EventDto attendee JSON from COM Recipients

## Summary

- Populates `EventDto.RequiredAttendeesJson`, `OptionalAttendeesJson`, and `ResourcesJson` in `OutlookScanner.BuildEventDto` from the COM `AppointmentItem.Recipients` collection; these fields previously carried `null` despite existing on the contract.
- Classifies each recipient by `Type` (`1=required`, `2=optional`, `3=resource`) and serializes each group to a JSON array of `{"name","email"}` objects matching the Graph `emailAddress` shape (lowercase keys, deterministic order).
- Extends safe-mode redaction in `ResponseShaper.ShapeEvent` to null all three attendee fields, matching the existing message-path redaction of `SenderName`/`SenderEmail`.
- Adds a new `OutlookScanner.Attendees.cs` partial (pure JSON shaping + COM enumeration with deterministic wrapper release) and a fail-soft `OutlookComHelpers.GetOptionalIndexedItem` helper.
- No `EventDto` contract shape change; coverage improves to 94.07% line / 86.54% branch with all changed production files at 100%.

## Why

`EventDto` already carried `RequiredAttendeesJson`, `OptionalAttendeesJson`, and `ResourcesJson`, and `CacheRepository` persisted them, but `OutlookScanner.BuildEventDto` hardcoded all three to `null`. Downstream consumers (deferred from #70) could not see who was invited to a meeting. This change populates the fields from the COM `Recipients` collection while respecting the bridge's redaction model: attendee names and emails are PII and must be redacted in safe mode for parity with the message path.

## What Changed

**Core feature (`src/OpenClaw.MailBridge/`)**
- `OutlookScanner.Attendees.cs` (new): pure shaping function (ordered `(Name, Email)` lists → JSON arrays via a single static `JsonSerializerOptions`, lowercase `name`/`email`, order preserved) plus a private instance method that enumerates the COM `Recipients` collection in a single pass, classifies by `Type`, and releases all COM wrappers deterministically.
- `OutlookScanner.GraphFields.cs`: wires the three populated values into `BuildEventDto` (replacing the three `null` literals); documents the `ProtectedFieldsAvailable` decision (left body-derived, not weakened).
- `OutlookComHelpers.cs`: adds fail-soft `GetOptionalIndexedItem` for 1-based COM collection access.
- `ResponseShaper.cs`: safe-mode branch of `ShapeEvent` now nulls the three attendee fields.

**Tests (`tests/OpenClaw.MailBridge.Tests/`)**
- `OutlookScannerAttendeesShapeTests.cs` (new): pure-shaping assertions — Graph shape/lowercase keys/order, empty list → `"[]"`, missing name/email → `""` with both keys present.
- `OutlookScannerAttendeesTests.cs` (new): scanner/COM-seam assertions — enhanced-mode population, per-type classification, out-of-range `Type` exclusion, missing values, empty/absent collection → `"[]"`, and fail-soft on a throwing recipient.
- `MailBridgeRuntimeTestDoubles.cs`: adds reflection-readable `Recipients`/`Recipient`/`AddressEntry` doubles and a throwing double.
- `ResponseShaperEventBodyFullTests.cs`: adds safe-mode-nulls and enhanced-mode-preserves redaction tests.

**Docs / evidence**
- Feature folder `docs/features/active/mailbridge-event-attendees-json-71/`: spec, user-story, plan, the three feature-review audit artifacts, and baseline/QA-gate evidence.

## Architecture / How It Fits Together

Outlook COM remains confined to `OpenClaw.MailBridge`. During calendar normalization, `BuildEventDto` reads the appointment's `Recipients` collection on the dedicated STA thread, groups recipients by `OlMeetingRecipientType`, and serializes each group. The resulting JSON strings flow unchanged through `CacheRepository` into the existing `required_attendees_json` / `optional_attendees_json` / `resources_json` columns. `ResponseShaper` applies mode-based redaction at the response boundary: enhanced mode returns the populated values, safe mode nulls them. No new project references are introduced; the dependency graph is unchanged.

## Verification

**Completed (from context evidence, base `main` @ `c0fa1024`):**
- Format — CSharpier `format`/`check`: EXIT 0.
- Build / analyzers — `dotnet build ... -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true`: EXIT 0.
- Nullable / type-check — `dotnet build ... -p:TreatWarningsAsErrors=true`: EXIT 0.
- Architecture — no new `ProjectReference` edges; COM confinement preserved: EXIT 0.
- Tests + coverage — `dotnet test ... --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`: EXIT 0 (474 passed, 3 skipped, 0 failed).
- Coverage — 94.07% line / 86.54% branch (baseline 93.55% / 85.47%, no regression on changed lines; all four changed production files at 100%/100%).
- Contract unchanged — `BridgeContracts.cs` diff empty: EXIT 0.
- Feature-review — policy-audit, code-review, and feature-audit produced with zero blocking findings.

**Recommended:**
- Run the full `OpenClaw.MailBridge.sln` test suite on the CI runner class and confirm the required PR Pipeline checks are green.

## Backward Compatibility / Migration Notes

- No `EventDto` contract shape change: positional argument count and order are unchanged; only the three `null` literals became populated expressions.
- No SQLite schema or `CacheRepository` column changes; no migration or backfill required.
- Behavioral change: events scanned in enhanced mode now return populated attendee JSON instead of `null`. Safe mode continues to return `null` for these fields.

## Risks and Mitigations

- **COM round-trips per event** for recipient enumeration. Mitigated by a single pass over the `Recipients` collection and deterministic wrapper release (`_com.ReleaseAll` in `finally`) to avoid RCW accumulation.
- **Per-recipient read failure** could otherwise abort an event scan. Mitigated by fail-soft per-recipient reads (`GetOptional*` / `GetOptionalIndexedItem`); a throwing recipient is covered by a unit test.
- **PII exposure** of attendee names/emails. Mitigated by safe-mode redaction parity in `ResponseShaper.ShapeEvent`, asserted by tests.
- Rollback: revert this PR; the fields return to `null` with no schema impact.

## Review Guide

1. `src/OpenClaw.MailBridge/OutlookScanner.Attendees.cs` — core logic (pure shaping + COM enumeration/release).
2. `src/OpenClaw.MailBridge/OutlookScanner.GraphFields.cs` and `ResponseShaper.cs` — wiring and redaction.
3. `src/OpenClaw.MailBridge/OutlookComHelpers.cs` — fail-soft indexed accessor.
4. Test files for classification, redaction, and fail-soft coverage.
5. Feature-doc/evidence files are mechanical record-keeping.

## Follow-ups

- #73 — add Graph-shaped fields to `MessageDto` (including `toJson`/`ccJson`); message recipient JSON is explicitly out of scope here.
- Exchange DN-to-SMTP resolution beyond the COM recipient surface is deferred.

## GitHub Auto-close

- Closes #71
