### PR TITLE
docs(sqlite-92): add feature-review audit artifacts for #92

### DIFF
--- a/docs/features/active/sqlite-advisory-nu1903-92/code-review.2026-07-01T21-15.md
+++ b/docs/features/active/sqlite-advisory-nu1903-92/code-review.2026-07-01T21-15.md
@@ -1,0 +1,108 @@
+# Code Review: SQLitePCLRaw 3.x override to clear NU1903 (#92)
+
+**Review Date:** 2026-07-01
+**Reviewer:** feature-review agent
+**Feature Folder:** `docs/features/active/sqlite-advisory-nu1903-92`
+**Feature Folder Selection Rule:** Suffix `-92` matches the canonical issue number in the branch name `fix/sqlite-advisory-nu1903`.
+**Base Branch:** `main` (merge-base `1f3bb41`)
+**Head Branch:** `fix/sqlite-advisory-nu1903` (commit `d4161c1`)
+**Review Type:** Initial review
+
+---
+
+## Executive Summary
+
+This change resolves the repo-wide NU1903 build failure (GHSA-2m69-gcr7-jv3q) caused by the transitive package `SQLitePCLRaw.lib.e_sqlite3` 2.1.6, which is pulled in by `Microsoft.Data.Sqlite` 8.0.11. The fix adds a single direct `PackageReference` to `SQLitePCLRaw.bundle_e_sqlite3` version `3.0.0`, identically, to `src/OpenClaw.Core/OpenClaw.Core.csproj` and `src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj`. This forces the transitive `SQLitePCLRaw.lib.e_sqlite3` to 3.50.3, which clears the advisory. `Microsoft.Data.Sqlite` is left unchanged at 8.0.11.
+
+The reviewer independently reproduced the build gate and the transitive resolution, and inspected the executor's runtime and coverage evidence.
+
+**What changed:**
+- `src/OpenClaw.Core/OpenClaw.Core.csproj`: `+ <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.0" />`
+- `src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj`: the identical line (lockstep).
+- The rest of the diff is feature-folder documentation and 26 evidence artifacts. No .cs, .ps1, .py, or .ts source file changed.
+
+**Top 3 risks:**
+1. Unsupported combination: SQLitePCLRaw 3.x native provider paired with `Microsoft.Data.Sqlite` 8.0.11 core. This is mitigated by the AC-4 runtime evidence showing the native provider loads and cache open/read/write paths pass (Core 14/14, MailBridge 18/18, 0 DllNotFoundException, 0 core-mismatch).
+2. Provider drift on future `Microsoft.Data.Sqlite` upgrades: a later MDS bump could reintroduce a core/version mismatch. Mitigated because the direct reference pins the provider family; any future bump will re-trigger restore/runtime gates.
+3. Pre-existing HostAdapter branch coverage (67.19%) remains below 75%, but this assembly is untouched by the change and the pooled branch figure (79.31%) clears the threshold.
+
+**PR readiness recommendation:** **Go** — the change is minimal, correctly scoped, lockstep across both projects, introduces no advisory suppression, and is runtime-verified.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Info | `src/OpenClaw.Core/OpenClaw.Core.csproj` | line 18 | Direct `SQLitePCLRaw.bundle_e_sqlite3` 3.0.0 added; transitive `lib.e_sqlite3` resolves to 3.50.3. | None. Correct minimal fix. | Clears GHSA-2m69-gcr7-jv3q at the required version floor. | `dotnet list ... package --include-transitive` (reviewer-reproduced): `SQLitePCLRaw.lib.e_sqlite3 3.50.3`. |
+| Info | `src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj` | line 24 | Identical direct reference added (lockstep with Core). | None. | Satisfies the lockstep constraint in issue.md. | `git diff main...HEAD` shows the identical `+` line in both csproj. |
+| Info | both csproj | ItemGroup | `Microsoft.Data.Sqlite` unchanged at 8.0.11; unsupported combo with SQLitePCLRaw 3.x. | Track future MDS upgrades so the runtime gate is re-run. | Combo is functional now but not officially supported; documented in issue.md. | `evidence/other/ac4-runtime-sqlite-provider.2026-07-01T20-30.md`. |
+
+No Blocker or Major findings.
+
+---
+
+## Implementation Audit
+
+### C# implementation audit
+
+#### What changed well
+
+- Minimal, surgical dependency change: one line per project, identical across both, no product-code churn, no unrelated dependency edits.
+- The fix uses a direct `PackageReference` to override the transitive version rather than any suppression mechanism (`NoWarn`, `NuGetAuditMode`, `NuGetAuditSuppress`), which is the policy-correct approach and preserves the advisory audit for any future regression.
+- The unsupported provider/core combination is not merely asserted but runtime-verified: SQLite-backed tests open real connections that load the native provider, and the evidence records zero DllNotFoundException, zero provider-init failure, and zero core-version mismatch.
+
+#### Type safety and API notes
+
+- No public API surface changed. No .cs file changed. Nullable/analyzer state is clean under warnings-as-errors (0 diagnostics), reviewer-reproduced.
+
+#### Error handling and logging
+
+- Not applicable — no code paths changed. The restore-graph coherence gate (`dotnet restore` clean, no NU1605/NU1107) confirms the dependency graph resolves without downgrade or conflict.
+
+---
+
+## Test Quality Audit
+
+The change adds no tests. Verification relies on the existing MSTest suites plus a targeted SQLite-backed runtime subset used to exercise the native provider. The reviewer verified evidence artifacts rather than re-running the full suite (the required evidence-verification model), and independently reproduced the build and transitive-resolution gates.
+
+### Reviewed test and QA artifacts
+
+- `evidence/qa-gates/final-test-coverage.2026-07-01T20-30.md` — full suite 587 pass / 5 skip / 0 fail across 3 assemblies; pooled line 90.73% / branch 79.31%.
+- `evidence/qa-gates/ac4-runtime-sqlite-provider.2026-07-01T20-30.md` — SQLite-backed subset Core 14/14, MailBridge 18/18; native e_sqlite3 3.50.3 provider loaded at runtime with no DllNotFoundException / provider-init / core-mismatch.
+- `evidence/qa-gates/coverage-delta.2026-07-01T20-30.md` — 0.00 pp delta on line and branch; no changed product-code lines.
+- `evidence/qa-gates/targeted-nu1903-cleared.2026-07-01T20-30.md` — build gate 0 NU1903, 0 new NUxxxx.
+- `evidence/other/no-suppression-check.2026-07-01T20-30.md` — zero suppression tokens in the diff.
+- `evidence/other/ac7-restore-graph-coherence.2026-07-01T20-30.md` — restore clean for all 9 projects.
+
+### Quality assessment prompts
+
+- **Determinism:** SQLite tests use in-memory shared-cache connections (no temp files, no network); deterministic.
+- **Isolation:** each SQLite-backed test targets a single open/read/write behavior.
+- **Speed:** unchanged by a package-only change; no new tests.
+- **Diagnostics:** the runtime evidence explicitly scans logs for DllNotFoundException and provider-init/core-mismatch counts, so a provider-load failure would have been visible.
+
+---
+
+## Security / Correctness Checks
+
+| Check | Status | Evidence |
+|---|---|---|
+| No secrets in code | ✅ PASS | Diff is two `<PackageReference>` lines plus docs; no secrets. |
+| No unsafe subprocess or command construction | N/A | No executable code changed. |
+| Input validation at boundaries | N/A | No code paths changed. |
+| Error handling remains explicit | ✅ PASS | No error-handling code changed; restore/build/runtime gates all clean. |
+| No advisory suppression introduced | ✅ PASS | `git diff main...HEAD | grep -iE "NoWarn|NuGetAuditMode|NuGetAuditSuppress|NU1903"` matches only doc/plan files, never a build file. |
+| Dependency advisory cleared | ✅ PASS | `SQLitePCLRaw.lib.e_sqlite3` resolves to 3.50.3 (>= 3.50.3); build shows 0 NU1903 (reviewer-reproduced). |
+
+---
+
+## Research Log
+
+No external research was required. The advisory (GHSA-2m69-gcr7-jv3q / NU1903) and the required cleared version (`SQLitePCLRaw.lib.e_sqlite3` >= 3.50.3) are documented in `issue.md`, and both were verified directly against the resolved dependency graph via `dotnet list ... --include-transitive`.
+
+---
+
+## Verdict
+
+The change is ready for normal PR flow. It is a minimal, lockstep dependency override that clears NU1903 without suppression, changes no product code, and is substantiated by a reviewer-reproduced clean warnings-as-errors build, reviewer-reproduced transitive resolution to 3.50.3, and executor runtime evidence confirming the native provider loads for the unsupported SQLitePCLRaw 3.x / Microsoft.Data.Sqlite 8.0.11 combination. This conclusion is consistent with the Findings Table (no Blocker/Major findings) and the Go readiness recommendation above.

