### PR TITLE
fix(mailbridge): include in-progress and window-spanning events in calendar scan filter

### DIFF
--- a/.claude/agent-memory/feature-review/feedback_per-file-coverage-masking.md
+++ b/.claude/agent-memory/feature-review/feedback_per-file-coverage-masking.md
@@ -15,9 +15,12 @@ MailBridge project aggregate passed. The masking happened because the new file's
 SMTP-resolution chain was a small fraction of the project's total lines.
 
 **How to apply:** Do not trust per-project aggregates for the new-code verdict. Re-run
-`dotnet test ... --collect:"XPlat Code Coverage"` to the canonical
-`<FEATURE>/evidence/qa-gates/coverage-review/` path, then parse the cobertura and aggregate hits
-per `filename` for each new/changed file individually. The on-disk artifacts under
+`dotnet test ... --collect:"XPlat Code Coverage" --results-directory "<FEATURE>/evidence/qa-gates/coverage-review"`
+(the `--results-directory` flag routes cobertura output straight to the canonical path — worked on
+the #19 review, 2026-07-02), then parse the cobertura and aggregate hits per `filename` for each
+new/changed file individually. Cobertura may contain duplicate `<class>` entries per partial-class
+file and the results dir may hold stale runs from an interrupted attempt — dedupe/delete before
+pooling (on #19 an interrupted attempt left 3 byte-identical extra reports that doubled raw counts). The on-disk artifacts under
 `artifacts/coverage/*` are gitignored and frequently stale/missing the new classes, so generate a
 fresh run. See [[artifact-validator-quirks]].
 

--- a/.claude/agent-memory/feature-review/project_review-env-fallbacks.md
+++ b/.claude/agent-memory/feature-review/project_review-env-fallbacks.md
@@ -10,11 +10,12 @@ Two environment gaps recur when running feature review in this repo's worktrees:
 1. **MCP tools absent from the agent toolset.** `resolve_policy_audit_template_asset` and
    `validate_orchestration_artifacts` may not be exposed. No repo-local template files exist
    (glob for `*template*.md` finds only `.github/prompts/execute-plan-template.md`).
-   **How to apply:** mirror the structure of the most recent validator-PASSING artifact set —
-   `docs/features/archive/2026-06-09-openclaw-agent-deterministic-core-70/{policy-audit,code-review,feature-audit}.2026-06-09T13-48.md`
-   — combined with the exact rules in [[artifact-validator-quirks]]. Record the missing MCP
-   resolution as a documented exception in section 8 of the policy audit (verified acceptable on
-   #80 review, 2026-07-02).
+   **How to apply:** mirror the structure of the most recent accepted artifact set — the #80 set
+   `docs/features/active/core-response-status-roundtrip-80/{policy-audit,code-review,feature-audit}.2026-07-02T07-35.md`
+   (or its archive location after merge; older fallback: archived #70 set at
+   `docs/features/archive/2026-06-09-openclaw-agent-deterministic-core-70/`) — combined with the
+   exact rules in [[artifact-validator-quirks]]. Record the missing MCP resolution as a documented
+   exception in section 8 of the policy audit (accepted on #80 and #19 reviews, 2026-07-02).
 
 2. **`dotnet tool restore` fails** ("command csharpier ... package contains dotnet-csharpier").
    **How to apply:** use the globally installed `csharpier check .` (1.3.0) instead; record the

--- a/.claude/agent-memory/prd-feature/MEMORY.md
+++ b/.claude/agent-memory/prd-feature/MEMORY.md
@@ -2,3 +2,4 @@
 
 - [Harness canonical policy](project_harness_canonical_policy.md) — `.claude/rules/*` is the single source of truth; `.github/instructions/*` and `AGENTS.md` reconcile to it (Issue #66, 2026-06-08).
 - [Harness deferred follow-ups](project_harness_deferred_followups.md) — generator script, benchmark validator, and dotnet-tools manifest are deferred out of Issue #66 scope.
+- [Test framework discrepancy](project_test_framework_discrepancy.md) — repo tests use MSTest + FluentAssertions despite csharp.md saying xUnit; specs must cite MSTest.

--- a/.claude/agent-memory/prd-feature/project_test_framework_discrepancy.md
+++ b/.claude/agent-memory/prd-feature/project_test_framework_discrepancy.md
@@ -1,0 +1,12 @@
+---
+name: test-framework-mstest-not-xunit
+description: Tests in this repo use MSTest + FluentAssertions even though .claude/rules/csharp.md says xUnit; specs must cite MSTest.
+metadata:
+  type: project
+---
+
+`tests/OpenClaw.MailBridge.Tests/` uses MSTest (`[TestClass]`/`[TestMethod]`) with FluentAssertions, while `.claude/rules/csharp.md` prescribes xUnit + NSubstitute. Orchestrator delegation prompts also specify MSTest + FluentAssertions (confirmed for issue #19, 2026-07-02).
+
+**Why:** The rule file predates or diverges from the actual codebase; following it verbatim would produce specs and test strategies that do not match the project.
+
+**How to apply:** When authoring spec.md test strategies or acceptance criteria for this repo, cite MSTest + FluentAssertions and the existing fake COM test doubles (`MailBridgeRuntimeTestDoubles.cs`, `FakeOutlookItems.LastFilter`), not xUnit. Verify against the actual test tree if in doubt.

--- a/docs/features/active/calendar-overlap-filter-19/code-review.2026-07-02T08-24.md
+++ b/docs/features/active/calendar-overlap-filter-19/code-review.2026-07-02T08-24.md
@@ -1,0 +1,100 @@
+# Code Review: calendar-overlap-filter (#19)
+
+**Review Date:** 2026-07-02
+**Branch:** `bug/calendar-overlap-filter-19` @ `d7fc69a31b441c9a5d98abf693ef6d00916134e1`
+**Base:** `main` @ merge-base `1bc4148867bd757b724af503b59a3a19bc6f37b4`
+**Scope:** Full feature-vs-base branch diff. C# surface: `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` (modified, one expression body), `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs` (new, 186 lines). Markdown surface: feature folder docs/evidence for issue #19 and two `prd-feature` agent-memory files.
+
+---
+
+## Executive Summary
+
+This is a minimal, correctly targeted bugfix. The defective start-only Restrict predicate (`[Start] >= windowStart AND [Start] < windowEnd`) is replaced with the standard interval-overlap predicate (`[Start] < windowEnd AND [End] > windowStart`) in a single expression body. The strict `<`/`>` operators encode the required boundary semantics directly (an event with `End == windowStart` or `Start == windowEnd` is excluded), so no additional logic was needed. The `LocalDateTime` conversion and `MM/dd/yyyy hh:mm tt` format established by the issue #55 fix are preserved character-for-character, and the surrounding scan orchestration in `OutlookScanner.cs` (`Sort("[Start]")`, `IncludeRecurrences = true`, then `Restrict`) is untouched — verified by diff inspection, not just by evidence assertion.
+
+The new test class is well constructed. It captures the actual filter string emitted through `ScanCalendarAsync` using the established fake-COM doubles (no live Outlook dependency), pins the exact string with invariant formatting, and then evaluates event membership against the emitted filter with a small clause parser covering all five interval-boundary scenarios. The evaluator deliberately supports `>=`/`<=` in addition to `<`/`>`, which is what allowed the fail-before run to evaluate the old predicate and prove that exactly the in-progress and window-spanning rows fail under it — a high-quality discriminating regression design.
+
+The reviewer independently re-ran the full toolchain at branch head (format, build with analyzers/nullable as errors, architecture tests, full solution test suite with coverage): all clean, 596/596 runnable tests passing. Per-file coverage was re-measured from fresh cobertura: the modified file is at 100% line / 100% branch with the changed line covered 56 times.
+
+No Blocking or Major findings. One Minor pre-existing observation (host-culture sensitivity of Restrict-boundary formatting) and two Informational notes are recorded below; none require action on this branch.
+
+---
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|----------|------|----------|---------|----------------|-----------|----------|
+| Minor | src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs | `BuildCalendarFilter` (line 49) and pre-existing `BuildInboxFilter` (line 45) | Restrict boundaries are rendered via string interpolation, which formats with the current culture; on a non-en-US host the `MM/dd/yyyy hh:mm tt` custom format would emit culture-specific separators/AM-PM designators, producing a filter Outlook may not parse and diverging from the test's `CultureInfo.InvariantCulture` expectation. | No action on this branch (the spec explicitly required preserving the existing formatting exactly, and the defect fix must stay minimal). File a follow-up to render Restrict boundaries invariantly (e.g. `FormattableString.Invariant`) in both builders and align the test expectation. | Pre-existing pattern in both builders that predates this branch; the branch neither introduced nor worsened it, and dev/CI hosts are en-US, so behavior and test determinism are unaffected in practice. | Production interpolation at Helpers.cs lines 45 and 49; test expected-string construction with `string.Create(CultureInfo.InvariantCulture, ...)` at test file lines 75-78. |
+| Info | tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs | `EvaluateClause` (lines 156-185) | The clause evaluator supports `>=` and `<=` operators that the fixed filter never emits. | None — keep as is. | The extra operators are load-bearing for the regression contract: the fail-before run evaluates the pre-fix predicate, which uses `>=`. Removing them would break the fail-before discrimination property. | `evidence/regression-testing/regression-fail-before.2026-07-02T07-59.md` shows the DataRow tests evaluating the old `>=` predicate. |
+| Info | .claude/agent-memory/prd-feature/MEMORY.md, .claude/agent-memory/prd-feature/project_test_framework_discrepancy.md | branch diff | Two agent-memory files from the `prd-feature` agent ride on this bugfix branch (recording the repo's MSTest-vs-xUnit rule divergence). | None — agent memory is version-controlled by design in this repo; the content is accurate bookkeeping. | The executor's scope-verification artifact explicitly identifies these as writes from a different agent, not part of the fix scope; they contain no code or policy changes. | `evidence/qa-gates/scope-verification.2026-07-02T08-04.md`; diff hunks for both files. |
+
+No Blocking or Major findings.
+
+---
+
+## Implementation Audit
+
+### C# implementation audit
+
+#### What changed well
+
+- **Correct predicate, minimal diff.** The interval-overlap membership test (`Start < windowEnd AND End > windowStart`) is the canonical form, and the strict operators yield the specified boundary semantics without extra conditionals. The production diff is exactly one line (+1/-1); `git diff` confirms no other production change anywhere in the branch.
+- **Invariants preserved verbatim.** The `LocalDateTime` conversion, the `MM/dd/yyyy hh:mm tt` format string, the `private` method visibility, and the method signature are all unchanged; the issue #55 `GetOptionalUtcDateTimeOffset` normalization path is untouched. `ScanCalendarAsync`'s `Sort`/`IncludeRecurrences`/`Restrict` ordering is unchanged (read directly at `OutlookScanner.cs` lines ~278-284).
+- **No scope creep.** `BuildInboxFilter`, the cache schema, `FreeBusyProjection`, and HostAdapter routes — all named non-goals in the spec — are untouched. The spec's optional `internal`-visibility seam was correctly declined in favor of asserting the captured filter through the existing fakes, keeping the public/internal surface identical.
+- **Recurrence escape hatch handled by decision, not code.** The plan records an explicit stop-and-report rule if a recurring-occurrence edge case had surfaced, rather than speculatively adding a post-filter pass. None surfaced; none was added.
+
+#### Type safety and API notes
+
+- No public API surface change; `OutlookScanner` remains `internal sealed partial` and `BuildCalendarFilter` remains `private`.
+- No suppressions, pragmas, or analyzer-configuration changes anywhere in the diff; build is clean with warnings-as-errors.
+
+#### Error handling and logging
+
+- No new production error paths; the existing null-check on the restricted items collection in `ScanCalendarAsync` is sufficient and unchanged, as the spec specified.
+
+---
+
+## Test Quality Audit
+
+### Reviewed test and QA artifacts
+
+- `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs` (new, 186 lines, 6 tests) — read in full.
+- `evidence/regression-testing/regression-fail-before.2026-07-02T07-59.md` — EXIT 1; exactly the 3 predicted tests fail against the unfixed predicate (exact-string test, in-progress row, window-spanning row) while the fully-within and both boundary-exclusion rows pass. This is the correct discrimination signature: the old predicate genuinely satisfies those three cases, so their pre-fix passes are expected, and the artifact says so explicitly.
+- `evidence/regression-testing/regression-pass-after.2026-07-02T08-00.md` — EXIT 0; 6/6 pass.
+- `evidence/regression-testing/full-suite-after-fix.2026-07-02T08-00.md` — 596 passed / 0 failed / 5 skipped; no existing test file modified.
+- Reviewer re-run at head: full solution 596 passed / 0 failed / 5 pre-existing environment-gated skips; architecture subset 2/2.
+
+### Quality assessment
+
+- **Assertion strength:** The primary test pins the exact filter string (`Should().Be(expected)`), not a substring — the strongest possible assertion for a string-builder fix. Membership rows assert both inclusion and exclusion with scenario messages.
+- **Independence/isolation:** Each test call builds a fresh fake graph via `CaptureEmittedFilterAsync`; no static mutable state beyond the immutable `FixedNow`.
+- **Determinism:** Fixed injected clock through the existing `() => FixedNow` constructor seam; no wall clock, sleeps, timers, network, filesystem, or temporary files. (See the Minor finding for the theoretical host-culture caveat, inapplicable to this repo's en-US environments.)
+- **AAA structure and docs:** Explicit Arrange/Act/Assert comments in both tests; XML docs on the class, tests, and all three helpers, including the window-arithmetic explanation for the DataRow offsets (37-day window).
+- **Fail-fast evaluator:** `EvaluateClause` throws on unsupported fields/operators instead of returning a default — a malformed future filter cannot silently pass the membership test.
+- **Convention match:** Mirrors the `OutlookScannerCalendarUtcTests` pattern (fixed clock seam, `FakeComActiveObject`, default-folder wiring, `FakeOutlookItems.LastFilter` capture) as the plan required; MSTest + FluentAssertions per repo convention.
+
+---
+
+## Security / Correctness Checks
+
+- **Filter-string injection:** Inputs to `BuildCalendarFilter` are `DateTimeOffset` values computed internally from settings; no user-controlled text enters the Restrict string. Unchanged risk posture.
+- **Behavioral compatibility:** The corrected predicate's result set is a strict superset of the old one (every event with `Start` in the window also satisfies overlap), so no previously included event is lost — matching the spec's backward-compatibility claim; the full pre-existing suite passing unchanged corroborates it.
+- **No secrets, no new dependencies, no configuration changes** in the diff.
+- **Banned APIs:** No `DateTime.Now`/`UtcNow`, `Random.Shared`, `Thread.Sleep`, or `Task.Delay` introduced.
+- **Architecture:** COM interop remains confined to `OpenClaw.MailBridge`; NetArchTest suite passes (2/2, reviewer run).
+
+---
+
+## Research Log
+
+- Read the full production diff and the complete new test file; confirmed the production change is exactly the one-line expression-body replacement.
+- Read `OutlookScanner.cs` around the `Restrict` call to confirm `Sort("[Start]")` and `IncludeRecurrences = true` ordering is unchanged.
+- Confirmed `FakeOutlookItems.LastFilter` capture exists in `MailBridgeRuntimeTestDoubles.cs` (lines 74-80) and is the established capture point used by prior calendar tests.
+- Re-measured per-file coverage from fresh cobertura at head: `OutlookScanner.Helpers.cs` 100% line / 100% branch; changed line 49 hits 56 (per-file re-measurement done deliberately rather than trusting project aggregates).
+- Verified `mailbridge.runsettings` excludes test assemblies (`[*.Tests]*`) from coverage measurement per policy, and that no production path is excluded.
+- Confirmed no suppression attributes, pragmas, or `.editorconfig`/props changes anywhere in the diff, and no workflow/benchmark paths (rule `modified-workflow-needs-green-run` not triggered).
+
+---
+
+## Verdict
+
+**Go.** No Blocking or Major findings. One Minor pre-existing observation (culture-dependent Restrict formatting, recommended as a follow-up issue) and two no-action Informational notes. The fix is the smallest correct change, the regression tests discriminate the defect precisely, and all toolchain results were independently re-verified at branch head.

--- a/docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-build.2026-07-02T07-54.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-build.2026-07-02T07-54.md
@@ -1,0 +1,6 @@
+# Baseline — Build (Analyzers + Nullable)
+
+Timestamp: 2026-07-02T07-54
+Command: dotnet build OpenClaw.MailBridge.sln
+EXIT_CODE: 0
+Output Summary: Build succeeded — 0 Warning(s), 0 Error(s). All 9 projects built (Contracts, HostAdapter.Contracts, MailBridge.Client, HostAdapter, MailBridge, Core, HostAdapter.Tests, MailBridge.Tests, Core.Tests).

--- a/docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-csharpier-check.2026-07-02T07-54.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-csharpier-check.2026-07-02T07-54.md
@@ -1,0 +1,6 @@
+# Baseline — CSharpier Check
+
+Timestamp: 2026-07-02T07-54
+Command: csharpier check .
+EXIT_CODE: 0
+Output Summary: Checked 194 files in 384ms. No formatting violations on the clean baseline.

--- a/docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-git.2026-07-02T07-54.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-git.2026-07-02T07-54.md
@@ -1,0 +1,6 @@
+# Baseline — Git State
+
+Timestamp: 2026-07-02T07-54
+Command: git rev-parse --abbrev-ref HEAD && git rev-parse HEAD
+EXIT_CODE: 0
+Output Summary: Branch `bug/calendar-overlap-filter-19`; baseline HEAD commit `1bc4148867bd757b724af503b59a3a19bc6f37b4` (working tree clean at capture). This commit is the reference for the [P4-T6] scope diff.

--- a/docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-test-coverage.2026-07-02T07-55.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-test-coverage.2026-07-02T07-55.md
@@ -1,0 +1,11 @@
+# Baseline — Test Run with Coverage
+
+Timestamp: 2026-07-02T07-55
+Command: dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"
+EXIT_CODE: 0
+Output Summary:
+- Test results: 590 passed, 0 failed, 5 skipped (OpenClaw.HostAdapter.Tests 100/100 passed; OpenClaw.Core.Tests 213/213 passed; OpenClaw.MailBridge.Tests 277 passed, 5 skipped of 282).
+- Solution-wide (pooled across the three cobertura reports): line coverage 90.26% (4029/4464 lines), branch coverage 79.36% (911/1148 branches).
+- Per-assembly cobertura totals: Core.Tests report line 89.62% / branch 78.44%; MailBridge.Tests report line 93.08% / branch 86.92%; HostAdapter.Tests report line 87.70% / branch 67.19%.
+- OpenClaw.MailBridge package (module) values from the MailBridge cobertura output: line coverage 92.40%, branch coverage 84.61%.
+- Raw cobertura intermediates staged under `artifacts/csharp/baseline/` (core/mailbridge/hostadapter `coverage.cobertura.xml`).

--- a/docs/features/active/calendar-overlap-filter-19/evidence/other/phase0-instructions-read.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/other/phase0-instructions-read.md
@@ -1,0 +1,14 @@
+# Phase 0 — Policy Reading Evidence
+
+Timestamp: 2026-07-02T07-54
+
+Policy Order: policy-compliance-order baseline — (1) CLAUDE.md-loaded standing rules, (2) .claude/rules/general-code-change.md, (3) .claude/rules/general-unit-test.md, (4) language/domain rules in scope (C#): .claude/rules/csharp.md, .claude/rules/architecture-boundaries.md, then supporting rules .claude/rules/quality-tiers.md and .claude/rules/tonality.md.
+
+Files read:
+- CLAUDE.md-loaded standing rules (auto-loaded project instructions, including .claude/rules/benchmark-baselines.md, .claude/rules/ci-workflows.md, .claude/rules/orchestrator-state.md)
+- .claude/rules/general-code-change.md
+- .claude/rules/general-unit-test.md
+- .claude/rules/csharp.md
+- .claude/rules/architecture-boundaries.md
+- .claude/rules/quality-tiers.md
+- .claude/rules/tonality.md

--- a/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-comparison.2026-07-02T08-03.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-comparison.2026-07-02T08-03.md
@@ -1,0 +1,24 @@
+# Final QA — Coverage Comparison ([P4-T5])
+
+Timestamp: 2026-07-02T08-03
+Command: comparison of baseline cobertura data ([P0-T5], `artifacts/csharp/baseline/`) against post-change cobertura data ([P4-T4], `artifacts/csharp/post-fix/`); changed-line check via line-level cobertura entries for `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`
+EXIT_CODE: 0
+Output Summary:
+
+| Metric | Baseline ([P0-T5]) | Post-change ([P4-T4]) | Delta |
+|---|---|---|---|
+| Solution-wide line coverage (pooled) | 90.26% (4029/4464) | 90.26% (4029/4464) | 0.00 |
+| Solution-wide branch coverage (pooled) | 79.36% (911/1148) | 79.36% (911/1148) | 0.00 |
+| OpenClaw.MailBridge package line coverage | 92.40% | 92.40% | 0.00 |
+| OpenClaw.MailBridge package branch coverage | 84.61% | 84.61% | 0.00 |
+
+Changed-line coverage:
+- The only production change is the `BuildCalendarFilter` expression body at `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` line 49.
+- Post-change cobertura (`artifacts/csharp/post-fix/mailbridge.coverage.cobertura.xml`, class `OpenClaw.MailBridge.OutlookScanner`, filename `OpenClaw.MailBridge\OutlookScanner.Helpers.cs`) reports line 49 with 56 hits — covered, exercised by the new regression tests plus existing calendar-scan tests.
+- Changed-line coverage: 100% (1/1 changed production line covered).
+
+Threshold verification:
+- Line coverage >= 85%: PASS (90.26% solution-wide; 92.40% MailBridge package).
+- Branch coverage >= 75%: PASS (79.36% solution-wide; 84.61% MailBridge package).
+- No coverage regression versus baseline: PASS (all values identical to baseline).
+- All changed lines covered: PASS (line 49, 56 hits).

--- a/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-review.2026-07-02T08-24.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-review.2026-07-02T08-24.md
@@ -1,0 +1,15 @@
+# Reviewer Coverage Re-Verification (feature review, issue #19)
+
+Timestamp: 2026-07-02T08-24
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory "docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-review"` (fresh run at branch head `d7fc69a31b441c9a5d98abf693ef6d00916134e1`), followed by direct parse of the three cobertura reports.
+EXIT_CODE: 0
+Output Summary:
+
+- Test results: 596 passed, 0 failed, 5 environment-gated skips (OpenClaw.HostAdapter.Tests 100/100; OpenClaw.Core.Tests 213/213; OpenClaw.MailBridge.Tests 283 passed, 5 skipped of 288). Matches executor evidence exactly.
+- Cobertura reports (this run): `coverage-review/01c10619-838c-4cc4-a201-46b502091bc9/coverage.cobertura.xml` (HostAdapter.Tests), `coverage-review/30650892-27d8-4e4c-9fed-508f25e19219/coverage.cobertura.xml` (MailBridge.Tests), `coverage-review/af72d815-0ea1-40fa-9bc8-82ec55e5fbc8/coverage.cobertura.xml` (Core.Tests).
+- Pooled solution-wide (parsed from report-level totals): line 4029/4464 = 90.26%; branch 911/1148 = 79.36%. Identical to the executor's baseline and post-change values (`evidence/baseline/baseline-test-coverage.2026-07-02T07-55.md`, `evidence/qa-gates/final-test-coverage.2026-07-02T08-02.md`).
+- `OpenClaw.MailBridge` package (MailBridge report): line 2214/2396 = 92.40%; branch 572/676 = 84.62%.
+- Per-changed-file (the only changed production file): `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` — line coverage 100% (all 21 instrumented lines have hits > 0), branch coverage 100% (4/4 conditions covered). The changed line (49, the `BuildCalendarFilter` expression body) reports 56 hits, exercised by the new regression tests plus existing calendar-scan tests.
+- Changed-line coverage: 100% (1/1 changed production line covered). No regression versus baseline (all pooled and package values identical to baseline).
+- Threshold verdicts (uniform per `.claude/rules/quality-tiers.md`): line >= 85% PASS (90.26% pooled; 92.40% MailBridge package; 100% changed file); branch >= 75% PASS (79.36% pooled; 84.62% MailBridge package; 100% changed file); no-regression PASS.
+- Housekeeping: three cobertura directories from an interrupted prior review attempt (08:09, byte-identical coverage values) were removed from this directory to leave a single unambiguous run (08:21).

--- a/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-build.2026-07-02T08-02.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-build.2026-07-02T08-02.md
@@ -1,0 +1,6 @@
+# Final QA — Build (Analyzers + Nullable, Warnings-as-Errors) ([P4-T3])
+
+Timestamp: 2026-07-02T08-02
+Command: dotnet build OpenClaw.MailBridge.sln
+EXIT_CODE: 0
+Output Summary: Build succeeded — 0 Warning(s), 0 Error(s) across all 9 solution projects.

--- a/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-csharpier-check.2026-07-02T08-02.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-csharpier-check.2026-07-02T08-02.md
@@ -1,0 +1,6 @@
+# Final QA — CSharpier Check ([P4-T2])
+
+Timestamp: 2026-07-02T08-02
+Command: csharpier check .
+EXIT_CODE: 0
+Output Summary: Checked 195 files in 388ms. No formatting violations.

--- a/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-csharpier-format.2026-07-02T08-02.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-csharpier-format.2026-07-02T08-02.md
@@ -1,0 +1,6 @@
+# Final QA — CSharpier Format ([P4-T1])
+
+Timestamp: 2026-07-02T08-02
+Command: csharpier format .
+EXIT_CODE: 0
+Output Summary: Processed 195 files in 378ms. No files were reformatted: `git status` after the run shows only the intentional fix (`src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`) and the new test file (`tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs`), both unchanged by the formatter. No phase restart required.

--- a/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-test-coverage.2026-07-02T08-02.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-test-coverage.2026-07-02T08-02.md
@@ -1,0 +1,11 @@
+# Final QA — Test Run with Coverage ([P4-T4])
+
+Timestamp: 2026-07-02T08-02
+Command: dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"
+EXIT_CODE: 0
+Output Summary:
+- Test results: 596 passed, 0 failed, 5 skipped (OpenClaw.HostAdapter.Tests 100/100; OpenClaw.Core.Tests 213/213; OpenClaw.MailBridge.Tests 283 passed, 5 skipped of 288). Architecture-boundary, unit, and integration tests all pass.
+- Solution-wide (pooled across the three cobertura reports): line coverage 90.26% (4029/4464 lines), branch coverage 79.36% (911/1148 branches).
+- Per-assembly cobertura totals: Core.Tests report line 89.62% / branch 78.44%; MailBridge.Tests report line 93.08% / branch 86.92%; HostAdapter.Tests report line 87.70% / branch 67.19%.
+- OpenClaw.MailBridge package (module) values: line coverage 92.40%, branch coverage 84.61%.
+- Raw cobertura intermediates staged under `artifacts/csharp/post-fix/`.

--- a/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/scope-verification.2026-07-02T08-04.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/scope-verification.2026-07-02T08-04.md
@@ -1,0 +1,13 @@
+# Final QA — Scope Verification ([P4-T6])
+
+Timestamp: 2026-07-02T08-04
+Command: git diff --name-only 1bc4148867bd757b724af503b59a3a19bc6f37b4 (baseline commit from [P0-T2]); untracked additions enumerated via git ls-files --others --exclude-standard
+EXIT_CODE: 0
+Output Summary:
+- Only production change (tracked diff): `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` — the `BuildCalendarFilter` expression body, per [P2-T1].
+- Only new/changed test file: `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs` (new, untracked).
+- Remaining paths attributable to this execution are feature docs/evidence under `docs/features/active/calendar-overlap-filter-19/` (plan checklist, spec.md AC-3 annotation, issue.md mirror annotation, and evidence artifacts under `evidence/baseline/`, `evidence/regression-testing/`, `evidence/qa-gates/`, `evidence/other/`). Raw coverage intermediates are staged under `artifacts/csharp/` (gitignored non-evidence intermediates).
+- Out-of-scope paths present in the working tree but NOT produced by this execution:
+  - `.claude/agent-memory/prd-feature/MEMORY.md` (tracked, modified) and `.claude/agent-memory/prd-feature/project_test_framework_discrepancy.md` (untracked) — agent-memory writes from a different agent (`prd-feature`); this executor did not touch them.
+  - `docs/features/active/calendar-overlap-filter-19/user-story.md` (untracked) — pre-existing feature-folder document, not created or modified by this execution (full-bug mode treats user-story.md as optional).
+- Verdict: the change set attributable to this execution matches the plan scope exactly.

--- a/docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/full-suite-after-fix.2026-07-02T08-00.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/full-suite-after-fix.2026-07-02T08-00.md
@@ -1,0 +1,10 @@
+# Regression Evidence — Full Suite After Fix ([P2-T3])
+
+Timestamp: 2026-07-02T08-00
+Command: dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings
+EXIT_CODE: 0
+Output Summary:
+- OpenClaw.HostAdapter.Tests: Passed! Failed: 0, Passed: 100, Total: 100.
+- OpenClaw.Core.Tests: Passed! Failed: 0, Passed: 213, Total: 213.
+- OpenClaw.MailBridge.Tests: Passed! Failed: 0, Passed: 283, Skipped: 5, Total: 288 (baseline 277 passed + the 6 new regression tests).
+- Solution totals: 596 passed, 0 failed, 5 skipped. All pre-existing tests, including `OutlookScannerCalendarUtcTests`, pass unchanged; no existing test file was modified (git diff confirms tests/ changes limited to the new `OutlookScannerCalendarOverlapFilterTests.cs`).

--- a/docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/regression-fail-before.2026-07-02T07-59.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/regression-fail-before.2026-07-02T07-59.md
@@ -1,0 +1,13 @@
+# Regression Evidence — Fail Before Fix ([P1-T3], expect-fail)
+
+Timestamp: 2026-07-02T07-59
+Command: dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~OutlookScannerCalendarOverlapFilterTests"
+EXIT_CODE: 1
+Output Summary:
+- Run against the unfixed predicate (`[Start] >= '<start>' AND [Start] < '<end>'`) at baseline commit 1bc4148867bd757b724af503b59a3a19bc6f37b4.
+- Result: Failed: 3, Passed: 3, Total: 6 (OpenClaw.MailBridge.Tests).
+- Failing tests (as predicted by the plan):
+  1. `ScanCalendarAsync_emits_interval_overlap_restrict_filter` — emitted filter is the start-only predicate, not the interval-overlap string.
+  2. `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` DataRow (-1, 0.5, True, "an in-progress event starting before the window and ending inside it must be included") — old predicate excludes in-progress events.
+  3. `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` DataRow (-1, 38, True, "an event spanning the entire window must be included") — old predicate excludes window-spanning events.
+- Passing rows under the old predicate (expected): fully-within row and both strict-boundary exclusion rows (End == windowStart; Start == windowEnd).

--- a/docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/regression-pass-after.2026-07-02T08-00.md
+++ b/docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/regression-pass-after.2026-07-02T08-00.md
@@ -1,0 +1,14 @@
+# Regression Evidence — Pass After Fix ([P2-T2])
+
+Timestamp: 2026-07-02T08-00
+Command: dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~OutlookScannerCalendarOverlapFilterTests"
+EXIT_CODE: 0
+Output Summary:
+- Result: Passed! Failed: 0, Passed: 6, Skipped: 0, Total: 6 (OpenClaw.MailBridge.Tests).
+- Passing tests:
+  1. `ScanCalendarAsync_emits_interval_overlap_restrict_filter`
+  2. `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` (1, 1.5, True — fully within window)
+  3. `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` (-1, 0.5, True — in-progress event)
+  4. `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` (-1, 38, True — window-spanning event)
+  5. `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` (-1, 0, False — End == windowStart excluded)
+  6. `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` (37, 38, False — Start == windowEnd excluded)

--- a/docs/features/active/calendar-overlap-filter-19/feature-audit.2026-07-02T08-24.md
+++ b/docs/features/active/calendar-overlap-filter-19/feature-audit.2026-07-02T08-24.md
@@ -1,0 +1,59 @@
+# Feature Audit: calendar-overlap-filter (#19)
+
+**Audit Date:** 2026-07-02
+**Auditor:** feature-review agent
+**Work Mode:** `full-bug` (persisted marker `- Work Mode: full-bug` in `issue.md`)
+
+---
+
+## Scope and Baseline
+
+- **Feature branch:** `bug/calendar-overlap-filter-19` @ head `d7fc69a31b441c9a5d98abf693ef6d00916134e1`
+- **Resolved base branch:** `main` (supplied by caller; consistent with `pr_context.summary.txt` "Base ref (resolved): origin/main")
+- **Merge-base SHA:** `1bc4148867bd757b724af503b59a3a19bc6f37b4`
+- **Diff range:** `1bc4148867bd757b724af503b59a3a19bc6f37b4..d7fc69a31b441c9a5d98abf693ef6d00916134e1`
+- **PR-context artifacts:** `artifacts/pr_context.summary.txt` and `artifacts/pr_context.appendix.txt`, refreshed at head `d7fc69a` (matches current HEAD; not stale).
+- **Changed surface:** 1 modified production C# file (one-line predicate fix), 1 new C# test file, 20 Markdown files (feature docs/evidence, agent memory). Working tree clean at review time.
+- **AC source (per `full-bug` work mode):** `spec.md` `## Acceptance Criteria` only. A 5-item mirror in `issue.md` is noted for consistency (it condenses spec AC-4/AC-5 and AC-6/AC-7 pairs); `spec.md` is authoritative. `user-story.md` carries no trackable AC by its own declaration.
+
+## Acceptance Criteria Inventory
+
+From `docs/features/active/calendar-overlap-filter-19/spec.md` `## Acceptance Criteria` (7 checkbox items, all currently marked `[x]` by the executor):
+
+- **AC-1:** The calendar filter/selection includes: (a) events starting within the window, (b) events starting before the window but ending inside it, and (c) events spanning the entire window.
+- **AC-2:** The calendar filter/selection excludes events ending at-or-before windowStart and events starting at-or-after windowEnd (boundary semantics explicit: `End == windowStart` excluded, `Start == windowEnd` excluded).
+- **AC-3:** A regression test in `tests/OpenClaw.MailBridge.Tests/` fails before the fix and passes after it, exercising the pure filter-string builder and/or a post-filter predicate, with no live Outlook COM dependency (file path and test names recorded). Recorded in the spec: `OutlookScannerCalendarOverlapFilterTests.cs`; tests `ScanCalendarAsync_emits_interval_overlap_restrict_filter` and `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` (5 DataRow boundary cases).
+- **AC-4:** Date formatting (`MM/dd/yyyy hh:mm tt`, `LocalDateTime` conversion) and the timezone handling established by the #55 fix are unchanged; all existing tests pass unchanged.
+- **AC-5:** No behavior change outside `BuildCalendarFilter` (and, only if required, a documented post-filter pass in the calendar scan path).
+- **AC-6:** Full C# toolchain passes in a single clean pass: CSharpier check -> `dotnet build` (analyzers, nullable, warnings-as-errors) -> architecture tests -> `dotnet test` with coverage.
+- **AC-7:** Line coverage >= 85% and branch coverage >= 75% hold, with all changed lines covered; coverage baseline/post/comparison evidence stored under `docs/features/active/calendar-overlap-filter-19/evidence/coverage/`.
+
+## Acceptance Criteria Evaluation
+
+| AC | Verdict | Evidence |
+|----|---------|----------|
+| AC-1 | PASS | The fixed predicate `[Start] < '<windowEnd>' AND [End] > '<windowStart>'` (diff, `OutlookScanner.Helpers.cs` line 49) admits all three inclusion cases. Verified behaviorally by DataRows (1, 1.5, True), (-1, 0.5, True), (-1, 38, True) evaluated against the actually emitted filter, all passing at head (reviewer run). Fail-before evidence shows the in-progress and window-spanning rows fail under the old predicate — proving the criterion is delivered by this change, not pre-existing. |
+| AC-2 | PASS | Strict `<`/`>` operators in the emitted filter; DataRows (-1, 0, False) (`End == windowStart`) and (37, 38, False) (`Start == windowEnd`) both pass at head, and both also passed pre-fix (fail-before artifact), confirming exclusion semantics were preserved rather than loosened. |
+| AC-3 | PASS | New file `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs` exercises the filter through `ScanCalendarAsync` with fake COM doubles only (`FakeComActiveObject`; no live Outlook). Fail-before: `evidence/regression-testing/regression-fail-before.2026-07-02T07-59.md`, EXIT_CODE 1, 3 named failing tests. Pass-after: `evidence/regression-testing/regression-pass-after.2026-07-02T08-00.md`, EXIT_CODE 0, 6/6. File path and test names are recorded in spec AC-3 and mirrored in issue.md (plan P3-T1/P3-T2). |
+| AC-4 | PASS | Diff preserves `LocalDateTime` conversion and the `MM/dd/yyyy hh:mm tt` format verbatim; the #55 normalization path (`OutlookComHelpers`) is untouched by the diff. The exact-string regression test pins the format. Full suite after fix: 596 passed / 0 failed / 5 pre-existing skips with no existing test file modified (`full-suite-after-fix.2026-07-02T08-00.md`; independently reproduced by the reviewer at head, including `OutlookScannerCalendarUtcTests`). |
+| AC-5 | PASS | The production diff is exactly one expression body in `BuildCalendarFilter` (+1/-1); no post-filter pass was needed or added. `ScanCalendarAsync` (`Sort`, `IncludeRecurrences`, `Restrict` ordering) unchanged, verified by direct diff and file read. Scope-verification artifact (`scope-verification.2026-07-02T08-04.md`) enumerates the full change set and matches the authoritative `git diff --stat` (22 files: 2 C#, 20 Markdown). |
+| AC-6 | PASS | Executor Phase 4 single-pass loop artifacts: `final-csharpier-format` / `final-csharpier-check` (EXIT 0, no files reformatted), `final-build` (0W/0E), `final-test-coverage` (596 passed, architecture tests included in the solution run) — all at 2026-07-02T08-02. Reviewer independently re-ran the full chain at head `d7fc69a` in one clean pass: `csharpier check .` EXIT 0 (195 files); `dotnet build` 0W/0E; NetArchTest subset 2/2; full `dotnet test` with coverage 596/0/5. |
+| AC-7 | PASS | Thresholds (reviewer re-measured from fresh cobertura): pooled 90.26% line >= 85%, 79.36% branch >= 75%; `OpenClaw.MailBridge` package 92.40%/84.62%; changed file `OutlookScanner.Helpers.cs` 100% line / 100% branch; the single changed line (49) covered with 56 hits; zero regression versus baseline (values identical). Evidence: baseline `evidence/baseline/baseline-test-coverage.2026-07-02T07-55.md`, post `evidence/qa-gates/final-test-coverage.2026-07-02T08-02.md`, comparison `evidence/qa-gates/coverage-comparison.2026-07-02T08-03.md`, reviewer `evidence/qa-gates/coverage-review.2026-07-02T08-24.md`. Path note: the AC text names `evidence/coverage/`, which is not a canonical evidence kind in this repo; the plan's "Evidence Locations" section documents the mapping of coverage evidence to the canonical `evidence/baseline/` and `evidence/qa-gates/` kinds. The substantive requirement — thresholds met with recorded baseline/post/comparison evidence at canonical locations — is fully satisfied; the documented path mapping does not reduce the verdict. |
+
+## Summary
+
+All 7 acceptance criteria from the authoritative `spec.md` source evaluate to **PASS** with direct diff, test, and coverage evidence, each independently re-verified by the reviewer at branch head rather than accepted solely from executor evidence. The fix is a one-line predicate correction with a discriminating fail-before/pass-after regression suite; scope discipline is exact (no changes to `BuildInboxFilter`, timezone handling, `FreeBusyProjection`, or any named non-goal). The policy audit (`policy-audit.2026-07-02T08-24.md`) found no Blocking or material PARTIAL findings, and the code review (`code-review.2026-07-02T08-24.md`) recorded one Minor pre-existing observation (culture-dependent Restrict formatting, follow-up recommended) and two no-action Informational notes. Remediation is not required.
+
+**Go/no-go recommendation: Go — ready for PR to `main`.**
+
+## Acceptance Criteria Check-off
+
+- Source file: `docs/features/active/calendar-overlap-filter-19/spec.md` (authoritative for `full-bug`); a condensed 5-item mirror exists in `issue.md`; `user-story.md` defers to spec.md by design.
+- All 7 AC checkboxes were already marked `[x]` by the executor (issue.md mirror: all 5 marked `[x]`). The reviewer verified each criterion independently and confirms every `[x]` is justified; no check-off edits were needed and none were made. No criteria remain unchecked; no phantom criteria were added.
+
+### Acceptance Criteria Status
+- Source: docs/features/active/calendar-overlap-filter-19/spec.md
+- Total AC items: 7
+- Checked off (delivered): 7
+- Remaining (unchecked): 0
+- Items remaining: none

--- a/docs/features/active/calendar-overlap-filter-19/issue.md
+++ b/docs/features/active/calendar-overlap-filter-19/issue.md
@@ -1,0 +1,52 @@
+# Bug: fix-calendar-overlap-filter (Issue #19)
+
+- Issue: #19
+- Type: bug
+- Work Mode: full-bug
+- Issue URL: https://github.com/drmoisan/open-claw-bridge/issues/19
+- Date captured: 2026-07-02
+- Author: drmoisan
+- Status: Active — docs/features/active/calendar-overlap-filter-19/
+
+## Summary
+
+`OutlookScanner.BuildCalendarFilter` (`src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`, lines 48-49) builds the Outlook `Items.Restrict` filter using a start-time-only predicate:
+
+```csharp
+private string BuildCalendarFilter(DateTimeOffset startUtc, DateTimeOffset endUtc) =>
+    $"[Start] >= '{startUtc.LocalDateTime:MM/dd/yyyy hh:mm tt}' AND [Start] < '{endUtc.LocalDateTime:MM/dd/yyyy hh:mm tt}'";
+```
+
+Only events whose `Start` falls inside the query window are selected. An event that begins before the window but is still in progress during it — its `End` falls inside `[windowStart, windowEnd)`, or it spans the entire window — is excluded from the calendar scan.
+
+The defect was identified in orchestrator research (`docs/research/2026-07-01-open-claw-vision-gap-analysis.md`, gap table entry "Calendar overlap-window correctness (issue #19)") and confirmed by feature review on 2026-07-02.
+
+## Impact
+
+The calendar cache populated by `OutlookScanner.ScanCalendarAsync` misses in-progress and window-spanning events. Downstream, `FreeBusyProjection` (`src/OpenClaw.HostAdapter/FreeBusyProjection.cs`) and the deterministic scheduler compute availability from that cache, so occupied time can be reported as free. This is a correctness defect against the master-document requirement that availability derives from actual calendar contents (`docs/open-claw-approach.master.md` section 10.4, Deterministic Availability Algorithm).
+
+## Root Cause
+
+The Restrict predicate tests only `[Start]`. The correct membership test for "event overlaps window" is the interval-overlap predicate: an event is in the window when `Start < windowEnd AND End > windowStart`.
+
+## Relationship to Issue #55
+
+Issue #55 (archived at `docs/features/archive/2026-04-25-calendar-windows-wrong-55/`) fixed a UTC double-shift in `OutlookComHelpers` when normalizing `StartUTC`/`EndUTC` values read from COM. This bug is distinct: it concerns the window-membership predicate in the Restrict filter string, not timezone conversion. The date formatting established by the current helper (`'{value.LocalDateTime:MM/dd/yyyy hh:mm tt}'`) and the #55 normalization behavior must be preserved.
+
+## Expected Fix Shape (suggested; planner decides final)
+
+Change the restriction to the overlap predicate `[Start] < windowEnd AND [End] > windowStart`, preserving the existing local-time date formatting. The filter is passed to Outlook `Items.Restrict` with `IncludeRecurrences = true` (`src/OpenClaw.MailBridge/OutlookScanner.cs`, around lines 278-284). If a pure Restrict-string change is insufficient for edge cases (for example, recurring occurrences), a documented post-filter pass over materialized occurrences is acceptable, but the minimal Restrict-string change is preferred.
+
+## Acceptance Criteria
+
+Authoritative acceptance criteria for this `full-bug` feature live in `spec.md` (per the acceptance-criteria tracking protocol). The criteria below mirror them for issue-level visibility.
+
+- [x] The calendar filter/selection includes events starting within the window, events starting before the window but ending inside it, and events spanning the entire window.
+- [x] The calendar filter/selection still excludes events ending at-or-before windowStart and events starting at-or-after windowEnd (boundary semantics: `End == windowStart` excluded, `Start == windowEnd` excluded).
+- [x] A regression test in `tests/OpenClaw.MailBridge.Tests/` fails before the fix and passes after, without any live Outlook COM dependency. Recorded: file `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs`; tests `ScanCalendarAsync_emits_interval_overlap_restrict_filter` and `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` (5 DataRow boundary cases).
+- [x] Date formatting and timezone handling established by the #55 fix are unchanged; existing tests pass unchanged.
+- [x] Full C# toolchain passes (CSharpier → analyzers/nullable build → architecture → tests); line coverage >= 85% and branch coverage >= 75% hold, with changed lines covered.
+
+## Severity
+
+High — availability computed from the cached calendar window can mark occupied time as free whenever an in-progress or window-spanning event exists, producing incorrect scheduling recommendations.

--- a/docs/features/active/calendar-overlap-filter-19/plan.2026-07-02T07-41.md
+++ b/docs/features/active/calendar-overlap-filter-19/plan.2026-07-02T07-41.md
@@ -1,0 +1,93 @@
+# calendar-overlap-filter (Plan)
+
+- **Issue:** #19
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-07-02T07-41
+- **Status:** Draft
+- **Version:** 1.0
+- **Work Mode:** full-bug (per `issue.md` metadata; `spec.md` is the authoritative acceptance-criteria source)
+
+**Fail-closed evidence rule:** Include explicit baseline artifact tasks, final-QA artifact tasks, and coverage-comparison tasks for each in-scope language when policy requires coverage. If any required baseline artifact, QA artifact, or coverage-comparison artifact is missing, the audit verdict must be BLOCKED or INCOMPLETE, never PASS.
+
+**Evidence accounting rule:** Record the expected artifact path or location in each evidence-producing task. Do not mark evidence-backed work complete without the artifact.
+
+## Scope
+
+- Bug: `OutlookScanner.BuildCalendarFilter` (`src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`, lines 48–49) restricts the calendar scan with a start-only predicate `[Start] >= '<start>' AND [Start] < '<end>'`, excluding in-progress and window-spanning events.
+- Fix: minimal Restrict-string change to the interval-overlap predicate `[Start] < '<windowEnd>' AND [End] > '<windowStart>'`, preserving the existing `'{value.LocalDateTime:MM/dd/yyyy hh:mm tt}'` formatting exactly.
+- Only in-scope language: C#. Only production file changed: `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`. New tests only under `tests/OpenClaw.MailBridge.Tests/`. No opportunistic refactors. No live Outlook COM in tests. No temporary files in tests. MSTest + FluentAssertions (existing test-project conventions). 500-line file cap applies.
+- Consumer context (unchanged): `src/OpenClaw.MailBridge/OutlookScanner.cs` `ScanCalendarFolderAsync` (lines ~278–284) keeps `Sort("[Start]")`, `IncludeRecurrences = true`, then `Restrict(filter)`.
+
+## Evidence Locations (canonical, non-overridable)
+
+All evidence artifacts are written under `docs/features/active/calendar-overlap-filter-19/evidence/<kind>/` per `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`:
+
+- Baseline: `docs/features/active/calendar-overlap-filter-19/evidence/baseline/`
+- Regression testing (fail-before / pass-after): `docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/`
+- Final QA gates and coverage comparison: `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/`
+- Policy-read evidence: `docs/features/active/calendar-overlap-filter-19/evidence/other/`
+
+Note on spec AC-7 path: `spec.md` names `evidence/coverage/` for coverage artifacts. `coverage` is not a canonical evidence kind; this plan maps coverage evidence to the canonical kinds instead — baseline coverage under `evidence/baseline/`, post-change coverage and the comparison under `evidence/qa-gates/`. This mapping satisfies AC-7's evidence requirement at canonical locations. Raw coverage intermediates (cobertura XML, TestResults folders) may be staged under `artifacts/csharp/` (non-evidence intermediates only); the auditable numeric evidence lives in the canonical artifacts above.
+
+Every command-step evidence artifact MUST include: `Timestamp:` (ISO-8601 `yyyy-MM-ddTHH-mm`), `Command:`, `EXIT_CODE:`, `Output Summary:`. Coverage-bearing test artifacts MUST include numeric line and branch coverage in `Output Summary:`. `<timestamp>` in filenames below is the ISO-8601 run timestamp.
+
+## Toolchain Commands (C#)
+
+- Format: `csharpier format .` (write) / `csharpier check .` (verify) — CSharpier is a global tool (1.3.0); this repo has no local tool manifest, so do NOT use `dotnet csharpier`.
+- Lint + type check: `dotnet build OpenClaw.MailBridge.sln` (analyzers, nullable, warnings-as-errors via `Directory.Build.props`).
+- Architecture + unit + integration tests with coverage: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"` (architecture-boundary tests run inside the solution test suite, e.g. `tests/OpenClaw.Core.Tests/Agent/AgentArchitectureBoundaryTests.cs`).
+
+### Phase 0 — Policy Reading and Baseline Capture
+
+- [x] [P0-T1] Read policy documents in the `policy-compliance-order` sequence: `CLAUDE.md`-loaded rules, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/csharp.md`, `.claude/rules/architecture-boundaries.md`, `.claude/rules/quality-tiers.md`, `.claude/rules/tonality.md`. Write `docs/features/active/calendar-overlap-filter-19/evidence/other/phase0-instructions-read.md` containing `Timestamp:`, `Policy Order:`, and the explicit list of files read. Acceptance: artifact exists with all three fields.
+- [x] [P0-T2] Record the branch name and HEAD commit hash (`git rev-parse --abbrev-ref HEAD`, `git rev-parse HEAD`) in `docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-git.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: artifact exists and names the exact baseline commit used later by [P4-T6].
+- [x] [P0-T3] Run `csharpier check .` from repo root and record `docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-csharpier-check.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`. Acceptance: artifact exists; expected `EXIT_CODE: 0` on the clean baseline.
+- [x] [P0-T4] Run `dotnet build OpenClaw.MailBridge.sln` and record `docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-build.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (error/warning counts). Acceptance: artifact exists; expected `EXIT_CODE: 0`.
+- [x] [P0-T5] Run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"` and record `docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-test-coverage.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, and an `Output Summary:` containing pass/fail test counts plus numeric baseline line coverage percent and branch coverage percent (solution-wide, and the `OpenClaw.MailBridge` module values from the cobertura output). Raw cobertura/TestResults intermediates may be copied under `artifacts/csharp/baseline/`. Acceptance: artifact exists with numeric line and branch coverage values (no placeholders).
+
+### Phase 1 — Regression Test (must fail before fix)
+
+- [x] [P1-T1] Create `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs` (MSTest `[TestClass]` + FluentAssertions, fixed clock `FixedNow` injected via the `() => FixedNow` constructor seam, `FakeComActiveObject`/`FakeOutlookApplication`/`FakeOutlookFolder`/`FakeScanStateRepository` doubles — same pattern as `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarUtcTests.cs`) containing one test `ScanCalendarAsync_emits_interval_overlap_restrict_filter` that runs `ScanCalendarAsync` and asserts `calendar.Items.LastFilter` (captured by `FakeOutlookItems.Restrict` in `tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs`) equals exactly `[Start] < '<endLocal>' AND [End] > '<startLocal>'`, where `<endLocal>` = `(FixedNow.AddDays(CalendarFutureDays)).LocalDateTime` and `<startLocal>` = `(FixedNow.AddDays(-CalendarPastDays)).LocalDateTime`, both formatted `MM/dd/yyyy hh:mm tt` with `CultureInfo.InvariantCulture` (preserving the #55-era formatting expectation). No live Outlook COM; no temp files. Acceptance: file exists, compiles, and contains this test; file <= 500 lines.
+- [x] [P1-T2] In the same test file, add a small private static filter evaluator (parse `LastFilter` into its two clauses — field name `[Start]`/`[End]`, operator `<`/`>`/`>=`/`<=`, boundary parsed via `DateTime.ParseExact("MM/dd/yyyy hh:mm tt", CultureInfo.InvariantCulture)` — and evaluate event membership) plus a `[DataTestMethod]` `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` with exactly five `[DataRow]` cases evaluated against the emitted filter: (a) event fully within the window — included; (b) in-progress event, `Start` before windowStart and `End` inside the window — included; (c) event spanning the entire window — included; (d) event with `End == windowStart` — excluded; (e) event with `Start == windowEnd` — excluded. Acceptance: all five boundary cases are asserted explicitly; file still <= 500 lines.
+- [x] [P1-T3] [expect-fail] Run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~OutlookScannerCalendarOverlapFilterTests"` against the unfixed predicate and record `docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/regression-fail-before.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:` (non-zero expected), and an `Output Summary:` naming the failing tests (the exact-filter-string test and the in-progress/spanning data rows must fail; the exclusion rows and fully-within row may pass under the old predicate). Acceptance: artifact exists showing a non-zero exit code and named failing tests before the fix.
+
+### Phase 2 — Minimal Fix
+
+- [x] [P2-T1] Edit `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` `BuildCalendarFilter` expression body (lines 48–49) to emit the interval-overlap predicate: `$"[Start] < '{endUtc.LocalDateTime:MM/dd/yyyy hh:mm tt}' AND [End] > '{startUtc.LocalDateTime:MM/dd/yyyy hh:mm tt}'"`. Preserve the method signature, `private` visibility, `LocalDateTime` conversion, and the `MM/dd/yyyy hh:mm tt` format exactly; change nothing else in the file (`BuildInboxFilter` and all other members untouched). No changes to `src/OpenClaw.MailBridge/OutlookScanner.cs` (`Sort("[Start]")`, `IncludeRecurrences = true`, and the `Restrict` call remain unchanged). Acceptance: `git diff` for production code touches only the `BuildCalendarFilter` expression body in `OutlookScanner.Helpers.cs`.
+- [x] [P2-T2] Re-run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~OutlookScannerCalendarOverlapFilterTests"` and record `docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/regression-pass-after.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and an `Output Summary:` listing the passing test names. Acceptance: artifact exists; all regression tests pass.
+- [x] [P2-T3] Run the full suite `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings` and record `docs/features/active/calendar-overlap-filter-19/evidence/regression-testing/full-suite-after-fix.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and an `Output Summary:` with pass counts confirming all pre-existing tests (including `OutlookScannerCalendarUtcTests`) pass unchanged. Acceptance: artifact exists; zero failing tests; no existing test file modified.
+
+### Phase 3 — Documentation and Status
+
+- [x] [P3-T1] Update `docs/features/active/calendar-overlap-filter-19/spec.md`: in Acceptance Criteria item 3, record the regression test file path (`tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs`) and the test names added in [P1-T1]/[P1-T2]; bump `Last Updated`. Do not alter the substance of any acceptance criterion. Acceptance: spec.md AC-3 names the file and tests.
+- [x] [P3-T2] Update `docs/features/active/calendar-overlap-filter-19/issue.md`: annotate the mirrored regression-test acceptance bullet with the same test file path and test names, keeping the mirror consistent with spec.md. Acceptance: issue.md mirror references the file and tests.
+
+### Phase 4 — Final QA Loop and Coverage Gates (C#)
+
+Loop rule: if any task in this phase fails or changes files, fix the cause and restart the phase from [P4-T1] until all tasks pass in one clean pass. Every command task below is unconditional; `EXIT_CODE: SKIPPED` is not a valid outcome.
+
+- [x] [P4-T1] Run `csharpier format .` from repo root and record `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-csharpier-format.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (state whether any files were reformatted; if yes, restart the phase after this task completes). Acceptance: artifact exists.
+- [x] [P4-T2] Run `csharpier check .` and record `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-csharpier-check.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE: 0`, `Output Summary:`. Acceptance: artifact exists with exit code 0.
+- [x] [P4-T3] Run `dotnet build OpenClaw.MailBridge.sln` (analyzers + nullable, warnings-as-errors) and record `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-build.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE: 0`, `Output Summary:` (0 errors, 0 warnings). Acceptance: artifact exists with exit code 0.
+- [x] [P4-T4] Run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"` (covers architecture-boundary, unit, and integration tests) and record `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-test-coverage.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and an `Output Summary:` containing pass/fail counts plus numeric post-change line and branch coverage percent (solution-wide and `OpenClaw.MailBridge` module). Raw cobertura/TestResults intermediates may be staged under `artifacts/csharp/post-fix/`. Acceptance: artifact exists with numeric coverage values and zero failing tests.
+- [x] [P4-T5] Produce the coverage comparison artifact `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-comparison.<timestamp>.md` reporting: baseline line/branch coverage (from [P0-T5]), post-change line/branch coverage (from [P4-T4]), and changed-line coverage for `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` (verify from the post-change cobertura data that the modified `BuildCalendarFilter` line(s) are covered by the new tests). Verify and state: line coverage >= 85%, branch coverage >= 75%, no coverage regression versus baseline, all changed lines covered. Acceptance: artifact exists with all numeric values (no placeholders); any threshold miss makes the plan outcome remediation-required, not PASS.
+- [x] [P4-T6] Run `git diff --name-only <baseline-commit-from-P0-T2>` and record `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/scope-verification.<timestamp>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, and an `Output Summary:` confirming the only production change is `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`, the only new/changed test file is `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs`, and remaining paths are feature docs/evidence. Acceptance: artifact exists and the diff list matches this scope exactly.
+
+## Acceptance Criteria Mapping (spec.md is authoritative, full-bug mode)
+
+| Spec AC | Criterion (abbreviated) | Plan tasks |
+|---|---|---|
+| AC-1 | Includes events starting within, starting-before-ending-inside, and spanning the window | P1-T1, P1-T2 (rows a–c), P2-T1, P2-T2 |
+| AC-2 | Excludes `End == windowStart` and `Start == windowEnd` (strict boundary semantics) | P1-T2 (rows d–e), P2-T1, P2-T2 |
+| AC-3 | Regression test fails before / passes after, no live COM, file+test names recorded | P1-T1, P1-T2, P1-T3 [expect-fail], P2-T2, P3-T1, P3-T2 |
+| AC-4 | `MM/dd/yyyy hh:mm tt` / `LocalDateTime` formatting and #55 timezone handling unchanged; existing tests pass unchanged | P1-T1 (format assertion), P2-T1 (format preserved), P2-T3, P4-T4 |
+| AC-5 | No behavior change outside `BuildCalendarFilter` | P2-T1, P2-T3, P4-T6 |
+| AC-6 | Full C# toolchain passes in a single clean pass | P4-T1 through P4-T4 (single-pass loop rule) |
+| AC-7 | Line >= 85%, branch >= 75%, changed lines covered, baseline/post/comparison evidence | P0-T5, P4-T4, P4-T5 (canonical-location mapping noted above) |
+
+## Assumptions and Decisions
+
+- `BuildCalendarFilter` stays `private`; the regression test asserts the filter string captured by `FakeOutlookItems.LastFilter` through `ScanCalendarAsync`, so no visibility change and no public-API change is needed (spec offered either option; this is the smaller diff).
+- The Restrict-string-only change is sufficient; no post-filter pass over materialized occurrences is planned. If [P2-T2] or [P2-T3] reveals a recurring-occurrence edge case the Restrict string cannot express, stop and report remediation-required — do not extend scope silently.
+- The test project uses MSTest + FluentAssertions (existing convention in `tests/OpenClaw.MailBridge.Tests/`), which takes precedence over the xUnit default named in `.claude/rules/csharp.md` for this existing project.

--- a/docs/features/active/calendar-overlap-filter-19/policy-audit.2026-07-02T08-24.md
+++ b/docs/features/active/calendar-overlap-filter-19/policy-audit.2026-07-02T08-24.md
@@ -1,0 +1,415 @@
+# Policy Compliance Audit: calendar-overlap-filter (#19)
+
+**Audit Date:** 2026-07-02
+**Code Under Test:** C# only. 1 modified production `.cs` file (`src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`, single-line change to the `BuildCalendarFilter` expression body) and 1 new test `.cs` file (`tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs`, 186 lines). Plus feature scoping/evidence Markdown (feature folder for issue #19) and two `prd-feature` agent-memory Markdown files. No Python, PowerShell, TypeScript, Bash, or governed JSON files changed in the branch diff.
+
+**Scope:** Full feature branch `bug/calendar-overlap-filter-19` @ `d7fc69a31b441c9a5d98abf693ef6d00916134e1` versus resolved base `main` @ merge-base `1bc4148867bd757b724af503b59a3a19bc6f37b4`. Scope is feature-vs-base over the complete branch diff. Diff file breakdown (name-only): 2 `.cs`, 20 `.md` (22 files, +645/-1). Work mode: `full-bug` (persisted marker `- Work Mode: full-bug` in `issue.md`); acceptance-criteria source is `spec.md`.
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| C# | 1 production `.cs` + 1 test `.cs` | 601 (solution) / 288 (MailBridge.Tests) | 596 pass, 0 fail, 5 env-gated skips | 90.26% line, 79.36% branch (pooled solution) | 90.26% line, 79.36% branch (pooled solution) | OutlookScanner.Helpers.cs 100% line / 100% branch; changed line 49 covered (56 hits) |
+
+**Note:** Python, PowerShell, Bash, TypeScript, and governed-JSON rows are omitted because the branch diff contains no changed files in those languages. Coverage verdicts are therefore C#-only; no other language has changed files on the branch. The C# coverage verdict is an explicit PASS.
+
+### Coverage Evidence Checklist
+
+- C# baseline coverage artifact: `docs/features/active/calendar-overlap-filter-19/evidence/baseline/baseline-test-coverage.2026-07-02T07-55.md` (pooled 90.26% line / 79.36% branch; `OpenClaw.MailBridge` package 92.40% line / 84.61% branch)
+- C# post-change coverage artifact: `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/final-test-coverage.2026-07-02T08-02.md` (pooled 90.26% line / 79.36% branch; `OpenClaw.MailBridge` package 92.40% line / 84.61% branch)
+- Reviewer-regenerated cobertura (this audit, fresh `dotnet test` at branch head): `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-review/{01c10619...,30650892...,af72d815...}/coverage.cobertura.xml`; independently parsed pooled 90.26% line (4029/4464) / 79.36% branch (911/1148), identical to executor evidence. Reviewer evidence: `docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-review.2026-07-02T08-24.md`
+- Per-language comparison summary: Section 1.2.1 below
+- TypeScript baseline coverage artifact: `N/A - out of scope`
+- TypeScript post-change coverage artifact: `N/A - out of scope`
+- PowerShell baseline coverage artifact: `N/A - out of scope`
+- PowerShell post-change coverage artifact: `N/A - out of scope`
+- Python / TypeScript / PowerShell coverage artifacts: `N/A - no changed files in those languages on the branch`
+
+**Non-negotiable verdict rule:** This audit includes numeric baseline and post-change coverage metrics for the only in-scope language (C#), plus per-changed-file coverage re-measured by the reviewer from fresh cobertura. The C# coverage gate is met (pooled line 90.26% >= 85%, branch 79.36% >= 75%; the modified file is at 100% line / 100% branch; the single changed line is covered with 56 hits; no regression).
+
+---
+
+## Executive Summary
+
+This bugfix branch closes issue #19: `OutlookScanner.BuildCalendarFilter` restricted the calendar scan with a start-time-only predicate (`[Start] >= windowStart AND [Start] < windowEnd`), silently excluding in-progress and window-spanning events from the cached calendar window and allowing `FreeBusyProjection` to report occupied time as free. The fix is a single-expression change to the interval-overlap predicate `[Start] < '<windowEnd>' AND [End] > '<windowStart>'`, preserving the `LocalDateTime` conversion and `MM/dd/yyyy hh:mm tt` formatting established by the issue #55 fix. A new six-test MSTest regression class asserts the exact emitted Restrict string and evaluates all five interval-boundary scenarios (fully-within, in-progress, window-spanning included; `End == windowStart` and `Start == windowEnd` excluded) against the captured filter.
+
+The mandatory toolchain was independently re-run by the reviewer against the branch head `d7fc69a` and passes in a single pass:
+- **Formatting:** `csharpier check .` (CSharpier 1.3.0) — "Checked 195 files", EXIT 0, no diffs.
+- **Lint + nullable type-check + analyzers:** `dotnet build OpenClaw.MailBridge.sln` — Build succeeded, 0 Warning(s), 0 Error(s) (AnalysisLevel=latest-all, AnalysisMode=All, TreatWarningsAsErrors=true per Directory.Build.props).
+- **Architecture-boundary tests:** NetArchTest suite in `OpenClaw.Core.Tests` — 2 passed, 0 failed.
+- **Tests + coverage:** full solution `dotnet test` with `--collect:"XPlat Code Coverage"` — 596 passed, 0 failed, 5 environment-gated skips (same skips as baseline); pooled coverage 90.26% line / 79.36% branch, above the uniform gates; modified file 100% line / 100% branch.
+- **Regression evidence:** fail-before artifact (EXIT 1; 3 of 6 tests failing exactly as the plan predicted against the unfixed predicate) and pass-after artifact (EXIT 0, 6/6 passing) are present and schema-valid under `evidence/regression-testing/`.
+
+No Blocking findings. No material PARTIAL findings. Remediation is not required. The feature is recommended Go for PR.
+
+**Policy documents evaluated:**
+- `.claude/rules/general-code-change.md`
+- `.claude/rules/general-unit-test.md`
+- `.claude/rules/quality-tiers.md`
+- `.claude/rules/architecture-boundaries.md`
+- `.claude/rules/csharp.md`
+- `.claude/rules/ci-workflows.md` (not triggered — no workflow changes)
+- `.claude/rules/benchmark-baselines.md` (not triggered — no baseline changes)
+- `.claude/rules/tonality.md`
+
+**Language-specific policies evaluated:**
+- C#: `.claude/rules/csharp.md`
+- N/A Python / PowerShell / Bash / TypeScript / governed JSON (no changed files on the branch)
+
+**Temporary artifacts cleanup:**
+- No temporary or throwaway scripts were introduced by this feature; the diff is one production line, one test file, and documentation/evidence Markdown. The reviewer removed three stale duplicate cobertura directories left in `evidence/qa-gates/coverage-review/` by an interrupted prior review attempt (values byte-identical to the fresh run; documented in `coverage-review.2026-07-02T08-24.md`).
+
+---
+
+## Rejected Scope Narrowing
+
+None. The caller prompt instructed execution of the full `feature-review-workflow` contract, supplied the authoritative base branch (`main`), merge-base SHA (`1bc4148`), head SHA (`d7fc69a`), and refreshed PR-context artifacts, and stated "Scope determination is your responsibility per your skill contract." No instruction attempted to narrow scope to a plan/task/phase subset, to a file subset, or to mark any in-scope language as out-of-scope or informational-only.
+
+Observation (not a narrowing instruction, recorded for completeness): the PR-context summary's "Changed files overview" reports "Core logic changes: 0 files" and categorizes the branch as docs/tooling only. That categorization is inaccurate; the authoritative `git diff 1bc4148..d7fc69a` contains 1 production C# file and 1 test C# file. The audit used the authoritative git diff file list, not the summary categorization. No scope was narrowed.
+
+---
+
+## Evidence Location Compliance
+
+The branch diff was scanned for evidence files written under the non-canonical roots `artifacts/baselines/`, `artifacts/baseline/`, `artifacts/qa/`, `artifacts/qa-gates/`, `artifacts/evidence/`, `artifacts/coverage/`, `artifacts/regression-testing/`, or `artifacts/post-change/`.
+
+- Command: `git diff --name-only 1bc4148..HEAD | grep -E '^artifacts/(baselines|baseline|qa|qa-gates|evidence|coverage|regression-testing|post-change)/'`
+- Result: **NONE.** All feature evidence in the diff is written to the canonical `docs/features/active/calendar-overlap-filter-19/evidence/<kind>/` locations (baseline, qa-gates, regression-testing, other). No files under `artifacts/` are tracked in the diff at all.
+- Verdict: **PASS** — no evidence-location violations. No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` events occurred during this review; the reviewer's own evidence was written to the canonical `evidence/qa-gates/` path.
+
+Note: the repository does not contain a `validate_evidence_locations.py` script (consistent with the prior #70 and #80 audits); the scan was performed by direct diff inspection. The executor's untracked raw cobertura copies under `artifacts/csharp/baseline/` and `artifacts/csharp/post-fix/` are non-evidence coverage tooling intermediates at a path the feature-review skill itself designates for C# coverage; the canonical feature evidence lives under `evidence/baseline/` and `evidence/qa-gates/`. The spec's AC-7 text names `evidence/coverage/`, which is not a canonical evidence kind; the plan (`plan.2026-07-02T07-41.md`, "Evidence Locations" section) explicitly maps coverage evidence to the canonical kinds (`evidence/baseline/`, `evidence/qa-gates/`) — this is compliant with the evidence-location invariant, and the mapping is documented.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** — Tests run in any order | PASS | Each test builds its own `FakeOutlookFolder`/`FakeComActiveObject`/`FakeScanStateRepository` graph via `CaptureEmittedFilterAsync()`; no shared mutable state between tests. 283/288 MailBridge.Tests pass in a single run (reviewer), 5 pre-existing env-gated skips. |
+| **Isolation** — Each test targets single behavior | PASS | Test 1: exact emitted Restrict string; test 2 (5 DataRows): interval-membership semantics of the emitted filter, one scenario per row. |
+| **Fast Execution** | PASS | `OpenClaw.MailBridge.Tests` completes 288 tests in ~11 s (reviewer run); the 6 new tests are pure in-memory fake-COM interactions. |
+| **Determinism** | PASS | Fixed clock `FixedNow` (2026-04-25T12:00Z) injected via the `() => FixedNow` constructor seam; no wall-clock reads, sleeps, timers, network, or filesystem. See Section 8 for a documented informational note on host-culture sensitivity of the exact-string assertion (pre-existing production formatting pattern, en-US hosts unaffected). |
+| **Readability & Maintainability** | PASS | Descriptive names (`ScanCalendarAsync_emits_interval_overlap_restrict_filter`), explicit Arrange/Act/Assert comments, FluentAssertions `because` messages, XML doc summaries on the class, both tests, and all three private helpers. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | PASS | Baseline pooled: 90.26% line, 79.36% branch; `OpenClaw.MailBridge` package 92.40% line / 84.61% branch. Source: `evidence/baseline/baseline-test-coverage.2026-07-02T07-55.md`. |
+| **No Coverage Regression** | PASS | Post-change pooled: 90.26% line, 79.36% branch (identical to baseline; the fix replaces one covered line with one covered line). Independently confirmed from reviewer cobertura (this audit). |
+| **New Code Coverage** | PASS | Per-changed-file (reviewer cobertura): `OutlookScanner.Helpers.cs` 100% line (21/21 instrumented lines) / 100% branch (4/4 conditions); changed line 49 has 56 hits. The new test file is excluded from coverage measurement per policy (`[*.Tests]*` exclude in `mailbridge.runsettings`). |
+| **Comprehensive Coverage** | PASS | The emitted-filter string, all three inclusion scenarios, and both strict-boundary exclusion scenarios are exercised; existing calendar-scan tests (`OutlookScannerCalendarUtcTests`, `MailBridgeRuntimeTests.Calendar`) continue to exercise the surrounding scan path. |
+| **Positive Flows** | PASS | Exact-string test plus DataRows (a) fully-within, (b) in-progress, (c) window-spanning — all included. |
+| **Negative Flows** | PASS | DataRows (d) `End == windowStart` and (e) `Start == windowEnd` — both excluded; `EvaluateClause` throws `InvalidOperationException` on unsupported fields/operators rather than passing silently. |
+| **Edge Cases** | PASS | The two strict-boundary rows pin the exact `<`/`>` operator semantics; the fail-before artifact proves rows (b) and (c) fail under the old predicate while (a), (d), (e) pass — precisely the defect boundary. |
+| **Error Handling** | PASS | Existing `ScanCalendarAsync` unavailable-items error-path tests pass unchanged (spec Test Strategy requirement); no new error paths were added by the one-line fix. |
+| **Concurrency** | N/A | Pure filter-string construction; no new concurrency surface. |
+| **State Transitions** | N/A | No stateful component changed; the scan-state repository interaction is unchanged. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- C#: Baseline: 90.26% line, 79.36% branch (pooled solution) -> Post-change: 90.26% line, 79.36% branch. Change: +0.00% line, +0.00% branch. New/changed-code coverage: OutlookScanner.Helpers.cs 100% line / 100% branch with changed line 49 covered (56 hits); new test file excluded from measurement per policy. Disposition: PASS (line >= 85%, branch >= 75%, no regression on changed lines). Evidence: `evidence/baseline/baseline-test-coverage.2026-07-02T07-55.md`, `evidence/qa-gates/final-test-coverage.2026-07-02T08-02.md`, `evidence/qa-gates/coverage-comparison.2026-07-02T08-03.md`, reviewer re-run `evidence/qa-gates/coverage-review.2026-07-02T08-24.md`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | PASS | FluentAssertions with `because` clauses on every assertion, including inside the filter-evaluator helpers ("the calendar filter must contain exactly two clauses"); DataRow scenarios carry human-readable descriptions surfaced on failure. |
+| **Arrange-Act-Assert Pattern** | PASS | Both tests carry explicit `// Arrange`, `// Act`, `// Assert` sections. |
+| **Document Intent** | PASS | XML class summary states the issue-#19 regression purpose and the #55 formatting-preservation constraint; each test and helper documents its scenario. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | PASS | No live Outlook COM, network, filesystem, or external process; the fake COM doubles (`MailBridgeRuntimeTestDoubles.cs`) capture the Restrict filter in-memory. |
+| **Use Mocks/Stubs** | PASS | Established repo fakes (`FakeComActiveObject`, `FakeOutlookApplication`, `FakeOutlookFolder`, `FakeOutlookItems.LastFilter`, `FakeScanStateRepository`) — same pattern as `OutlookScannerCalendarUtcTests`. |
+| **Environment Stability** | PASS | No temporary files; no mutable global state; fixed injected clock. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | PASS | This audit serves as the required policy review. No outstanding items. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | PASS | Issue #19, `spec.md` (confirmed root cause with file/line evidence), and the gap-analysis research define the defect and fix precisely. |
+| **Read existing change plans** | PASS | `evidence/other/phase0-instructions-read.md` records the policy-order read; `plan.2026-07-02T07-41.md` present with all tasks checked. |
+| **Document the plan** | PASS | `plan.2026-07-02T07-41.md` with per-phase evidence under `evidence/**`; all 16 tasks checked off with corresponding artifacts. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | PASS | Minimal targeted fix: one expression body changed; no refactors, no new abstractions, no visibility changes (spec offered an `internal` visibility option; the smaller LastFilter-capture approach was chosen). |
+| **Reusability** | PASS | The test reuses the existing fake-COM doubles and the fixed-clock constructor seam instead of duplicating infrastructure. |
+| **Extensibility** | PASS | No API surface change; the filter-builder seam remains a single private method, and the spec documents the sanctioned post-filter escape hatch if recurring-occurrence edge cases ever require it. |
+| **Separation of concerns** | PASS | The pure filter-string builder stays in the Helpers partial; the COM scan orchestration in `OutlookScanner.cs` is untouched (`Sort("[Start]")`, `IncludeRecurrences = true`, `Restrict` ordering unchanged, verified in diff). |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | PASS | Changes confined to one production partial and one new mirrored test file. |
+| **Under 500 lines** | PASS | `wc -l`: OutlookScanner.Helpers.cs 50, new test file 186, OutlookScanner.cs 465 (unchanged). All under the 500-line cap. |
+| **Public vs internal** | PASS | `OutlookScanner` remains `internal sealed partial`; `BuildCalendarFilter` remains `private`; no public API surface change. |
+| **No circular dependencies** | PASS | No project-reference changes; NetArchTest boundary suite passes (2/2, reviewer run). |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | PASS | Test names describe scenario and expectation; DataRow descriptions state the boundary semantics; helper names (`CaptureEmittedFilterAsync`, `EvaluateFilter`, `EvaluateClause`) are literal. |
+| **Docs/docstrings** | PASS | XML docs on the test class, both tests, and all helpers; the Helpers partial's existing file-level summary remains accurate. |
+| **Comment why, not what** | PASS | The class summary explains the issue-#19 overlap requirement and the issue-#55 formatting-preservation constraint — the two "why" anchors of this fix. |
+
+### 2.5 After Making Changes — Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | PASS | Reviewer: `csharpier check .` — Checked 195 files, EXIT 0. Executor: `evidence/qa-gates/final-csharpier-check.2026-07-02T08-02.md` EXIT 0 (plus a format-then-verify pass in `final-csharpier-format.2026-07-02T08-02.md`, no files reformatted). |
+| **2. Linting** | PASS | Reviewer: `dotnet build OpenClaw.MailBridge.sln` — 0 warnings, 0 errors (analyzers as errors). |
+| **3. Type checking** | PASS | Same build; nullable reference analysis runs as errors per Directory.Build.props; clean. |
+| **4. Architecture** | PASS | NetArchTest boundary tests: 2 passed, 0 failed (reviewer run, `--filter FullyQualifiedName~ArchitectureBoundary`). COM interop remains confined to `OpenClaw.MailBridge` per `.claude/rules/architecture-boundaries.md`. |
+| **5. Testing** | PASS | Reviewer: full solution test run — 596 passed, 0 failed, 5 environment-gated skips (identical to baseline skips). |
+| **6. Contract/schema checks** | N/A | No governed API contract, DTO, or schema surface changed; the Restrict string is an internal query detail, and the cached-window contents become a strict superset (spec Backward-compatibility). |
+| **7. Integration tests** | N/A | No adapter/external-system boundary changed; the fake-COM scan-path tests are the appropriate scope, and live-Outlook validation is explicitly optional per spec. |
+| **Full toolchain loop** | PASS | Reviewer re-ran format -> build -> arch -> test+coverage in a single clean pass with no file mutations; executor evidence records the same single-pass Phase 4 loop. |
+| **Explicit reporting** | PASS | Commands and results documented here, in Appendix B, and in `evidence/qa-gates/coverage-review.2026-07-02T08-24.md`. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | PASS | `spec.md` Proposed Fix matches the delivered diff exactly; evidence artifacts summarize each gate; the commit message describes the behavior change. |
+| **Design choices explained** | PASS | Plan "Assumptions and Decisions" records the private-visibility/LastFilter decision and the no-post-filter decision with a stop-and-report rule for recurrence edge cases. |
+| **Update supporting documents** | PASS | spec.md AC-3 and the issue.md mirror were annotated with the delivered test file and test names (plan P3-T1/P3-T2). |
+| **Provide next steps** | PASS | Spec Rollout section: standard PR to `main` (merge commit); optional live confirmation during the next bridge session. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+Only Section 3 C# applies. Python, PowerShell, Bash, TypeScript, and governed-JSON sections are omitted: no changed files in those categories on the branch.
+
+### Section 3-C#: C# Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting — CSharpier** | PASS | `csharpier check .` EXIT 0 (reviewer, CSharpier 1.3.0 global; the repo tool-manifest restore mismatch is a pre-existing environment accommodation also recorded in the #70 and #80 audits). |
+| **Linting — .NET analyzers** | PASS | `dotnet build` clean: 0 warnings / 0 errors with AnalysisLevel=latest-all, AnalysisMode=All, TreatWarningsAsErrors=true. |
+| **Type Checking — Nullable** | PASS | Nullable enabled solution-wide; the test's single `!` operator on `LastFilter` follows a `Should().NotBeNull()` guard. |
+| **Null-safety** | PASS | No new nullable flow in production (one string-interpolation expression); test guards the captured filter before dereference. |
+| **Async / resource safety** | PASS | Test awaits `ScanCalendarAsync` directly; no fire-and-forget, no blocking waits. |
+| **Naming / file-scoped namespaces** | PASS | File-scoped namespace in the new test file; PascalCase/`Async` suffix conventions maintained; underscore-separated scenario test names match the established repo test convention. |
+| **Exceptions fail-fast** | PASS | The test's filter evaluator throws `InvalidOperationException` on unsupported fields/operators instead of silently evaluating; no new catch blocks in production. |
+| **No new suppressions** | PASS | The diff contains no pragma or suppression attributes and no analyzer-suppression additions (verified by reading the full C# diff). |
+
+Note on test framework: `.claude/rules/csharp.md` names xUnit/NSubstitute, but the repository's actual convention is MSTest + FluentAssertions (all existing suites use MSTest; the divergence is recorded in `.claude/agent-memory/prd-feature/project_test_framework_discrepancy.md`, added on this branch). The new test follows the established repo convention, consistent with the prior validated #70 and #80 audits. Pre-existing repo-wide divergence, not a finding against this branch.
+
+Note on banned APIs: no `DateTime.Now`/`DateTime.UtcNow`, `Random.Shared`, `Thread.Sleep`, or `Task.Delay` in the diff; the clock is the injected `() => FixedNow` seam already used by `OutlookScanner` (`_utcNow`), the repo's established pre-`TimeProvider` seam for this class.
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+Only C# tests changed. Python, PowerShell, and TypeScript sections are omitted.
+
+### Section 4-C#: C# Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Framework (repo convention: MSTest + FluentAssertions)** | PASS | `[TestClass]`/`[TestMethod]`/`[DataTestMethod]`+`[DataRow]`; FluentAssertions with `because` messages throughout. |
+| **Test file location** | PASS | `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs` mirrors `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`; no colocation in the production tree. |
+| **Coverage expectation** | PASS | Pooled 90.26% line / 79.36% branch; modified file 100% line / 100% branch; changed line covered with 56 hits. |
+| **Property-based tests (T2 density)** | PASS | `OpenClaw.MailBridge` is T2; the T2 gate is >= 1 property test per new pure function. The change adds no new pure function — it rewrites the body of the existing `BuildCalendarFilter`. The five-DataRow membership test pins the overlap property across the boundary partition; no new property-test obligation is created. |
+| **Mutation testing** | N/A | Mutation gates apply to T1 modules and run in pre-merge/nightly pipelines per policy, not the per-commit loop; `OpenClaw.MailBridge` is T2 (trend-only). |
+| **Determinism (no sleeps, no wall clock)** | PASS | Fixed `FixedNow` via constructor seam; no `Thread.Sleep`/`Task.Delay`/`DateTime.Now`; no timers, no fake-timer facility needed (no time advancement occurs). |
+| **No temporary files** | PASS | Pure in-memory fakes; zero filesystem artifacts. |
+| **Focused / isolated** | PASS | Fresh fake graph per invocation of `CaptureEmittedFilterAsync`; no cross-test state. |
+
+---
+
+## 5. Test Coverage Detail
+
+### OutlookScannerCalendarOverlapFilterTests (6 new tests: 1 exact-string + 5 DataRows)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `ScanCalendarAsync_emits_interval_overlap_restrict_filter` | Positive (exact Restrict string, #55 formatting pinned) | PASS |
+| `..._matches_interval_overlap_semantics` (1, 1.5, True) | Positive (event fully within window included) | PASS |
+| `..._matches_interval_overlap_semantics` (-1, 0.5, True) | Positive (in-progress event included — the defect case) | PASS |
+| `..._matches_interval_overlap_semantics` (-1, 38, True) | Positive (window-spanning event included — the defect case) | PASS |
+| `..._matches_interval_overlap_semantics` (-1, 0, False) | Boundary exclusion (`End == windowStart`) | PASS |
+| `..._matches_interval_overlap_semantics` (37, 38, False) | Boundary exclusion (`Start == windowEnd`) | PASS |
+
+**Coverage:** `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` 100% line (21/21 instrumented) / 100% branch (4/4 conditions); the changed line (49) has 56 hits. **Gap:** none.
+
+**Fail-before / pass-after:** `evidence/regression-testing/regression-fail-before.2026-07-02T07-59.md` (EXIT 1; exactly the 3 tests the plan predicted fail under the old predicate — the exact-string test plus the in-progress and window-spanning rows — while the fully-within and both exclusion rows pass, correctly discriminating the defect) and `evidence/regression-testing/regression-pass-after.2026-07-02T08-00.md` (EXIT 0; 6/6 pass).
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (solution, reviewer run) | 601 (596 passed, 5 env-gated skips) | PASS |
+| OpenClaw.MailBridge.Tests | 283 passed / 288 (baseline 277 passed + 6 new; same 5 skips) | PASS |
+| Tests Failed | 0 | PASS |
+| MailBridge.Tests Execution Time | ~11 s | PASS |
+| Pooled Code Coverage | 90.26% line, 79.36% branch | PASS |
+| `OpenClaw.MailBridge` package coverage | 92.40% line, 84.62% branch | PASS |
+| Net new tests vs baseline | +6 | PASS |
+
+---
+
+## 7. Code Quality Checks
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| CSharpier format | `csharpier check .` (CSharpier 1.3.0, reviewer) | Checked 195 files, EXIT 0 | PASS |
+| .NET analyzers + nullable | `dotnet build OpenClaw.MailBridge.sln` | 0 warnings, 0 errors | PASS |
+| Architecture (NetArchTest) | `dotnet test tests/OpenClaw.Core.Tests/... --filter "FullyQualifiedName~ArchitectureBoundary"` | 2 passed, 0 failed | PASS |
+| MSTest tests + coverage | `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"` | 596 passed, 0 failed, 5 skipped | PASS |
+
+**Notes:** The reviewer re-ran the full toolchain against branch head `d7fc69a` on 2026-07-02. The 5 skips are the same environment-gated COM/publish tests skipped at baseline; none relate to this change.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+**None Blocking.** One informational observation, recorded (not a policy violation on this branch):
+
+- **Host-culture sensitivity of the exact-string assertion (Informational).** Production `BuildCalendarFilter` (and the pre-existing `BuildInboxFilter`) format Restrict boundaries with an interpolated string, which uses the current culture, while the regression test's expected string is rendered with `CultureInfo.InvariantCulture`. On an en-US host (this repo's development and CI environment) the outputs are identical and the test passes deterministically. On a hypothetical non-en-US host, the production filter itself would render culture-dependent separators/designators — a pre-existing latent issue in both builders that predates and is unchanged by this branch, and the spec explicitly required preserving the existing formatting exactly. Recommended follow-up (out of scope here): render Restrict boundaries invariantly in both builders. Detailed in the code review findings table.
+
+### Approved Exceptions
+
+- **CSharpier invocation path:** the repo has no local dotnet-tool manifest that restores cleanly in this environment; the reviewer used the globally installed CSharpier 1.3.0, matching the plan's documented command and the accommodation recorded in the #70 and #80 audits. The format check ran to EXIT 0 over all 195 files.
+- **MCP template/validator tools unavailable:** the MCP tools `resolve_policy_audit_template_asset` and `validate_orchestration_artifacts` are not available in this review environment. The artifact structure was reproduced from the most recent validator-passing artifact set (issue #80 review, 2026-07-02) and the recorded validator requirements (exact headings, Coverage Evidence Checklist literals, single-line Section 1.2.1 comparison). Documented best-effort assumption per the workflow's fail-soft guidance.
+
+### Removed/Skipped Tests
+
+- **None.** The branch adds six tests and removes none; no existing test file was modified; no assertions were weakened.
+
+---
+
+## 9. Summary of Changes
+
+### Commits in This Branch (vs base `1bc4148`)
+
+Branch `bug/calendar-overlap-filter-19`, head `d7fc69a31b441c9a5d98abf693ef6d00916134e1` (single commit: "fix(mailbridge): include in-progress and window-spanning events in calendar scan filter"). Range: `1bc4148867bd757b724af503b59a3a19bc6f37b4..d7fc69a31b441c9a5d98abf693ef6d00916134e1`.
+
+### Files Modified (categories)
+
+1. **`src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`** (MODIFIED, +1/-1) — `BuildCalendarFilter` expression body changed from the start-only predicate to the interval-overlap predicate; `LocalDateTime` conversion and `MM/dd/yyyy hh:mm tt` format preserved; nothing else in the file touched.
+2. **`tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs`** (NEW, 186 lines) — 6 regression tests (exact Restrict string + 5 interval-boundary DataRows) with a small private filter evaluator.
+3. **`docs/features/active/calendar-overlap-filter-19/**`** (NEW, 17 files) — issue/spec/user-story/plan and canonical evidence (baseline, qa-gates, regression-testing, other).
+4. **`.claude/agent-memory/prd-feature/**`** (memory index + one project memory) — agent memory bookkeeping recording the MSTest-vs-xUnit rule divergence; no code or policy content.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: FULLY COMPLIANT
+
+The C# change passes formatting, linting, nullable type-checking, architecture-boundary enforcement, the full unit-test suite, and the uniform coverage gates, all independently re-run by the reviewer at branch head. Fail-before/pass-after regression evidence is present, schema-valid, and discriminates the defect exactly as planned. No evidence-location or file-size violations. No new suppressions. The `modified-workflow-needs-green-run` rule does not fire (verified: no `.github/workflows/**`, `scripts/benchmarks/**`, or `.github/actions/**` paths in the diff). The `benchmark-baselines` and `ci-workflows` rules are not triggered.
+
+**Fail-closed reminder:** All required baseline and post-change coverage metrics are present and independently re-verified; the audit is marked PASS because no required artifact, metric, or gate is missing or failing.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- Before Making Changes: PASS (spec/plan/policy-order evidence present)
+- Design Principles: PASS (single-expression fix, smallest viable diff)
+- Module & File Structure: PASS (all files under 500 lines)
+- Naming, Docs, Comments: PASS
+- Toolchain Execution: PASS (single clean pass, reviewer re-verified)
+- Summarize & Document: PASS
+
+#### Language-Specific Code Change Policy (Section 3) — C#
+- Tooling & Baseline: PASS
+- Design & Type-Safety: PASS
+- Error Handling: PASS (fail-fast evaluator; no new production error paths)
+
+#### General Unit Test Policy (Section 1)
+- Core Principles: PASS
+- Coverage & Scenarios: PASS (90.26%/79.36% pooled; changed file 100%/100%)
+- Test Structure: PASS
+- External Dependencies: PASS (fake COM doubles, no temp files)
+- Policy Audit: PASS
+
+#### Language-Specific Unit Test Policy (Section 4) — C#
+- Framework & Location: PASS (MSTest + FluentAssertions repo convention; tests/ mirror)
+- Determinism: PASS (fixed injected clock, no sleeps)
+- T2 obligations: PASS (no new pure functions; mutation gate is trend-only for T2 and pipeline-stage)
+
+---
+
+### Metrics Summary
+
+- 596/596 runnable solution tests passing (5 pre-existing environment-gated skips)
+- 90.26% pooled line coverage, 79.36% pooled branch coverage (gates: 85%/75%)
+- Changed file: OutlookScanner.Helpers.cs 100% line / 100% branch; changed line 49 covered with 56 hits
+- Build: 0 warnings / 0 errors (analyzers + nullable as errors)
+- Architecture boundary: 2/2 NetArchTest tests pass
+
+---
+
+### Recommendation
+
+**Ready for merge — Go.** All toolchain stages, coverage gates, regression evidence, and policy requirements pass against branch head `d7fc69a`. No remediation inputs are required.
+
+---
+
+## Appendix A: Test Inventory
+
+C# test files added by this feature:
+
+1. `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs` — 6 MSTest regression tests for issue #19:
+   - `ScanCalendarAsync_emits_interval_overlap_restrict_filter` — asserts the exact emitted Restrict string `[Start] < '<windowEndLocal>' AND [End] > '<windowStartLocal>'` with `MM/dd/yyyy hh:mm tt` local-time formatting (issue #55 formatting pinned).
+   - `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` — 5 DataRows evaluating event membership against the emitted filter: fully-within (included), in-progress (included), window-spanning (included), `End == windowStart` (excluded), `Start == windowEnd` (excluded). A private evaluator parses the two filter clauses (field, operator, `ParseExact` boundary) and supports `>=`/`<=` so the same evaluator discriminates the pre-fix predicate in the fail-before run.
+
+No test files were modified or removed. Reviewer run: `OpenClaw.MailBridge.Tests` 283 passed, 0 failed, 5 env-gated skipped; solution total 596 passed, 0 failed, 5 skipped.
+
+---
+
+## Appendix B: Toolchain Commands Reference (C#)
+
+```bash
+# Formatting (reviewer, CSharpier 1.3.0 global — repo tool-manifest accommodation)
+csharpier check .
+
+# Lint + nullable type-check + analyzers (as errors per Directory.Build.props)
+dotnet build OpenClaw.MailBridge.sln
+
+# Tests + coverage (full solution; reviewer results directory is the canonical evidence path)
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory "docs/features/active/calendar-overlap-filter-19/evidence/qa-gates/coverage-review"
+
+# Architecture-boundary tests (subset)
+dotnet test tests/OpenClaw.Core.Tests/OpenClaw.Core.Tests.csproj --no-build --filter "FullyQualifiedName~ArchitectureBoundary"
+
+# Regression subset (fail-before / pass-after evidence)
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~OutlookScannerCalendarOverlapFilterTests"
+
+# Evidence-location scan
+git diff --name-only 1bc4148867bd757b724af503b59a3a19bc6f37b4..HEAD | grep -E '^artifacts/(baselines|baseline|qa|qa-gates|evidence|coverage|regression-testing|post-change)/'
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-07-02
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/calendar-overlap-filter-19/spec.md
+++ b/docs/features/active/calendar-overlap-filter-19/spec.md
@@ -1,0 +1,127 @@
+# calendar-overlap-filter (Spec)
+
+- **Issue:** #19
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-07-02T08-01
+- **Status:** Draft
+- **Version:** 0.2
+
+## Context
+- Summary of the bug and its impact (link to repro/playbook entry): `OutlookScanner.BuildCalendarFilter` (`src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs`, lines 48-49) restricts the calendar scan with a start-time-only predicate (`[Start] >= windowStart AND [Start] < windowEnd`). Events that begin before the query window but are still in progress during it (end inside the window, or spanning the whole window) are excluded from the scan. The cached calendar window therefore misses in-progress events, and `FreeBusyProjection` (`src/OpenClaw.HostAdapter/FreeBusyProjection.cs`) plus the deterministic scheduler can treat occupied time as free. Evidence: `docs/research/2026-07-01-open-claw-vision-gap-analysis.md` (gap table entry for issue #19), confirmed by feature review 2026-07-02. See `issue.md` in this folder.
+- Observed environment(s): Any environment running the MailBridge calendar scan (`OutlookScanner.ScanCalendarAsync`); the defect is in pure filter-string construction and is environment-independent.
+- Customer impact and severity (who is affected, how often, how bad): High. Any free/busy query over a window that overlaps an in-progress or window-spanning event returns incorrect availability, so the scheduling agent can propose times that conflict with existing meetings. Violates the master-document requirement that availability derives from actual calendar contents (`docs/open-claw-approach.master.md` section 10.4, Deterministic Availability Algorithm).
+- First observed date and version(s) impacted: Identified 2026-07-01 (gap-analysis research); confirmed 2026-07-02. Present since `BuildCalendarFilter` was introduced; all current versions impacted.
+
+## Repro & Evidence
+- Steps to reproduce (with data/flags/inputs):
+  1. Create a calendar event whose `Start` precedes the scan window start (`utcNow - CalendarPastDays`) and whose `End` falls inside the window (or spans it entirely).
+  2. Run `OutlookScanner.ScanCalendarAsync` (window: `utcNow - CalendarPastDays` to `utcNow + CalendarFutureDays`, `src/OpenClaw.MailBridge/OutlookScanner.cs`, lines 281-284).
+  3. Inspect the cached events / the Restrict filter string: the event is excluded because its `Start` is before the window start.
+  4. Query free/busy over an interval covered by that event: the interval is reported free.
+- Expected vs actual behavior: Expected — every event overlapping `[windowStart, windowEnd)` is included in the scan. Actual — only events whose `Start` lies inside the window are included.
+- Logs/screenshots/error snippets: No error is raised; this is a silent exclusion. The defective predicate is directly visible in the filter string: `[Start] >= '<start>' AND [Start] < '<end>'`.
+- Frequency / determinism (always, intermittent, data-dependent): Deterministic; occurs for every event whose start precedes the window start while it overlaps the window.
+
+## Scope & Non-Goals
+- In scope: The window-membership predicate produced by `BuildCalendarFilter` (and, only if required for recurring-occurrence edge cases, a documented post-filter pass over materialized occurrences); one regression test in `tests/OpenClaw.MailBridge.Tests/`.
+- Out of scope / non-goals: Timezone/UTC normalization (fixed by issue #55 and unchanged here); the inbox filter (`BuildInboxFilter`); scanner scheduling, cache schema, `FreeBusyProjection` logic, and HostAdapter routes; any opportunistic refactor of `OutlookScanner`.
+- Explicitly excluded systems, integrations, or datasets: Microsoft Graph paths, HostAdapter endpoints, live Outlook COM in unit tests.
+
+## Root Cause Analysis
+- Current hypothesis or confirmed root cause: Confirmed. The Restrict filter tests only `[Start]` membership in the window instead of interval overlap. Correct membership: an event overlaps the window when `Start < windowEnd AND End > windowStart`.
+- Signals/evidence supporting it: Direct code reading of `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` lines 48-49; gap-analysis research `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`; feature-review confirmation 2026-07-02.
+- Affected components/modules (paths, services, pipelines): `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` (`BuildCalendarFilter`); consumer `src/OpenClaw.MailBridge/OutlookScanner.cs` (`ScanCalendarAsync`, Restrict call with `IncludeRecurrences = true`); downstream consumers of the cached window: `src/OpenClaw.HostAdapter/FreeBusyProjection.cs`, `src/OpenClaw.HostAdapter/SchedulingRoutes.cs`.
+
+## Proposed Fix
+
+### Design summary (what changes where):
+Change `BuildCalendarFilter` to emit the interval-overlap predicate:
+
+```
+[Start] < '<windowEnd>' AND [End] > '<windowStart>'
+```
+
+preserving the existing date formatting exactly: each boundary is rendered as `'{value.LocalDateTime:MM/dd/yyyy hh:mm tt}'` (UTC window edge converted to local time, minute precision, US-style format expected by Outlook Restrict). The strict `<` / `>` operators give the required boundary semantics directly: an event with `End == windowStart` fails `End > windowStart` (excluded), and an event with `Start == windowEnd` fails `Start < windowEnd` (excluded). Events starting inside the window, ending inside the window, or spanning it all satisfy the predicate.
+
+This is the minimal Restrict-string change and is the documented Outlook pattern for time-range queries used with `Items.Sort("[Start]")` plus `IncludeRecurrences = true`, both already set by `ScanCalendarAsync` before `Restrict` is invoked. If verification shows recurring-occurrence edge cases the Restrict string cannot express, a small post-filter pass over materialized occurrences applying the same overlap predicate is acceptable; the planner decides, but the Restrict-string-only change is preferred.
+
+### Boundaries and invariants to preserve:
+- COM interop stays confined to `OpenClaw.MailBridge` (architecture-boundaries rule).
+- Date formatting and timezone handling are unchanged: `LocalDateTime` conversion and `MM/dd/yyyy hh:mm tt` format are preserved; the #55 `GetOptionalUtcDateTimeOffset` normalization path is untouched.
+- `Sort("[Start]")` and `IncludeRecurrences = true` ordering relative to `Restrict` in `ScanCalendarAsync` is unchanged.
+- No production or test file exceeds 500 lines.
+
+### Dependencies or blocked work:
+None. The gap-analysis research lists this fix as independent of other epics.
+
+### Implementation strategy (what changes, not sequencing):
+
+#### Files/modules to change:
+- `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` — the `BuildCalendarFilter` expression body (the only production change expected).
+- `tests/OpenClaw.MailBridge.Tests/` — one new regression test file (suggested: `OutlookScannerCalendarOverlapFilterTests.cs`).
+
+#### Functions/classes/CLI commands impacted:
+- `OutlookScanner.BuildCalendarFilter(DateTimeOffset startUtc, DateTimeOffset endUtc)`. If the regression test asserts the builder directly, its visibility may be raised from `private` to `internal` (the test assembly already has `InternalsVisibleTo` via `src/OpenClaw.MailBridge/OpenClaw.MailBridge.csproj`); alternatively the test asserts the filter string captured by the existing fakes through `ScanCalendarAsync`. Planner decides; no public API surface changes either way.
+
+#### Data flow and validation changes:
+The Restrict filter string sent to Outlook changes from start-membership to interval-overlap. The cached window gains previously-excluded in-progress and window-spanning events. No schema, DTO, or cache-shape change.
+
+#### Error handling and logging updates:
+None. Existing null-check on the restricted items collection in `ScanCalendarAsync` is sufficient and unchanged.
+
+#### Rollback/feature-flag considerations (if applicable):
+None needed. Single-expression change; rollback is a revert.
+
+### Technical specifications (interfaces/contracts):
+
+#### Inputs/outputs and formats:
+- Input: `startUtc`, `endUtc` (`DateTimeOffset`, UTC window edges computed in `ScanCalendarAsync`).
+- Output: Outlook Restrict filter string `[Start] < '<endLocal>' AND [End] > '<startLocal>'` where each boundary uses the existing `MM/dd/yyyy hh:mm tt` local-time format.
+
+#### Required configuration keys and defaults:
+None new. Window size continues to come from `BridgeSettings.CalendarPastDays` / `CalendarFutureDays`.
+
+#### Backward-compatibility expectations:
+No public API change. Cached-window contents become a strict superset of the previous behavior (all previously included events remain included).
+
+#### Performance constraints (latency/throughput/memory):
+No measurable change expected: same single `Restrict` call; the result set grows only by the overlapping events that were incorrectly excluded.
+
+## Assumptions, Constraints, Dependencies
+- Assumptions (environment, data, access): Outlook Restrict supports `[End]` comparisons combined with `IncludeRecurrences` for appointment items (documented Outlook time-range pattern); the existing fakes (`FakeOutlookItems.Restrict` capturing `LastFilter` in `tests/OpenClaw.MailBridge.Tests/MailBridgeRuntimeTestDoubles.cs`) are sufficient to assert the emitted filter without live COM.
+- Constraints (budget, performance, compatibility): Minimal targeted fix per bugfix workflow; MSTest + FluentAssertions; no temporary files in tests; 500-line file cap; COM interop confined to `OpenClaw.MailBridge`.
+- External dependencies (services, libraries, releases): None new.
+
+## Data / API / Config Impact
+- User-facing or API changes: None. Free/busy results become correct for windows overlapping in-progress events.
+- Data or migration considerations: None; the cache repopulates on the next scan.
+- Logging/telemetry updates (if any): None.
+- Compatibility notes (CLI flags, config schemas, versioning): None.
+
+## Test Strategy
+- Regression tests to add or update: New MSTest class in `tests/OpenClaw.MailBridge.Tests/` (suggested: `OutlookScannerCalendarOverlapFilterTests.cs`) that fails against the current start-only predicate and passes with the overlap predicate. It must exercise the pure filter-string builder and/or the filter string captured by `FakeOutlookItems.LastFilter` after `ScanCalendarAsync` with `FakeComActiveObject` and a fixed `_utcNow` (pattern: `OutlookScannerCalendarUtcTests.cs`). No live Outlook COM.
+- Unit tests (MSTest + FluentAssertions) for the fixed behavior and boundaries: Assert the emitted filter contains `[Start] <` against the window end and `[End] >` against the window start, with boundaries formatted as `MM/dd/yyyy hh:mm tt` local time. If a post-filter pass is added, unit-test its predicate directly for all five interval cases below.
+- Edge cases and negative scenarios (invalid inputs, missing data, boundary values): (a) event starting inside the window — included; (b) event starting before the window, ending inside it — included; (c) event spanning the entire window — included; (d) event with `End == windowStart` — excluded; (e) event with `Start == windowEnd` — excluded.
+- Error handling and logging verification: Existing `ScanCalendarAsync` tests covering the unavailable-items error path continue to pass unchanged.
+- Coverage impact and targets for changed lines/modules: Line coverage >= 85% and branch coverage >= 75% (uniform, `.claude/rules/quality-tiers.md`); all changed lines covered; baseline, post-change, and comparison artifacts recorded under `docs/features/active/calendar-overlap-filter-19/evidence/coverage/`.
+- Toolchain commands to run (format → lint → type-check → test): `dotnet tool restore && dotnet csharpier check .` → `dotnet build` (analyzers + nullable, warnings as errors) → architecture tests → `dotnet test --collect:"XPlat Code Coverage"`. Restart the loop from formatting if any stage fails or changes files.
+- Manual validation steps (if required): Optional — on a machine with Outlook, run a bridge calendar scan while a meeting is in progress that started before the window start and confirm the event appears in the cache. Not required for merge; unit evidence is authoritative.
+
+## Acceptance Criteria
+- [x] The calendar filter/selection includes: (a) events starting within the window, (b) events starting before the window but ending inside it, and (c) events spanning the entire window.
+- [x] The calendar filter/selection excludes events ending at-or-before windowStart and events starting at-or-after windowEnd (boundary semantics explicit: `End == windowStart` excluded, `Start == windowEnd` excluded).
+- [x] A regression test in `tests/OpenClaw.MailBridge.Tests/` fails before the fix and passes after it, exercising the pure filter-string builder and/or a post-filter predicate, with no live Outlook COM dependency (file path and test names recorded here on completion). Recorded: file `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs`; tests `ScanCalendarAsync_emits_interval_overlap_restrict_filter` and `ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics` (5 DataRow boundary cases).
+- [x] Date formatting (`MM/dd/yyyy hh:mm tt`, `LocalDateTime` conversion) and the timezone handling established by the #55 fix are unchanged; all existing tests pass unchanged.
+- [x] No behavior change outside `BuildCalendarFilter` (and, only if required, a documented post-filter pass in the calendar scan path).
+- [x] Full C# toolchain passes in a single clean pass: CSharpier check → `dotnet build` (analyzers, nullable, warnings-as-errors) → architecture tests → `dotnet test` with coverage.
+- [x] Line coverage >= 85% and branch coverage >= 75% hold, with all changed lines covered; coverage baseline/post/comparison evidence stored under `docs/features/active/calendar-overlap-filter-19/evidence/coverage/`.
+
+## Risks & Mitigations
+- Technical or operational risks: (1) Outlook Restrict behavior for `[End]` combined with `IncludeRecurrences` may differ for recurring occurrences versus master items; mitigation — if the Restrict string proves insufficient, add the documented post-filter pass over materialized occurrences applying the same overlap predicate. (2) A larger result set from the corrected predicate; mitigation — the growth is bounded to genuinely overlapping events, and the scan already iterates the restricted collection.
+- Mitigations and rollbacks: Single-expression change; revert restores prior behavior. Regression test pins the corrected predicate against reintroduction.
+
+## Rollout & Follow-up
+- Release/rollout steps: Standard PR to `main` (merge commit) after feature review; no deployment steps beyond the normal bridge release.
+- Post-fix monitoring or clean-up tasks: None required; optionally confirm during the next live bridge session that in-progress events appear in free/busy output.
+- Links: issue #19 (`issue.md` in this folder); plan `plan.2026-07-02T07-41.md`; research `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`; related archived fix `docs/features/archive/2026-04-25-calendar-windows-wrong-55/`; master document `docs/open-claw-approach.master.md` section 10.4.

--- a/docs/features/active/calendar-overlap-filter-19/user-story.md
+++ b/docs/features/active/calendar-overlap-filter-19/user-story.md
@@ -1,0 +1,27 @@
+# calendar-overlap-filter (User Story)
+
+- **Issue:** #19
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-07-02T07-41
+- **Status:** Draft
+- **Version:** 0.1
+
+> Note: This feature runs in `full-bug` work mode, where `spec.md` is the sole authoritative acceptance-criteria source. This user story exists because the planner gate mechanically requires the artifact; it carries context only, not trackable acceptance criteria.
+
+## Story
+
+As the scheduling agent computing free/busy from the cached calendar window, I need the calendar scan to return every event that overlaps the query window — including events that started before the window but are still in progress, and events that span the entire window — so that the deterministic availability algorithm (`docs/open-claw-approach.master.md` section 10.4) never reports occupied time as free.
+
+## Narrative
+
+The scan window today is defined by start-time membership: only events whose `Start` falls inside `[windowStart, windowEnd)` are cached. From the scheduling agent's perspective, an in-progress meeting is exactly the kind of event that must block a proposed slot, yet it is the event most likely to be excluded by a start-only predicate. Correct behavior is interval overlap: an event belongs to the window when `Start < windowEnd AND End > windowStart`.
+
+## Value
+
+- Free/busy projections (`src/OpenClaw.HostAdapter/FreeBusyProjection.cs`) reflect actual calendar contents.
+- Scheduling recommendations stop proposing times that conflict with in-progress or window-spanning meetings.
+
+## Acceptance Criteria
+
+See `spec.md` — Acceptance Criteria (authoritative for `full-bug` work mode).

--- a/src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs
+++ b/src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs
@@ -46,5 +46,5 @@ internal sealed partial class OutlookScanner
     }
 
     private string BuildCalendarFilter(DateTimeOffset startUtc, DateTimeOffset endUtc) =>
-        $"[Start] >= '{startUtc.LocalDateTime:MM/dd/yyyy hh:mm tt}' AND [Start] < '{endUtc.LocalDateTime:MM/dd/yyyy hh:mm tt}'";
+        $"[Start] < '{endUtc.LocalDateTime:MM/dd/yyyy hh:mm tt}' AND [End] > '{startUtc.LocalDateTime:MM/dd/yyyy hh:mm tt}'";
 }

--- a/tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs
+++ b/tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs
@@ -1,0 +1,186 @@
+using System.Globalization;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.MailBridge;
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.MailBridge.Tests;
+
+/// <summary>
+/// Regression tests for the calendar overlap-filter bug (issue #19): the Restrict filter built by
+/// <c>OutlookScanner.BuildCalendarFilter</c> must use interval-overlap semantics
+/// (<c>[Start] &lt; windowEnd AND [End] &gt; windowStart</c>) so in-progress and window-spanning
+/// events are included in the calendar scan, while preserving the
+/// <c>MM/dd/yyyy hh:mm tt</c> local-time formatting established for issue #55.
+/// </summary>
+[TestClass]
+public sealed class OutlookScannerCalendarOverlapFilterTests
+{
+    private const int CalendarPastDays = 7;
+    private const int CalendarFutureDays = 30;
+
+    private static readonly DateTimeOffset FixedNow = new(2026, 4, 25, 12, 0, 0, TimeSpan.Zero);
+
+    private static OutlookScanner BuildScanner(BridgeSettings settings, FakeComActiveObject com) =>
+        new(
+            settings,
+            new BridgeStateStore(settings),
+            NullLogger<OutlookScanner>.Instance,
+            com,
+            _ => 0,
+            () => FixedNow
+        );
+
+    private static FakeOutlookApplication BuildOutlookWithCalendar(FakeOutlookFolder calendar)
+    {
+        var outlook = new FakeOutlookApplication();
+        outlook.Namespace.DefaultFolders[9] = calendar;
+        outlook.Namespace.DefaultFolders[6] = new FakeOutlookFolder();
+        return outlook;
+    }
+
+    /// <summary>
+    /// Runs a calendar scan against the fake Outlook doubles and returns the Restrict filter
+    /// string captured by <see cref="FakeOutlookItems.Restrict"/>.
+    /// </summary>
+    private static async Task<string> CaptureEmittedFilterAsync()
+    {
+        var settings = BridgeSettings.Default with
+        {
+            CalendarPastDays = CalendarPastDays,
+            CalendarFutureDays = CalendarFutureDays,
+        };
+        var calendar = new FakeOutlookFolder();
+        var com = new FakeComActiveObject { RunningObject = BuildOutlookWithCalendar(calendar) };
+        var repo = new FakeScanStateRepository();
+        var scanner = BuildScanner(settings, com);
+
+        await scanner.ScanCalendarAsync(repo);
+
+        calendar.Items.LastFilter.Should().NotBeNull("the calendar scan must call Restrict");
+        return calendar.Items.LastFilter!;
+    }
+
+    /// <summary>
+    /// Verifies the exact Restrict string: interval-overlap predicate with local-time boundaries
+    /// formatted <c>MM/dd/yyyy hh:mm tt</c> (issue #55 formatting preserved).
+    /// </summary>
+    [TestMethod]
+    public async Task ScanCalendarAsync_emits_interval_overlap_restrict_filter()
+    {
+        // Arrange
+        var windowStartLocal = FixedNow.AddDays(-CalendarPastDays).LocalDateTime;
+        var windowEndLocal = FixedNow.AddDays(CalendarFutureDays).LocalDateTime;
+        var expected = string.Create(
+            CultureInfo.InvariantCulture,
+            $"[Start] < '{windowEndLocal:MM/dd/yyyy hh:mm tt}' AND [End] > '{windowStartLocal:MM/dd/yyyy hh:mm tt}'"
+        );
+
+        // Act
+        var filter = await CaptureEmittedFilterAsync();
+
+        // Assert
+        filter
+            .Should()
+            .Be(
+                expected,
+                "the calendar Restrict filter must use interval-overlap semantics (issue #19)"
+            );
+    }
+
+    /// <summary>
+    /// Evaluates event membership against the emitted filter for the five boundary scenarios:
+    /// fully-within, in-progress, window-spanning (all included), and the two strict-boundary
+    /// exclusions (<c>End == windowStart</c>, <c>Start == windowEnd</c>).
+    /// Offsets are whole/fractional days relative to the window start; the window spans
+    /// <c>CalendarPastDays + CalendarFutureDays</c> = 37 days.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow(1.0, 1.5, true, "an event fully within the window must be included")]
+    [DataRow(
+        -1.0,
+        0.5,
+        true,
+        "an in-progress event starting before the window and ending inside it must be included"
+    )]
+    [DataRow(-1.0, 38.0, true, "an event spanning the entire window must be included")]
+    [DataRow(
+        -1.0,
+        0.0,
+        false,
+        "an event ending exactly at windowStart must be excluded (strict boundary)"
+    )]
+    [DataRow(
+        37.0,
+        38.0,
+        false,
+        "an event starting exactly at windowEnd must be excluded (strict boundary)"
+    )]
+    public async Task ScanCalendarAsync_filter_membership_matches_interval_overlap_semantics(
+        double startOffsetDays,
+        double endOffsetDays,
+        bool expectedIncluded,
+        string scenario
+    )
+    {
+        // Arrange
+        var windowStartLocal = FixedNow.AddDays(-CalendarPastDays).LocalDateTime;
+        var eventStart = windowStartLocal.AddDays(startOffsetDays);
+        var eventEnd = windowStartLocal.AddDays(endOffsetDays);
+
+        // Act
+        var filter = await CaptureEmittedFilterAsync();
+        var included = EvaluateFilter(filter, eventStart, eventEnd);
+
+        // Assert
+        included.Should().Be(expectedIncluded, scenario);
+    }
+
+    /// <summary>
+    /// Parses the two-clause Restrict filter and returns whether an event with the given
+    /// local start/end satisfies both clauses.
+    /// </summary>
+    private static bool EvaluateFilter(string filter, DateTime eventStart, DateTime eventEnd)
+    {
+        var clauses = filter.Split(" AND ", StringSplitOptions.None);
+        clauses.Should().HaveCount(2, "the calendar filter must contain exactly two clauses");
+        return clauses.All(clause => EvaluateClause(clause, eventStart, eventEnd));
+    }
+
+    /// <summary>
+    /// Parses a single clause of the form <c>[Field] op 'MM/dd/yyyy hh:mm tt'</c> (field
+    /// <c>[Start]</c> or <c>[End]</c>; operator <c>&lt;</c>, <c>&gt;</c>, <c>&lt;=</c>, or
+    /// <c>&gt;=</c>) and evaluates it against the event boundaries.
+    /// </summary>
+    private static bool EvaluateClause(string clause, DateTime eventStart, DateTime eventEnd)
+    {
+        var parts = clause.Split(' ', 3);
+        parts
+            .Should()
+            .HaveCount(3, $"clause '{clause}' must have field, operator, and quoted boundary");
+        var fieldValue = parts[0] switch
+        {
+            "[Start]" => eventStart,
+            "[End]" => eventEnd,
+            _ => throw new InvalidOperationException(
+                $"Unsupported field in filter clause '{clause}'."
+            ),
+        };
+        var boundary = DateTime.ParseExact(
+            parts[2].Trim('\''),
+            "MM/dd/yyyy hh:mm tt",
+            CultureInfo.InvariantCulture
+        );
+        return parts[1] switch
+        {
+            "<" => fieldValue < boundary,
+            ">" => fieldValue > boundary,
+            "<=" => fieldValue <= boundary,
+            ">=" => fieldValue >= boundary,
+            _ => throw new InvalidOperationException(
+                $"Unsupported operator in filter clause '{clause}'."
+            ),
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a free/busy correctness defect in the MailBridge calendar scan: events already in progress at the window start (and events spanning the whole window) were excluded from the scan, so occupied time could be treated as free downstream.
- Replaces the start-only Outlook `Restrict` predicate `[Start] >= start AND [Start] < end` with the overlap predicate `[Start] < windowEnd AND [End] > windowStart` in `BuildCalendarFilter`, preserving the existing `MM/dd/yyyy hh:mm tt` local-time formatting established by the #55 fix.
- Adds a six-test regression suite (`OutlookScannerCalendarOverlapFilterTests`) with explicit boundary semantics, observed to fail before the fix and pass after.
- One production line changed; no behavior change to date formatting or timezone handling.

## Why

`FreeBusyProjection` (HostAdapter) and the deterministic scheduler derive availability from the cached calendar window. With the start-only predicate, a meeting running across the window boundary never entered the cache, contradicting the availability model in `docs/open-claw-approach.master.md` §10.4. Tracked as issue #19; documented as gap F2 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`.

## What Changed

**Production**
- `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` — `BuildCalendarFilter` now emits the overlap predicate (one line changed).

**Tests**
- `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs` (new, 186 lines) — exact-filter-string assertion through the `FakeOutlookItems.LastFilter` seam plus a five-row data-driven boundary suite: fully-within, in-progress, and window-spanning events included; `End == windowStart` and `Start == windowEnd` excluded.

**Docs / evidence**
- `docs/features/active/calendar-overlap-filter-19/` — issue.md, spec.md, user-story.md, plan, baseline/regression/QA-gate evidence, and policy-audit / code-review / feature-audit artifacts (all three pass the MCP orchestration-artifact validator).

## Architecture / How It Fits Together

`OutlookScanner.ScanCalendarAsync` sorts by `[Start]`, sets `IncludeRecurrences = true`, and applies `Restrict(BuildCalendarFilter(...))` over the configured past/future window before caching events. The corrected predicate makes the cached window a true overlap query, which `FreeBusyProjection` and the agent's slot proposer then consume.

## Verification

**Completed** (evidence under `docs/features/active/calendar-overlap-filter-19/evidence/`):
- Regression fail-before (EXIT 1: exact-string test plus in-progress and spanning rows failed as predicted) and pass-after (EXIT 0, 6/6) — `evidence/regression-testing/`.
- Final toolchain single pass: `csharpier check .` clean, `dotnet build` 0 warnings / 0 errors, `dotnet test` 596 passed / 0 failed / 5 pre-existing environment-gated skips — `evidence/qa-gates/`.
- Coverage: pooled 90.26% line / 79.36% branch (zero regression); `OutlookScanner.Helpers.cs` re-measured 100% line / 100% branch; changed line covered (56 hits) — `evidence/qa-gates/coverage-review.2026-07-02T08-24.md`.
- Independent feature review at branch head: zero blocking findings, Go recommendation.

**Recommended**:
- `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~OutlookScannerCalendarOverlapFilterTests"`

## Backward Compatibility / Migration Notes

- No API, DTO, or schema changes. Scans now legitimately include additional (previously missed) in-progress events; consumers already handle these event shapes.

## Risks and Mitigations

- Minor pre-existing observation from review (not introduced here): `Restrict` boundary strings are formatted with the current culture in both filter builders; en-US hosts are unaffected. Recorded as a follow-up candidate, out of scope for this minimal fix.

## Review Guide

1. `src/OpenClaw.MailBridge/OutlookScanner.Helpers.cs` (the one-line predicate change)
2. `tests/OpenClaw.MailBridge.Tests/OutlookScannerCalendarOverlapFilterTests.cs`
3. Docs/evidence are mechanical and can be skimmed.

## Follow-ups

- Consider invariant-culture formatting for `Restrict` boundary strings (pre-existing, both filter builders).
- Program delivery continues per `docs/research/2026-07-01-open-claw-vision-gap-analysis.md` (next: re-verify/re-scope issue #82, then per-item sensitivity redaction #18).

## GitHub Auto-close

- Closes #19
