### PR TITLE
docs(memory): record merge-commit-only policy for PRs to main

### DIFF
--- a/.claude/agent-memory/orchestrator/MEMORY.md
+++ b/.claude/agent-memory/orchestrator/MEMORY.md
@@ -11,3 +11,4 @@
 - [Clean worktree before ready](feedback_clean-worktree-before-ready.md) — `git status --porcelain` must be empty before declaring a PR ready to merge; commit memory/docs, don't leave them.
 - [Autonomous finish sequence](feedback_autonomous-finish-sequence.md) — after a passing exit gate, commit+push all, open PR, remediate CI, commit memories, ensure green CI — without asking. Overrides "commit only when asked".
 - [.env files denied to tools](project_env-files-permission-denied-to-tools.md) — `.env`/`.env.example` blocked from Read/Write/Edit/Bash cat; inspect via git diff/show, have operator edit.
+- [Merge-commit policy](feedback_merge-commit-policy.md) — every PR merges to main with a MERGE COMMIT (`gh pr merge --merge`); never squash/rebase; never commit directly to main.

--- a/.claude/agent-memory/orchestrator/feedback_merge-commit-policy.md
+++ b/.claude/agent-memory/orchestrator/feedback_merge-commit-policy.md
@@ -1,0 +1,23 @@
+---
+name: merge-commit-policy
+description: Every PR must be merged into main with a MERGE COMMIT — never squash or rebase merges. gh pr merge <n> --merge only.
+metadata:
+  type: feedback
+---
+
+All merges into `main` MUST use a **merge commit**. Use `gh pr merge <n> --merge`
+(equivalently `git merge --no-ff`). Never `--squash` and never `--rebase`.
+
+**Why:** Repo policy requires merge-commit history on `main` (the existing history
+uses two-parent `Merge pull request #NN` commits). The operator flagged that squash
+merges are prohibited: a squash produces a single-parent commit on `main` that
+resembles a direct-to-`main` commit, which is not allowed, and it also leaves the
+source branch looking "unmerged" (its commits are not ancestors of `main`).
+Direct commits to `main` are likewise prohibited — all changes land via a PR.
+
+**How to apply:**
+- When merging any PR: `gh pr merge <number> --merge --delete-branch`. Do not pass
+  `--squash` or `--rebase`.
+- Never `git commit`/`git push` onto `main` directly; branch, PR, then merge-commit.
+- After merging, the source branch is deleted (server-side and local). Related:
+  [[clean-worktree-before-ready]], [[autonomous-finish-sequence]].


### PR DESCRIPTION
# Suggested title

docs(memory): record merge-commit-only policy for PRs to main

## Summary

- Records an orchestrator memory that every PR must be merged to `main` with a **merge commit** (`gh pr merge --merge`); squash/rebase merges and direct commits to `main` are prohibited.
- Documentation only (agent-memory), no code or dependency changes.

## Why

Operator directive following prior PRs that were squash-merged. Squash produces single-parent commits on `main` that resemble direct-to-`main` commits and leave source branches looking unmerged; the repository requires two-parent merge commits.

## What Changed

- `.claude/agent-memory/orchestrator/feedback_merge-commit-policy.md` (new memory).
- `.claude/agent-memory/orchestrator/MEMORY.md` (index entry).

## Verification

Completed:
- Documentation-only diff; no build/test impact.

Recommended:
- Confirm required checks pass on this PR head.
- Merge this PR with a merge commit (`gh pr merge 95 --merge`).

## Backward Compatibility / Migration Notes

- None. Documentation only.

## Risks and Mitigations

- None material.

## Review Guide

- The new memory file and the one-line index entry.

## Follow-ups

- None.

## GitHub Auto-close

None.