--- a/docs/features/active/sqlite-advisory-nu1903-92/feature-audit.2026-07-01T21-15.md
+++ b/docs/features/active/sqlite-advisory-nu1903-92/feature-audit.2026-07-01T21-15.md
@@ -1,0 +1,98 @@
+# Feature Audit: SQLitePCLRaw 3.x override to clear NU1903 (#92)
+
+**Audit Date:** 2026-07-01
+**Feature Folder:** `docs/features/active/sqlite-advisory-nu1903-92`
+**Base Branch:** `main`
+**Head Branch:** `fix/sqlite-advisory-nu1903`
+**Work Mode:** `minor-audit`
+**Audit Type:** Initial acceptance review
+
+---
+
+## Scope and Baseline
+
+- **Base branch:** `main` (commit `1f3bb41`)
+- **Head branch/commit:** `fix/sqlite-advisory-nu1903` (commit `d4161c1`)
+- **Merge base:** `1f3bb419cba0576a10944de842108283a1b88d43`
+- **Evidence sources:**
+  - Primary: `artifacts/pr_context.summary.txt` (regenerated during this review)
+  - Secondary baseline diff: `artifacts/pr_context.appendix.txt` (regenerated during this review)
+  - Feature evidence: `docs/features/active/sqlite-advisory-nu1903-92/evidence/**`
+  - Reviewer-reproduced: `dotnet build ... -warnaserror`, `dotnet list ... --include-transitive`, `csharpier check .`
+- **Feature folder used:** `docs/features/active/sqlite-advisory-nu1903-92`
+- **Requirements source:** `issue.md` (## Acceptance Criteria, AC-1..AC-7)
+- **Work mode resolution note:** `issue.md` carries the explicit marker `- Work Mode: minor-audit`; the AC source is the single `## Acceptance Criteria` section in `issue.md`.
+- **Scope note:** The PR-context artifacts were stale (they referenced `feature/env-driven-publish-versioning @ a231284`) and were regenerated against the resolved base `main @ 1f3bb41` and current head `d4161c1`. The audit scope is the full branch diff; the only non-doc changes are two `.csproj` files.
+
+---
+
+## Acceptance Criteria Inventory
+
+**Authoritative AC source files for this run:**
+- `docs/features/active/sqlite-advisory-nu1903-92/issue.md` — only source (minor-audit)
+
+### Acceptance criteria
+
+1. AC-1 A direct SQLitePCLRaw reference (`SQLitePCLRaw.bundle_e_sqlite3` 3.x, plus any companion package required for a coherent graph) is added identically to both `src/OpenClaw.Core/OpenClaw.Core.csproj` and `src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj`, restoring the transitive `SQLitePCLRaw.lib.e_sqlite3` to the 3.x line (>= 3.50.3).
+2. AC-2 `dotnet build OpenClaw.MailBridge.sln -c Release /warnaserror` completes with 0 `NU1903` errors and introduces no new package advisories (no new `NUxxxx`).
+3. AC-3 No advisory suppression is introduced (`NoWarn`/`NuGetAuditMode`/`NuGetAuditSuppress` unchanged).
+4. AC-4 `dotnet test OpenClaw.MailBridge.sln -c Release` passes, INCLUDING the SQLite-backed cache/DB tests that exercise the native `e_sqlite3` provider at runtime; line coverage >= 85% and branch coverage >= 75%; no regression on changed lines.
+5. AC-5 No product-code behavior change, or — if the override forces one — it is minimal, justified, and test-covered.
+6. AC-6 Full C# toolchain passes in a single clean pass: CSharpier format -> analyzers/build (`/warnaserror`) -> nullable -> architecture tests -> MSTest tests.
+7. AC-7 HARD GATE: if no coherent restore graph exists, or the SQLite-backed tests fail at runtime due to the SQLitePCLRaw 3.x / Microsoft.Data.Sqlite mismatch, the work STOPS and is surfaced to the operator (no forcing, no silent fallback to suppression).
+
+---
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Status | Evidence | Verification command(s) | Notes |
+|---|-----------|--------|----------|--------------------------|-------|
+| AC-1 | Identical direct SQLitePCLRaw 3.x ref in both csproj; transitive `lib.e_sqlite3` >= 3.50.3 | PASS | Both csproj add the identical `SQLitePCLRaw.bundle_e_sqlite3` 3.0.0 line (reviewer `git diff`). Transitive `lib.e_sqlite3` resolves to 3.50.3 in both projects (reviewer-reproduced). | `git diff main...HEAD -- src/**/*.csproj`; `dotnet list <proj> package --include-transitive` | No companion package or MDS bump was needed; MDS unchanged at 8.0.11. |
+| AC-2 | Build `-c Release /warnaserror`: 0 NU1903, no new NUxxxx | PASS | Reviewer reproduced: `dotnet build OpenClaw.MailBridge.sln -c Release -warnaserror` -> Build succeeded, 0 Warning(s), 0 Error(s). Executor: `targeted-nu1903-cleared` and `final-build-analyzers` record 0 NU1903, 0 NUxxxx. | `dotnet build OpenClaw.MailBridge.sln -c Release -warnaserror` | `/warnaserror` and `-warnaserror` are the same MSBuild switch; `-` form used to avoid MSYS path rewriting. |
+| AC-3 | No advisory suppression introduced | PASS | Reviewer grep of full diff for `NoWarn`/`NuGetAuditMode`/`NuGetAuditSuppress`/`NU1903` matched only doc/plan files, never a build file. Executor: `no-suppression-check.2026-07-01T20-30.md` (NO_SUPPRESSION_MATCHES). | `git diff main...HEAD | grep -iE "NoWarn|NuGetAuditMode|NuGetAuditSuppress|NU1903"` | Confirmed suppression tokens exist only in documentation describing the advisory. |
+| AC-4 | Tests pass incl. SQLite runtime; line >= 85% / branch >= 75%; no changed-line regression | PASS | Full suite 587 pass / 5 skip / 0 fail; pooled line 90.73% / branch 79.31%; delta 0.00 pp. SQLite-backed subset: Core 14/14, MailBridge 18/18; native e_sqlite3 3.50.3 loaded at runtime with 0 DllNotFoundException / 0 provider-init / 0 core-mismatch. | `dotnet test OpenClaw.MailBridge.sln -c Release --collect:"XPlat Code Coverage"` (executor evidence) | Coverage cited from executor cobertura evidence per the evidence-verification model; reviewer independently reproduced build + resolution. No changed product-code lines to regress. |
+| AC-5 | No product-code behavior change (or minimal/justified/test-covered) | PASS | No .cs file changed anywhere in the diff; the only non-doc changes are two `.csproj` package lines. | `git diff main...HEAD --name-only | grep -vE "^docs/"` -> only the two csproj | The override forced no product-code adjustment. |
+| AC-6 | Full C# toolchain single clean pass | PASS | CSharpier check exit 0 (reviewer-reproduced, Checked 193 files); analyzers/nullable via `-warnaserror` 0 diagnostics (reviewer-reproduced); architecture 0 violations (`final-architecture`); MSTest 587 pass. No QC-loop restart. | `csharpier check .`; `dotnet build ... -warnaserror`; executor architecture/test evidence | CSharpier changed no files, so a single clean pass held. |
+| AC-7 | HARD GATE: coherent restore + runtime pass, else STOP (no forcing, no suppression) | PASS | Restore succeeded for all 9 projects, no NU1605/NU1107 (`ac7-restore-graph-coherence`). Runtime mismatch check passed: SQLite-backed tests green, native provider loaded (`ac7-runtime-mismatch`, `ac4-runtime-sqlite-provider`). No forcing, no suppression fallback. | `dotnet restore OpenClaw.MailBridge.sln`; SQLite-backed filtered test runs | The gate condition (stop-if-broken) did not fire because both restore and runtime succeeded. |
+
+---
+
+## Summary
+
+**Overall Feature Readiness:** PASS
+
+**Criteria summary:**
+- **PASS:** 7 criteria
+- **PARTIAL:** 0 criteria
+- **UNVERIFIED:** 0 criteria
+- **FAIL:** 0 criteria
+
+**Top gaps preventing PASS:**
+
+1. None.
+
+**Recommended follow-up verification steps:**
+
+1. On any future `Microsoft.Data.Sqlite` upgrade, re-run the restore-graph and SQLite-backed runtime gates, because the SQLitePCLRaw 3.x / MDS 8.0.11 pairing is an unsupported combination.
+2. After merge to `main`, rebase PR #91 (`chore/update-agents`) onto `main` to inherit this fix, as noted in issue.md.
+
+---
+
+## Acceptance Criteria Check-off
+
+Per the acceptance-criteria tracking rules:
+- All 7 criteria evaluate PASS.
+- The `issue.md` acceptance criteria are authored as prose bullets (`- AC-1 ...`), not markdown checkbox items (`- [ ]`). Per the tracking rules, non-checkbox source items are not reformatted; status is recorded in this audit only. No checkbox change was made to `issue.md`.
+- The separate `## Evidence Checklist` in `issue.md` (baseline / targeted verification / end-state) was already checked `[x]` by the executor and is left unchanged.
+
+### AC Status Summary
+
+- Source: `docs/features/active/sqlite-advisory-nu1903-92/issue.md`
+- Total AC items: 7
+- Checked off (delivered): 0 (source uses prose bullets, not checkboxes; not reformatted)
+- Remaining (unchecked): 0 unmet — all 7 PASS, recorded in this audit
+- Items remaining: None.
+
+| Source File | Total AC | Checked (PASS) | Unchecked | Notes |
+|-------------|----------|----------------|-----------|-------|
+| `issue.md` | 7 | 7 (evaluated PASS) | 0 | Prose-only AC bullets; status recorded here, source not rewritten. |

--- a/docs/features/active/sqlite-advisory-nu1903-92/policy-audit.2026-07-01T21-15.md
+++ b/docs/features/active/sqlite-advisory-nu1903-92/policy-audit.2026-07-01T21-15.md
@@ -1,0 +1,316 @@
+# Policy Compliance Audit: SQLitePCLRaw 3.x override to clear NU1903 (issue #92)
+
+**Audit Date:** 2026-07-01
+**Code Under Test:**
+- `src/OpenClaw.Core/OpenClaw.Core.csproj` (MODIFIED, +1 line)
+- `src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj` (MODIFIED, +1 line)
+- Feature-folder documentation and evidence under `docs/features/active/sqlite-advisory-nu1903-92/**` (docs only)
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| C# | 2 files (both .csproj, MSBuild XML) | 587 | ✅ 587 pass, 5 skipped, 0 fail | line 90.73% / branch 79.31% pooled | line 90.73% / branch 79.31% pooled | N/A (no .cs lines changed) |
+
+**Note:** The only non-documentation changes in the branch diff are two `.csproj` files. No .cs, .ps1, .py, or .ts source files changed. There is therefore only one changed application language (C#), and its coverage verdict is explicit PASS (see Section 1.2). No new product-code files or lines were added, so the "new code coverage" cell is N/A by fact, not by scope narrowing.
+
+### Coverage Evidence Checklist
+
+- C# post-change coverage evidence: `docs/features/active/sqlite-advisory-nu1903-92/evidence/qa-gates/final-test-coverage.2026-07-01T20-30.md` (pooled line 90.73% / branch 79.31% from three cobertura reports)
+- C# baseline coverage evidence: `docs/features/active/sqlite-advisory-nu1903-92/evidence/baseline/baseline-test-coverage.md`
+- C# changed-line / no-regression evidence: `docs/features/active/sqlite-advisory-nu1903-92/evidence/qa-gates/coverage-delta.2026-07-01T20-30.md` (delta 0.00 pp line and branch)
+- Per-language comparison summary: Section 1.2.1 below
+- TypeScript baseline coverage artifact: N/A - out of scope (zero changed TypeScript files on this branch)
+- TypeScript post-change coverage artifact: N/A - out of scope (zero changed TypeScript files on this branch)
+- PowerShell baseline coverage artifact: N/A - out of scope (zero changed PowerShell files on this branch)
+- PowerShell post-change coverage artifact: N/A - out of scope (zero changed PowerShell files on this branch)
+- Python coverage artifacts: N/A - out of scope (zero changed Python files on this branch)
+
+**Verdict rules applied:** This audit includes numeric baseline and post-change coverage for the one in-scope language (C#) and confirms no regression on the changed (csproj-only) surface. All cited evidence artifacts exist on disk and were read during this review; no evidence was synthesized.
+
+---
+
+## Executive Summary
+
+The change adds a single direct `PackageReference` to `SQLitePCLRaw.bundle_e_sqlite3` version `3.0.0`, identically, to both `src/OpenClaw.Core/OpenClaw.Core.csproj` and `src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj`. `Microsoft.Data.Sqlite` remains unchanged at `8.0.11`. The direct reference forces the transitive `SQLitePCLRaw.lib.e_sqlite3` from the advisory-affected 2.1.6 to 3.50.3, which clears NU1903 (GHSA-2m69-gcr7-jv3q). The remainder of the branch diff is feature-folder documentation and evidence artifacts.
+
+The reviewer independently reproduced the C# build gate (`dotnet build OpenClaw.MailBridge.sln -c Release -warnaserror`: build succeeded, 0 Warning(s), 0 Error(s)) and independently confirmed the transitive resolution (`dotnet list ... package --include-transitive`: `SQLitePCLRaw.lib.e_sqlite3` 3.50.3 in both projects). The reviewer also independently reproduced the CSharpier format check (`csharpier check .`: Checked 193 files, exit 0). Test-suite pass/coverage figures are cited from the executor's coverage evidence, which is the required evidence-verification model for this reviewer.
+
+**Policy documents evaluated:**
+- ✅ `general-code-change.md` (cross-language code change policy)
+- ✅ `general-unit-test.md` (coverage thresholds and no-regression rule)
+- ✅ `quality-tiers.md` (uniform line >= 85% / branch >= 75%)
+- ✅ `csharp.md` (C# toolchain order — applicable, C# files changed)
+
+**Language-specific policies evaluated:**
+- ✅ C#: `csharp.md` (formatting -> analyzers/build -> nullable -> architecture -> MSTest)
+- N/A Python / PowerShell / Bash / JSON: no changed files on this branch
+
+**Temporary artifacts cleanup:**
+- ✅ No temporary or throwaway scripts were created by this change; the diff is package-reference-only plus documentation.
+
+---
+
+## Rejected Scope Narrowing
+
+None. The caller prompt explicitly instructed the reviewer to determine scope per the scope invariant and not to treat any changed-language toolchain as out of scope. No narrowing instruction was present. The audit scope is the full branch diff `main...HEAD` (`1f3bb41..d4161c1`).
+
+---
+
+## Evidence Location Compliance
+
+The reviewer scanned the branch diff for files written under `artifacts/baselines/`, `artifacts/qa/`, `artifacts/evidence/`, or `artifacts/coverage/`.
+
+- Result: no such files present. All feature evidence is written under the canonical `docs/features/active/sqlite-advisory-nu1903-92/evidence/<kind>/` path.
+- Command: `git diff main...HEAD --name-only | grep -iE "artifacts/(baselines|qa|evidence|coverage)/"` returned `NO_EVIDENCE_LOCATION_VIOLATIONS`.
+- Verdict: ✅ PASS. No evidence-location violations.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** | ✅ PASS | The change adds no tests and modifies no test code. The existing suite (587 passed, 5 skipped, 0 failed) ran clean post-change per `final-test-coverage.2026-07-01T20-30.md`. No ordering dependency was introduced. |
+| **Isolation** | ✅ PASS | No test changes. SQLite-backed tests exercise a single behavior each (open/read/write) per `ac4-runtime-sqlite-provider.2026-07-01T20-30.md`. |
+| **Fast Execution** | ✅ PASS | No test additions; suite runtime unaffected by a package-reference-only change. |
+| **Determinism** | ✅ PASS | SQLite tests use in-memory shared-cache connections (no temp files) per the AC-4 runtime evidence; no wall-clock or RNG dependency introduced. |
+| **Readability & Maintainability** | ✅ PASS | No test code changed. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | ✅ PASS | Baseline pooled line 90.73% / branch 79.31% recorded in `baseline-test-coverage.md` (2026-07-01T19-46) and reused in `coverage-delta.2026-07-01T20-30.md`. |
+| **No Coverage Regression** | ✅ PASS | Post-change pooled line 90.73% / branch 79.31%. Delta 0.00 pp on both. The change edits only two `.csproj` files; no product-code lines changed, so there are no changed product-code lines to regress. Evidence: `coverage-delta.2026-07-01T20-30.md`. |
+| **New Code Coverage** | N/A (factual) | No new product-code files or lines were added. The diff is two added `<PackageReference>` lines. There is no new code to cover. |
+| **Comprehensive Coverage** | ✅ PASS | Pooled line 90.73% >= 85% and branch 79.31% >= 75%. Per-assembly: MailBridge line 93.58% / branch 87.76%; Core line 90.06% / branch 77.70%; HostAdapter line 88.46% / branch 67.19% (branch below 75% on HostAdapter is pre-existing and unaffected by this package-only change; the pooled branch figure clears the threshold and no changed line touches HostAdapter). |
+| **Positive / Negative / Edge / Error / Concurrency / State** | ✅ PASS (unchanged) | No behavior changed; existing scenario coverage is unchanged. The runtime provider-load path is positively verified by the SQLite-backed suites (Core 14/14, MailBridge 18/18). |
+
+**C# coverage verdict: PASS.** Pooled line 90.73% >= 85%; pooled branch 79.31% >= 75%; no regression on the changed (csproj-only) surface.
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- C#: Baseline: 90.73% lines -> Post-change: 90.73% lines. Change: +0.00% lines (branch 79.31% -> 79.31%, +0.00%). New/changed-code coverage: N/A - out of scope (no .cs lines changed). Disposition: PASS. Evidence: `evidence/qa-gates/final-test-coverage.2026-07-01T20-30.md`, `evidence/qa-gates/coverage-delta.2026-07-01T20-30.md`.
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | ✅ PASS | SQLite tests use in-memory shared-cache connections; no temp files, no network per `ac4-runtime-sqlite-provider.2026-07-01T20-30.md`. |
+| **Environment Stability** | ✅ PASS | No temp-file creation; deterministic in-memory SQLite. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | ✅ PASS | Minimal change: a single direct `PackageReference` per project. No product-code churn, no build-property gymnastics. |
+| **Reusability / Extensibility / Separation of concerns** | ✅ PASS (N/A change) | Dependency-graph change only; no API or layering impact. Architecture evidence confirms no new project edge (`final-architecture.2026-07-01T20-30.md`). |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Under 500 lines** | ✅ PASS | Both csproj files remain small (single-line additions). No file approaches the 500-line cap. |
+| **No circular dependencies** | ✅ PASS | No `ProjectReference` added or removed; the compile-time project graph is unchanged (`final-architecture.2026-07-01T20-30.md`). |
+
+### 2.5 After Making Changes - Toolchain Execution (C#)
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | ✅ PASS | `csharpier check .` -> Checked 193 files, exit 0. Independently reproduced by reviewer (exit 0). Executor evidence: `final-csharpier.2026-07-01T20-30.md`. |
+| **2. Linting (analyzers)** | ✅ PASS | `dotnet build ... -c Release -warnaserror` -> 0 Warning(s), 0 Error(s); analyzer/CA/CS/IDE count 0. Independently reproduced by reviewer. Executor evidence: `final-build-analyzers.2026-07-01T20-30.md`. |
+| **3. Type checking (nullable)** | ✅ PASS | Warnings-as-errors build serves as the nullable gate; 0 diagnostics. Independently reproduced. |
+| **4. Architecture-boundary tests** | ✅ PASS | 0 violations; COM confinement preserved; no new project edge. Evidence: `final-architecture.2026-07-01T20-30.md`. |
+| **5. Testing (MSTest)** | ✅ PASS (cited) | 587 passed, 5 skipped, 0 failed across 3 assemblies. Evidence: `final-test-coverage.2026-07-01T20-30.md`. |
+| **6. Contract / schema** | N/A | No host-service boundary contract changed; dependency-only change. |
+| **7. Integration / runtime** | ✅ PASS (cited) | SQLite-backed tests load the native e_sqlite3 3.50.3 provider at runtime: Core 14/14, MailBridge 18/18, 0 DllNotFoundException, 0 provider-init failure, 0 core-mismatch. Evidence: `ac4-runtime-sqlite-provider.2026-07-01T20-30.md`. |
+| **Full toolchain loop** | ✅ PASS | CSharpier caused no file changes; single clean pass. Evidence: `final-csharpier.2026-07-01T20-30.md` (no QC-loop restart). |
+
+**Note on `/warnaserror` vs `-warnaserror`:** In Git Bash, `/warnaserror` is rewritten by MSYS path conversion; `-warnaserror` is the identical MSBuild switch. The reviewer used `-warnaserror` and reproduced exit 0.
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+### Section 3-C#: C# Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Dependencies: approved / minimal** | ✅ PASS | `SQLitePCLRaw` is the native provider family already pulled transitively by `Microsoft.Data.Sqlite`; the change promotes it to a direct reference at 3.x. It is a well-maintained, widely used package. The issue documents why: no `Microsoft.Data.Sqlite` release transitively clears the advisory; only the SQLitePCLRaw 3.x line does. |
+| **Lockstep / identical across projects** | ✅ PASS | Both csproj add the exact same `SQLitePCLRaw.bundle_e_sqlite3` `3.0.0` line. Verified by reviewer via `git diff` (identical `+` line in both files). |
+| **No advisory suppression** | ✅ PASS | Reviewer grep of the diff for `NoWarn` / `NuGetAuditMode` / `NuGetAuditSuppress` / `NU1903` matched only documentation/plan files describing the advisory, never any build file (csproj/props/targets). Executor evidence: `no-suppression-check.2026-07-01T20-30.md`. |
+| **No product-code behavior change** | ✅ PASS | No .cs file changed anywhere in the diff. Evidence: `coverage-delta.2026-07-01T20-30.md`, reviewer `git diff --name-only`. |
+| **Restore-graph coherence** | ✅ PASS | `dotnet restore` succeeded for all 9 projects; no NU1605/NU1107. Evidence: `ac7-restore-graph-coherence.2026-07-01T20-30.md`; reviewer's build restored cleanly. |
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+No test files were added or modified in this branch. The change is package-reference-only. There are no new or modified C# test files to audit under this section. The existing MSTest suites were executed unchanged and passed (587 pass / 5 skip / 0 fail), and the SQLite-backed subset was used for the AC-4 runtime provider-load verification.
+
+- Python unit tests: N/A — no changed Python files.
+- PowerShell unit tests: N/A — no changed PowerShell files.
+- C# unit tests: no test-code change; existing MSTest suites pass. Evidence: `evidence/qa-gates/final-test-coverage.2026-07-01T20-30.md`.
+
+---
+
+## 5. Test Coverage Detail
+
+No new or modified production code exists, so there is no per-function coverage delta to detail. Coverage is reported at the assembly level from the post-change cobertura reports (`evidence/qa-gates/final-test-coverage.2026-07-01T20-30.md`):
+
+| Assembly | Line Coverage | Branch Coverage | Status |
+|----------|---------------|-----------------|--------|
+| OpenClaw.MailBridge.Tests surface | 93.58% (1166/1246) | 87.76% (387/441) | ✅ |
+| OpenClaw.Core.Tests surface | 90.06% (1323/1469) | 77.70% (317/408) | ✅ |
+| OpenClaw.HostAdapter.Tests surface | 88.46% (997/1127) | 67.19% (170/253) | Pre-existing branch gap; assembly not touched by this change |
+| POOLED | 90.73% (3486/3842) | 79.31% (874/1102) | ✅ |
+
+**Not covered by new code:** None — no new code was added.
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests | 592 (587 executed + 5 skipped) | ✅ |
+| Tests Passed | 587 (99.2% of executed) | ✅ |
+| Tests Failed | 0 | ✅ |
+| Tests Skipped | 5 (pre-existing) | ✅ |
+| Assemblies | 3 (HostAdapter.Tests, Core.Tests, MailBridge.Tests) | ✅ |
+| Code Coverage | 90.73% lines, 79.31% branches (pooled) | ✅ |
+| SQLite-backed runtime subset | Core 14/14, MailBridge 18/18 pass | ✅ |
+
+---
+
+## 7. Code Quality Checks (C#)
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| CSharpier format | `csharpier check .` | Checked 193 files, exit 0 (reviewer-reproduced) | ✅ |
+| Analyzers + nullable | `dotnet build OpenClaw.MailBridge.sln -c Release -warnaserror` | 0 Warning(s), 0 Error(s) (reviewer-reproduced) | ✅ |
+| NU1903 / advisory | build log NUxxxx scan | 0 NU1903, 0 new NUxxxx | ✅ |
+| Transitive resolution | `dotnet list ... package --include-transitive` | `SQLitePCLRaw.lib.e_sqlite3` 3.50.3 in both projects (reviewer-reproduced) | ✅ |
+| MSTest | `dotnet test OpenClaw.MailBridge.sln -c Release --collect:"XPlat Code Coverage"` | 587 pass / 5 skip / 0 fail (cited) | ✅ |
+
+**Notes:** HostAdapter branch coverage 67.19% is a pre-existing condition on an assembly this change does not touch; pooled branch coverage (79.31%) clears the >= 75% threshold and there is no changed line in HostAdapter. This is not introduced by issue #92.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+**None.** All policy requirements applicable to a package-reference-only C# change are met. The one hard runtime gate (unsupported SQLitePCLRaw 3.x + Microsoft.Data.Sqlite 8.0.11 core combination) is substantiated by runtime evidence (AC-4/AC-7): the native provider loads and cache open/read/write paths pass.
+
+### Approved Exceptions
+**None.**
+
+### Removed/Skipped Tests
+**None.** The 5 skipped tests are pre-existing skips unrelated to this change (baseline was also 587 pass / 5 skip / 0 fail).
+
+---
+
+## 9. Summary of Changes
+
+### Commits in This Branch
+1. **d4161c1** — fix(deps): override SQLitePCLRaw to 3.x to clear NU1903 (GHSA-2m69-gcr7-jv3q)
+
+### Files Modified
+1. **src/OpenClaw.Core/OpenClaw.Core.csproj** (MODIFIED) — added `<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.0" />`.
+2. **src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj** (MODIFIED) — added the identical reference (lockstep).
+3. **docs/features/active/sqlite-advisory-nu1903-92/** (NEW) — issue.md, two plan files, 26 evidence artifacts.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: ✅ FULLY COMPLIANT
+
+The change clears NU1903 by forcing `SQLitePCLRaw.lib.e_sqlite3` to 3.50.3 through an identical direct reference in both project files, introduces no advisory suppression, changes no product code, and is substantiated by a reviewer-reproduced clean warnings-as-errors build, reviewer-reproduced transitive resolution, and executor runtime and coverage evidence.
+
+**Fail-closed check:** All required baseline, QA, and coverage-comparison artifacts are present on disk and were inspected. No PASS was recorded on missing evidence.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- ✅ Design Principles: minimal, simple dependency change
+- ✅ Module & File Structure: under 500 lines; no circular deps; no new project edge
+- ✅ Toolchain Execution: single clean C# pass (reviewer-reproduced format + build)
+- ✅ Summarize & Document: issue.md and plan/evidence documents present
+
+#### Language-Specific Code Change Policy (Section 3 — C#)
+- ✅ Dependencies: approved, minimal, lockstep
+- ✅ No advisory suppression
+- ✅ No product-code behavior change
+- ✅ Restore-graph coherence
+
+#### General Unit Test Policy (Section 1)
+- ✅ Coverage & Scenarios: pooled line 90.73% >= 85%, branch 79.31% >= 75%, no regression
+- ✅ External Dependencies: in-memory SQLite, no temp files
+
+---
+
+### Metrics Summary
+- ✅ 587/592 tests passing (5 pre-existing skips), 0 failures
+- ✅ Pooled line coverage 90.73%; pooled branch coverage 79.31%
+- ✅ 0 NU1903, 0 new NUxxxx (reviewer-reproduced)
+- ✅ `SQLitePCLRaw.lib.e_sqlite3` 3.50.3 resolved in both projects (reviewer-reproduced)
+- ✅ Identical lockstep reference across both csproj
+
+---
+
+### Recommendation
+
+**Ready for merge.** No blocking or partial findings. The change is a minimal, correctly-scoped dependency override that clears the advisory without suppression and is runtime-verified for the unsupported provider/core combination.
+
+---
+
+## Appendix A: Test Inventory
+
+No tests were added or modified by this change. The relevant runtime-verification subset (used to substantiate AC-4 / AC-7) consists of the SQLite-backed cache/DB test classes exercised at runtime:
+
+- OpenClaw.Core.Tests › CoreCacheRepositoryMessageFieldsTests
+- OpenClaw.Core.Tests › CoreCacheRepositoryGraphFieldsTests
+- OpenClaw.MailBridge.Tests › CacheRepositoryMessageFieldsTests
+- OpenClaw.MailBridge.Tests › CacheRepositoryGraphFieldsTests
+- OpenClaw.MailBridge.Tests › CacheRepositoryResponseStatusTests
+- OpenClaw.MailBridge.Tests › CacheRepositoryMigrationIdempotencyTests
+
+Full suite: 587 passed / 5 skipped / 0 failed across 3 assemblies. Evidence: `evidence/qa-gates/final-test-coverage.2026-07-01T20-30.md`, `evidence/qa-gates/ac4-runtime-sqlite-provider.2026-07-01T20-30.md`.
+
+---
+
+## Appendix B: Toolchain Commands Reference
+
+```bash
+# Format (reviewer-reproduced)
+csharpier check .
+
+# Build with warnings-as-errors / advisory gate (reviewer-reproduced)
+dotnet build OpenClaw.MailBridge.sln -c Release -warnaserror
+
+# Transitive resolution verification (reviewer-reproduced)
+dotnet list src/OpenClaw.Core/OpenClaw.Core.csproj package --include-transitive
+dotnet list src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj package --include-transitive
+
+# Suppression scan (reviewer-reproduced)
+git diff main...HEAD | grep -iE "NoWarn|NuGetAuditMode|NuGetAuditSuppress|NU1903"
+
+# Tests + coverage (executor evidence; not re-run by reviewer)
+dotnet test OpenClaw.MailBridge.sln -c Release --settings mailbridge.runsettings --collect:"XPlat Code Coverage"
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-07-01
+**Policy Version:** Current (as of audit date)


### PR DESCRIPTION
# Suggested title

docs(sqlite-92): add feature-review audit artifacts for #92

## Summary

- Adds the three feature-review audit records (policy-audit, code-review, feature-audit) for the NU1903 SQLitePCLRaw fix (issue #92) to its feature folder.
- Documentation only; no code or dependency changes.

## Why

The audit artifacts were generated during the review of the #92 fix, after that PR's pre-review commit, so they were not included in the merged PR #93. Committing them completes the `docs/features/active/sqlite-advisory-nu1903-92/` record per repository convention (feature-review outputs live in the feature folder).

## What Changed

- `docs/features/active/sqlite-advisory-nu1903-92/policy-audit.2026-07-01T21-15.md`
- `docs/features/active/sqlite-advisory-nu1903-92/code-review.2026-07-01T21-15.md`
- `docs/features/active/sqlite-advisory-nu1903-92/feature-audit.2026-07-01T21-15.md`

## Verification

Completed:
- Documentation-only diff; no build/test impact. Required CI checks are expected to pass unchanged.

Recommended:
- Confirm required checks pass on this PR head.

## Backward Compatibility / Migration Notes

- None. Documentation only.

## Risks and Mitigations

- None material. Docs-only addition.

## Review Guide

- The three added Markdown audit files.

## Follow-ups

- None.

## GitHub Auto-close

None (issue #92 was already closed by PR #93; this PR only adds its audit records).
