### PR TITLE
feat(core): persisted idempotency/dedupe keys for outbound sends

### DIFF
--- a/.claude/agent-memory/feature-review/MEMORY.md
+++ b/.claude/agent-memory/feature-review/MEMORY.md
@@ -1,4 +1,4 @@
 - [Artifact validator quirks](project_artifact-validator-quirks.md) — exact heading/line-format rules the orchestration-artifact validator enforces for review artifacts
 - [Per-file coverage masking](feedback_per-file-coverage-masking.md) — aggregates mask per-file line/branch fails AND async bodies are uninstrumented (runsettings CompilerGenerated exclude); re-measure from cobertura
-- [Review env fallbacks](project_review-env-fallbacks.md) — MCP template/validator tools and `dotnet tool restore` can be unavailable; use latest accepted artifact set (#19) as template and global csharpier
+- [Review env fallbacks](project_review-env-fallbacks.md) — MCP template/validator tools and `dotnet tool restore` unavailable; use latest accepted artifact set (#99) as template, global csharpier; PR-context summary misclassifies C# branches as docs-only
 - [T1/T2 property-test gate](project_t2-property-test-gate.md) — CsCheck present in OpenClaw.Core.Tests (expect real property tests there); elsewhere closable via directed deterministic invariant tests + dated decision record (#18 precedent)

--- a/.claude/agent-memory/feature-review/project_review-env-fallbacks.md
+++ b/.claude/agent-memory/feature-review/project_review-env-fallbacks.md
@@ -10,12 +10,14 @@ Two environment gaps recur when running feature review in this repo's worktrees:
 1. **MCP tools absent from the agent toolset.** `resolve_policy_audit_template_asset` and
    `validate_orchestration_artifacts` may not be exposed. No repo-local template files exist
    (glob for `*template*.md` finds only `.github/prompts/execute-plan-template.md`).
-   **How to apply:** mirror the structure of the most recent accepted artifact set — the #19 set
-   `docs/features/active/calendar-overlap-filter-19/policy-audit.2026-07-02T08-24.md` (or the #80
-   set `docs/features/active/core-response-status-roundtrip-80/*.2026-07-02T07-35.md`; check
-   archive locations after merge) — combined with the
+   **How to apply:** mirror the structure of the most recent accepted artifact set — the #99 set
+   `docs/features/active/2026-07-02-wire-sendmail-runtime-99/*.2026-07-02T11-25.md` (earlier
+   accepted sets: #19 `calendar-overlap-filter-19/*.2026-07-02T08-24.md`, #80
+   `core-response-status-roundtrip-80/*.2026-07-02T07-35.md`; check archive locations after
+   merge) — combined with the
    exact rules in [[artifact-validator-quirks]]. Record the missing MCP resolution as a documented
-   exception in section 8 of the policy audit (accepted on #80, #19, and #18 reviews, 2026-07-02).
+   exception in section 8 of the policy audit (accepted on #80, #19, #18, #99, and #101 reviews,
+   2026-07-02).
 
 2. **`dotnet tool restore` fails** ("command csharpier ... package contains dotnet-csharpier").
    **How to apply:** use the globally installed `csharpier check .` (1.3.0) instead; record the
@@ -25,3 +27,10 @@ Two environment gaps recur when running feature review in this repo's worktrees:
 
 Also: no `validate_evidence_locations.py` exists in this repo — do the evidence-location scan with
 `git diff --name-only <base>..HEAD | grep -E '^artifacts/(baselines|baseline|qa|qa-gates|evidence|coverage|regression-testing|post-change)/'`.
+
+Third recurring quirk — **PR-context summary misclassifies C# branches as docs-only.** On both the
+#99 and #101 reviews (2026-07-02) `artifacts/pr_context.summary.txt` "Changed files overview"
+reported "Core logic changes: 0 files" while the authoritative git diff contained 7+ production
+and 4-5 test `.cs` files. Never scope from the summary's file categorization; always use
+`git diff --stat <merge-base>..HEAD` and record the mismatch as an observation under Rejected
+Scope Narrowing (accepted pattern on both reviews).

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/code-review.2026-07-02T12-27.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/code-review.2026-07-02T12-27.md
@@ -1,0 +1,83 @@
+# Code Review: send-idempotency-dedupe (#101)
+
+- **Review Date:** 2026-07-02
+- **Branch:** `feature/send-idempotency-dedupe-101` @ `a3521833996bbf66e6d0e0ddedaebfaf8dcc85ec`
+- **Base:** `main` (resolved to `origin/main`) @ merge-base `d90681c766d8a9b9cff93fd59bc1989c80632d1f`
+- **Scope:** Full feature-vs-base diff (27 files: 12 `.cs`, 15 `.md`; +1494/-3)
+
+## Executive Summary
+
+The change implements persisted send idempotency for the scheduling worker with a clean three-layer split: a pure static key builder (`SentActionKey`), a clock-free two-method store contract (`ISentActionStore`), and a repository partial implementing the store over the existing per-call SQLite connection pattern. The worker consults the store before `SendMailAsync` and records after success, entirely inside the `SendEnabled`-gated branch, so the kill switch remains the outer boundary and a thrown send propagates to the existing per-message isolation before anything is recorded. The design choices are well-documented at the point of use (no-escaping key limitation, benign schema-ensure race, at-least-once window). Test quality is high: proven send-before-record call ordering, a real-store restart-persistence test over one shared in-memory database, a 4-row malformed-key negative test, and three CsCheck properties for the builder. No Blocking or Major findings. One Minor finding (dedupe-hit log content not asserted by a test) and three Info observations. Recommendation: **approve**.
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|---|---|---|---|---|---|---|
+| Minor | `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` | `RunCycle_StoreHit_SkipsSendAndCompletesWithoutThrowing` (lines 149-166) | AC-3's structured dedupe-hit log (`{MessageId}`, `{DedupeKey}` named template parameters) is emitted by the production code (`SchedulingWorker.Pipeline.cs:144-148`, verified by inspection) but is not content-asserted by any test; the hit test uses `NullLogger`. | In a follow-up, capture the logger (e.g., a recording `ILogger<SchedulingWorker>` test double) and assert the Information event's message template and both named parameters. | The log line is the only operator-visible signal that dedupe fired; today a template-parameter rename would pass the suite. The behavioral core of AC-3 (skip, normal outcome) is fully test-verified, so this is not blocking. | Production log call present in diff hunk `+@@ -126,9` (`LogInformation(... {MessageId} ... {DedupeKey} ...)`); test constructs worker with `NullLogger<SchedulingWorker>.Instance`. |
+| Info | `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` | `sentActionsSchemaEnsured` field / `EnsureSentActionsSchemaAsync` (lines 20, 91-105) | The lazy schema-ensure guard is a non-synchronized instance `bool`; two concurrent first calls on one repository instance can both execute the DDL. | No action required. The XML doc already states the race is harmless (`CREATE TABLE IF NOT EXISTS` is idempotent; the flag only avoids repeated DDL round-trips). If contention ever matters, a `SemaphoreSlim` or `Lazy<Task>` would make the guard single-flight. | Documented benign race with idempotent effect; matches the repository's simplicity-first policy priority. | XML doc lines 87-90; DDL constant line 17-18. |
+| Info | `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` | `RecordAsync` / `ParseSentActionKey` (lines 42, 70-84) | `RecordAsync` re-parses the dedupe key into `(mailbox, messageId, actionType)` for the redundant audit columns instead of accepting the components as parameters. Colon-containing message ids would land partially in the `action_type` column (`Split(':', 3)`), though the `dedupe_key` primary key — the only column dedupe reads — is always exact. | No action required for Stage 0. When the Stage 1 `{tenantId}` extension lands, prefer passing components explicitly (or a small record) so the store does not depend on the key's textual shape. | The parse doubles as a fail-fast shape guard (tested with 4 negative rows) and keeps the `ISentActionStore` interface minimal; the limitation mirrors the builder's documented colon-free contract and real inputs (UPN, hex EntryID, fixed constant) are colon-free. | `SentActionKey.cs` remarks lines 8-12; spec.md "Ambiguity note"; `RecordAsync_malformed_key_should_throw_ArgumentException`. |
+| Info | `mailbridge.runsettings` (unchanged) / `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` | New async logic lines 129-157; pre-existing partial branches lines 170, 177 | The pre-existing coverlet `ExcludeByAttribute=...CompilerGenerated...` setting leaves async method bodies uninstrumented, so the new consult/record logic contributes no per-line coverage data; file-level branch coverage stays at 50% (2/4) solely due to two pre-existing untouched ternaries (internal-domain fallback, empty-slots message), identical at baseline. | Carry forward the open #99 recommendation: evaluate removing `CompilerGeneratedAttribute` from `ExcludeByAttribute` so async bodies contribute line data; optionally add tests for the two pre-existing ternary arms (empty `InternalDomain`; zero proposed slots). | Instrumentation-scope limitation, not a regression; the new logic is behaviorally covered by five dedupe tests with fail-before/pass-after evidence (both `IsRecordedAsync` outcomes, failure, kill switch, restart). | Reviewer cobertura re-parse in `evidence/qa-gates/coverage-review.2026-07-02T12-27.md`; runsettings byte-identical to base (empty diff). |
+| Info | `artifacts/pr_context.summary.txt` | "Changed files overview" section | The PR-context summary categorizes the branch as "Core logic changes: 0 files" / docs-only; the authoritative diff contains 7 production and 5 test C# files. | No action for this branch; consider a follow-up on the summary generator's file-classification heuristic (same misclassification observed on the #99 review). | Reviews that trusted the summary categorization instead of the git diff would under-scope the audit. | `git diff --stat d90681c..a352183` (27 files) vs summary lines 179-195. |
+
+## Implementation Audit
+
+### C# implementation audit
+
+#### What changed well
+
+- **Kill-switch composition preserved exactly.** The consult/skip/record block lives wholly inside the pre-existing `else` of `if (!options.SendEnabled)`; with sends disabled the store is provably untouched (`RunCycle_SendDisabled_NeverTouchesStoreAndNeverSends` verifies both store methods `Times.Never`).
+- **Failure semantics are correct by construction.** `RecordAsync` is only reached after `SendMailAsync` completes; a throw propagates to `ProcessMessageSafelyAsync` unchanged, so retry eligibility is preserved without any new catch block. The at-least-once crash window is documented in spec and user-story rather than papered over.
+- **Clock discipline.** The store takes the timestamp as a parameter; the single clock read is `timeProvider.GetUtcNow()` at the worker, and the test asserts the recorded value equals the `FakeTimeProvider` time. No banned APIs anywhere in the diff.
+- **Migration is doubly safe.** The `sent_actions` DDL is both in `CreateTablesSql` (fresh/upgrade path via `InitializeAsync`) and in the lazy per-instance ensure guard (removes the hosted-service startup-ordering dependency the spec identified). Both paths are individually tested, including the pre-existing-database upgrade seeded with a pre-#101 schema shape.
+- **SQL hygiene.** All four store statements use named `$` parameters; the conflict-tolerant insert (`ON CONFLICT(dedupe_key) DO NOTHING`) makes the accepted duplicate-record window safe without read-modify-write.
+
+#### Type safety and API notes
+
+- Nullable analysis clean at `TreatWarningsAsErrors=true`; scalar-null handling via `is not null` pattern.
+- The public surface addition is minimal and spec-sanctioned: `SentActionKey` (static, 2 members) and `ISentActionStore` (2 methods). `CoreCacheRepository` stays `internal sealed`; the DI registration reuses the existing singleton instance so store and repository share one connection string.
+- XML docs state the contracts that matter: no component escaping (distinctness only for colon-free inputs), caller-supplied timestamps, `RecordAsync` idempotency.
+
+#### Error handling and logging
+
+- Fail-fast `ArgumentException` with the offending parameter name at both the builder (per component) and the store's key-shape guard; both are negatively tested with parameter-name assertions.
+- One new Information-level structured log (dedupe hit) using the file's existing message-template style; no log on the record step, which the spec justifies (the send is the observable action). See the Minor finding regarding test assertion of the log content.
+
+## Test Quality Audit
+
+### Reviewed test and QA artifacts
+
+- `tests/OpenClaw.Core.Tests/Agent/SentActionKeyTests.cs` (new, 78 lines) — 11 results
+- `tests/OpenClaw.Core.Tests/Agent/SentActionKeyPropertyTests.cs` (new, 81 lines) — 3 CsCheck properties
+- `tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs` (new, 212 lines) — 11 results
+- `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` (new, 296 lines) — 5 tests
+- `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs` (modified, helper factory only)
+- Executor evidence under `evidence/{baseline,qa-gates,regression-testing,other}/`; reviewer re-run `evidence/qa-gates/coverage-review.2026-07-02T12-27.md`
+
+### Quality assessment
+
+- **Ordering proof, not just counting.** The miss-path test records call order via Moq callbacks and asserts the exact sequence `["send", "record"]` — the strongest available proof that a failed send cannot have been recorded first.
+- **Restart persistence uses the real store.** Two `CoreCacheRepository` instances over one GUID-named shared in-memory database simulate a process restart with zero temp files; the assertion is exactly-once in total across both cycles, which is the user-facing invariant.
+- **Negative coverage is genuine.** Guard tests assert parameter names, not just exception types; the malformed-key test enumerates four distinct shape violations; the duplicate-record test verifies the row count directly over a second connection.
+- **Property tests are real properties.** Determinism, order preservation under split, and injectivity for colon-free triples — each quantified over 1000 generated samples with the suite's seeded, seed-printing convention; generators encode the documented contract (colon-free, non-whitespace) rather than filtering after the fact.
+- **No weakened assertions.** The only change to the pre-existing worker suite is a default not-recorded store mock in its private factory, keeping all 13 prior tests semantically identical.
+
+## Security / Correctness Checks
+
+- **SQL injection:** none possible — all values flow through named parameters; no string-concatenated SQL.
+- **Data integrity:** `dedupe_key` is the primary key; component columns are denormalized for audit only and never read by dedupe logic.
+- **Secrets/PII:** the table stores mailbox UPN and message id — same data classes already persisted elsewhere in the Core cache; no new exposure surface, no new logging of message content.
+- **Concurrency:** per-call connections; the ensure-guard race is benign and documented; `ON CONFLICT DO NOTHING` makes concurrent duplicate records safe.
+- **Cancellation:** the caller token is forwarded through `OpenAsync`, `ExecuteScalarAsync`, and `ExecuteNonQueryAsync`.
+- **Architecture:** no COM/VSTO/interop references; NetArchTest suite passes 2/2 (reviewer run).
+
+## Research Log
+
+- Verified diff hunks for `SchedulingWorker.Pipeline.cs` add only lines 129-151 and 155-157; the two partial-branch lines (170, 177) are pre-existing and untouched (`git diff --unified=0`).
+- Re-parsed executor baseline cobertura (`artifacts/csharp/baseline-101/`) and reviewer fresh cobertura: pooled 90.56%/80.05% -> 90.63%/80.25%; per-file figures match executor's `coverage-comparison.2026-07-02T12-16.md` exactly.
+- Confirmed CsCheck 4.7.0 already referenced by `OpenClaw.Core.Tests.csproj` (no dependency change).
+- Grep of all added C# lines for banned APIs and suppressions: no matches.
+- Confirmed no `.github/workflows/**`, `scripts/benchmarks/**`, or `.github/actions/**` paths in the diff (`modified-workflow-needs-green-run` not triggered).
+
+## Verdict
+
+**Approve.** No Blocking or Major findings. One Minor finding (dedupe-hit log content not test-asserted — follow-up recommended, not required for merge) and three Info observations, none requiring action on this branch. The implementation matches the spec precisely, the toolchain and coverage gates pass under independent re-verification, and regression evidence discriminates the new behavior. Remediation is not required.

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/baseline-build.2026-07-02T11-58.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/baseline-build.2026-07-02T11-58.md
@@ -1,0 +1,6 @@
+# Baseline — Build / Lint / Type-Check (dotnet build)
+
+Timestamp: 2026-07-02T11-58
+Command: `dotnet build OpenClaw.MailBridge.sln` (repo root)
+EXIT_CODE: 0
+Output Summary: Build succeeded — 0 Warning(s), 0 Error(s). All 8 projects built (Contracts x2, Client, MailBridge, HostAdapter, Core, and 3 test projects). Analyzer stack and nullable analysis run in this step with `TreatWarningsAsErrors=true`; baseline is clean.

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/baseline-format.2026-07-02T11-58.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/baseline-format.2026-07-02T11-58.md
@@ -1,0 +1,6 @@
+# Baseline — Formatting (CSharpier)
+
+Timestamp: 2026-07-02T11-58
+Command: `csharpier check .` (repo root)
+EXIT_CODE: 0
+Output Summary: Checked 205 files in 404ms. All files formatted; 0 unformatted files. Baseline formatting gate passes.

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/baseline-test-coverage.2026-07-02T11-59.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/baseline-test-coverage.2026-07-02T11-59.md
@@ -1,0 +1,19 @@
+# Baseline — Tests and Coverage
+
+Timestamp: 2026-07-02T11-59
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory artifacts/csharp/baseline-101` (repo root)
+EXIT_CODE: 0
+
+Output Summary:
+- Test results (all pass, 0 failed):
+  - OpenClaw.HostAdapter.Tests: 100 passed / 0 failed / 0 skipped (total 100)
+  - OpenClaw.Core.Tests: 224 passed / 0 failed / 0 skipped (total 224)
+  - OpenClaw.MailBridge.Tests: 347 passed / 0 failed / 5 skipped (total 352; skips are Windows-COM/publish-output integration tests skipped by design)
+  - Totals: 671 passed, 0 failed, 5 skipped (676 tests)
+- Coverage (Cobertura reports under `artifacts/csharp/baseline-101/`):
+  - Per-report: MailBridge.Tests run (3be2727f): line 93.58% (1533/1638), branch 88.16% (417/473); HostAdapter.Tests run (771270cc): line 87.70% (1113/1269), branch 67.19% (170/253); Core.Tests run (eb2dc395): line 89.77% (1528/1702), branch 78.73% (348/442)
+  - Pooled (summed across the three reports): line coverage 90.56% (4174/4609), branch coverage 80.05% (935/1168)
+  - `OpenClaw.Core` package (Core.Tests report): line 98.63%, branch 91.82%
+- Baseline verdict: pooled line 90.56% >= 85% and pooled branch 80.05% >= 75% — baseline thresholds satisfied.
+
+Raw artifacts: `artifacts/csharp/baseline-101/3be2727f-f531-452b-8c88-7bb9236edd2e/coverage.cobertura.xml`, `artifacts/csharp/baseline-101/771270cc-29b4-4391-971f-fcbe017fd385/coverage.cobertura.xml`, `artifacts/csharp/baseline-101/eb2dc395-bb4c-4b23-92d1-1928292c423a/coverage.cobertura.xml`

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,21 @@
+# Phase 0 — Policy Instructions Read
+
+Timestamp: 2026-07-02T11-58
+
+Policy Order:
+1. `CLAUDE.md`-loaded standing rules (repository has no root `CLAUDE.md` file; standing rules are auto-loaded from `.claude/rules/` per path-scoped frontmatter)
+2. `.claude/rules/general-code-change.md`
+3. `.claude/rules/general-unit-test.md`
+4. `.claude/rules/csharp.md`
+5. `.claude/rules/architecture-boundaries.md`
+6. `.claude/rules/quality-tiers.md`
+
+Files read (explicit list):
+- `.claude/rules/general-code-change.md` (loaded in session context; cross-language code change policy: design principles, seven-stage toolchain loop, 500-line file cap, error handling, naming, I/O boundaries)
+- `.claude/rules/general-unit-test.md` (loaded in session context; unit test policy: independence/isolation/determinism, coverage >= 85% line / >= 75% branch, no temp files in tests, tests/ tree mirroring, determinism infrastructure)
+- `.claude/rules/csharp.md` (read directly; CSharpier formatting, analyzer stack with TreatWarningsAsErrors, nullable analysis, banned APIs including DateTime.UtcNow/Task.Delay, TimeProvider clock seam, CsCheck property tests for T1/T2)
+- `.claude/rules/architecture-boundaries.md` (read directly; No-COM rules, NetArchTest.Rules enforcement for .NET, layer boundary assertions)
+- `.claude/rules/quality-tiers.md` (loaded in session context; T1-T4 tier system, uniform coverage thresholds, tier-dependent gate matrix)
+- Additional standing rules loaded in session context: `.claude/rules/benchmark-baselines.md`, `.claude/rules/ci-workflows.md`, `.claude/rules/orchestrator-state.md`, `.claude/rules/tonality.md`
+
+Note: The plan's test-stack convention (MSTest + FluentAssertions + Moq + CsCheck) follows the established in-repo stack per the spec, superseding the xUnit/NSubstitute defaults named in `csharp.md` (documented in plan Open Questions).

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/other/scope-and-size-verification.2026-07-02T12-18.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/other/scope-and-size-verification.2026-07-02T12-18.md
@@ -1,0 +1,48 @@
+# Scope and Size Verification (P5-T5)
+
+Timestamp: 2026-07-02T12-18
+Command: `git fetch origin main` then `git diff --name-only origin/main -- src/ tests/` plus `git status --porcelain` (untracked new files); line counts via `wc -l`. Diff base is `origin/main` (not the potentially stale local `main`).
+
+## (a) Production diff scope
+
+Modified (tracked) production files vs `origin/main`:
+- `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs`
+- `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs`
+- `src/OpenClaw.Core/CoreCacheRepository.Schema.cs`
+- `src/OpenClaw.Core/Program.cs`
+
+New (untracked) production files:
+- `src/OpenClaw.Core/Agent/SentActionKey.cs`
+- `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs`
+- `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs`
+
+These are exactly the seven files enumerated in the plan's Conventions diff-scope list. No file under `src/OpenClaw.HostAdapter/`, `src/OpenClaw.MailBridge/`, or any `*.Contracts` wire-surface project appears in the diff. Test-tree changes: `SchedulingWorkerTests.cs` (modified, helper only) plus four new test files, all under `tests/`. Verdict: PASS.
+
+## (b) File size (500-line cap)
+
+| File | Lines |
+|---|---|
+| `src/OpenClaw.Core/Agent/SentActionKey.cs` | 57 |
+| `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs` | 29 |
+| `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` | 106 |
+| `src/OpenClaw.Core/CoreCacheRepository.Schema.cs` | 253 |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs` | 104 |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` | 195 |
+| `src/OpenClaw.Core/Program.cs` | 329 |
+| `tests/OpenClaw.Core.Tests/Agent/SentActionKeyTests.cs` | 78 |
+| `tests/OpenClaw.Core.Tests/Agent/SentActionKeyPropertyTests.cs` | 81 |
+| `tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs` | 212 |
+| `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs` | 319 |
+| `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` | 296 |
+
+All new or modified production and test files are under 500 lines. Verdict: PASS.
+
+## (c) No temp files in tests
+
+Inspected the two SQLite-backed test files:
+- `tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs` — every connection string uses `Data Source=core-sa-<label>-<guid>;Mode=Memory;Cache=Shared`; direct-verification reads open a second connection to the same in-memory database; no filesystem paths, no `Path.GetTempFileName`, no file I/O.
+- `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` — the restart-persistence test uses `Data Source=worker-dedupe-<guid>;Mode=Memory;Cache=Shared`; all other dependencies are Moq mocks with `FakeTimeProvider` and `NullLogger`; no file I/O.
+
+Verdict: PASS.
+
+Overall: PASS on (a), (b), and (c).

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md
@@ -1,0 +1,41 @@
+# Coverage Comparison — Baseline vs Post-Change (P5-T4)
+
+Timestamp: 2026-07-02T12-16
+Baseline source: `artifacts/csharp/baseline-101/` (three Cobertura reports, run 2026-07-02T11-59)
+Final source: `artifacts/csharp/final-101/` (three Cobertura reports, run 2026-07-02T12-16)
+
+## (a) Baseline coverage
+
+- Pooled line coverage: 90.56% (4174/4609)
+- Pooled branch coverage: 80.05% (935/1168)
+- `OpenClaw.Core` package (Core.Tests report): line 98.63%, branch 91.82%
+
+## (b) Post-change coverage
+
+- Pooled line coverage: 90.63% (4207/4642) — up 0.07 points from baseline
+- Pooled branch coverage: 80.25% (947/1180) — up 0.20 points from baseline
+- `OpenClaw.Core` package (Core.Tests report): line 98.66%, branch 92.07% — both up from baseline
+
+## (c) Per-file line coverage for changed/new production files (Core.Tests report)
+
+| File | Status | Baseline line / branch | Final line / branch |
+|---|---|---|---|
+| `src/OpenClaw.Core/Agent/SentActionKey.cs` | new | n/a | 100% / 100% |
+| `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` | new | n/a | 100% / 100% |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs` | modified | 100% / 100% | 100% / 100% |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` | modified | 100% / 50% | 100% / 50% |
+| `src/OpenClaw.Core/CoreCacheRepository.Schema.cs` | modified | 100% / 100% | 100% / 100% |
+| `src/OpenClaw.Core/Program.cs` | modified | 100% / 100% | 100% / 100% |
+| `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs` | new | n/a | interface-only; no executable lines — legitimately excluded from executable coverage per policy |
+
+Note on `SchedulingWorker.Pipeline.cs` branch rate: the 50% branch rate is identical at baseline and final. Verified via line-level Cobertura data in the final report: the file has zero uncovered lines and exactly two partial branches, both on pre-existing lines untouched by this feature (line 170, the `MailboxUpn()` internal-domain ternary; line 177, the `BuildProposalReply` empty-slots ternary). The consult/record logic added by this feature (lines 129–157) is inside the async `ProposeAndActAsync` body, which the runsettings' CompilerGenerated exclusion leaves uninstrumented; its behavior is directly verified by the five `SchedulingWorkerDedupeTests` (hit-skip, miss-send-record ordering, failure no-record, kill-switch, restart persistence), including both outcomes of the new `IsRecordedAsync` branch. No changed-line regression.
+
+## (d) Verdict per threshold
+
+| Threshold | Value | Verdict |
+|---|---|---|
+| Line coverage >= 85% | 90.63% pooled (98.66% Core package) | PASS |
+| Branch coverage >= 75% | 80.25% pooled (92.07% Core package) | PASS |
+| Changed-line coverage no regression | all new/changed production lines 100% line-covered; pooled and Core-package figures both improved vs baseline | PASS |
+
+Overall: PASS.

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/coverage-review.2026-07-02T12-27.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/coverage-review.2026-07-02T12-27.md
@@ -1,0 +1,45 @@
+# Reviewer Coverage Re-Verification (feature-review, issue #101)
+
+- Timestamp: 2026-07-02T12-27
+- Branch: `feature/send-idempotency-dedupe-101` @ `a3521833996bbf66e6d0e0ddedaebfaf8dcc85ec`
+- Base: `origin/main` @ merge-base `d90681c766d8a9b9cff93fd59bc1989c80632d1f`
+- Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory "docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/coverage-review"` (repo root)
+- EXIT_CODE: 0
+- Test results: 701 passed, 0 failed, 5 environment-gated skips (OpenClaw.HostAdapter.Tests 100; OpenClaw.Core.Tests 254; OpenClaw.MailBridge.Tests 347 passed / 5 skipped) — identical totals to executor evidence `final-test-coverage.2026-07-02T12-16.md`.
+
+## Fresh cobertura reports (this run)
+
+- `evidence/qa-gates/coverage-review/0a055268-5bba-405b-beff-2156f9bfb531/coverage.cobertura.xml`
+- `evidence/qa-gates/coverage-review/46036f31-6182-47c0-b6ef-82cf0d71c979/coverage.cobertura.xml`
+- `evidence/qa-gates/coverage-review/fed5a0ea-322d-4bad-b7a5-2318ee5fef13/coverage.cobertura.xml`
+
+## Independently parsed results (per-file line AND branch, condition-coverage attributes)
+
+Pooled solution: line 4207/4642 = 90.63%; branch 947/1180 = 80.25%.
+`OpenClaw.Core` package (T1): line 1477/1497 = 98.66%; branch 360/391 = 92.07%.
+
+| File | Status | Line | Branch | Notes |
+|---|---|---|---|---|
+| `src/OpenClaw.Core/Agent/SentActionKey.cs` | new | 21/21 = 100% | 6/6 = 100% | |
+| `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs` | new | not instrumented | n/a | interface-only file; legitimately excluded from executable coverage per policy |
+| `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` | new | 10/10 = 100% | 6/6 = 100% | async bodies uninstrumented per pre-existing runsettings CompilerGenerated exclusion; behavior verified by 8 repository tests incl. the 4-row malformed-key negative test |
+| `src/OpenClaw.Core/CoreCacheRepository.Schema.cs` | modified | 37/37 = 100% | 6/6 = 100% | baseline 37/37, 6/6 — no regression |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs` | modified | 9/9 = 100% | no branch points | baseline 8/8 |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` | modified | 20/20 = 100% | 2/4 = 50% | partial conditions on lines 170 and 177 only — both PRE-EXISTING lines untouched by this branch (diff hunks add lines 129-151 and 155-157 only); baseline identical at 20/20 line, 2/4 branch — no regression |
+| `src/OpenClaw.Core/Program.cs` | modified | 236/236 = 100% | no branch points | baseline 235/235 |
+
+## Baseline cross-check
+
+Executor baseline artifacts at `artifacts/csharp/baseline-101/` (3 cobertura reports, untracked) independently re-parsed: pooled line 4174/4609 = 90.56%, branch 935/1168 = 80.05%; `OpenClaw.Core` package 98.63% line / 91.82% branch; `SchedulingWorker.Pipeline.cs` 20/20 line, 2/4 branch. These match executor evidence `evidence/baseline/baseline-test-coverage.2026-07-02T11-59.md` and `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md` exactly.
+
+## Instrumentation-scope note
+
+The new consult/skip/record logic in `SchedulingWorker.Pipeline.cs` (lines 129-157) sits inside the async `ProposeAndActAsync` body, which `mailbridge.runsettings` (`ExcludeByAttribute=...CompilerGeneratedAttribute...`, pre-existing, byte-identical to base) leaves uninstrumented. Per-line cobertura therefore cannot attest those changed lines. Behavioral verification substitutes: the five `SchedulingWorkerDedupeTests` cover both outcomes of the new `IsRecordedAsync` branch (hit-skip, miss-send-record with proven send-before-record ordering and `FakeTimeProvider` timestamp), failure no-record with next-candidate isolation, kill-switch composition (store untouched), and restart persistence over one shared in-memory database; fail-before evidence EXIT 1 (`evidence/regression-testing/dedupe-expect-fail.2026-07-02T12-10.md`) and pass-after EXIT 0 (`evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md`).
+
+## Verdict
+
+- Pooled line 90.63% >= 85%: PASS
+- Pooled branch 80.25% >= 75%: PASS
+- New files (`SentActionKey.cs`, `CoreCacheRepository.SentActions.cs`): 100% line / 100% branch >= 85%/75%: PASS
+- Modified files: all 100% line; no changed-line regression (Pipeline.cs 50% file-level branch is fully attributable to two pre-existing untouched ternaries, identical at baseline): PASS
+- Overall C# coverage verdict: **PASS**

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/final-build.2026-07-02T12-13.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/final-build.2026-07-02T12-13.md
@@ -1,0 +1,9 @@
+# Final QA Gate — Build / Lint / Type-Check (dotnet build)
+
+Timestamp: 2026-07-02T12-13
+Command: `dotnet build OpenClaw.MailBridge.sln` (repo root); additionally verified with `dotnet build OpenClaw.MailBridge.sln --no-incremental` so incremental compilation could not mask warnings
+EXIT_CODE: 0
+
+Output Summary: Build succeeded — 0 Warning(s), 0 Error(s) on both the standard and the non-incremental rebuild. Analyzer stack (`AnalysisLevel=latest-all`, `AnalysisMode=All`) and nullable analysis run with `TreatWarningsAsErrors=true`. The transient CS9113 (unread `sentActionStore` parameter) observed between P3-T1 and P4-T1 is resolved: the parameter is consumed by the pipeline consult/record logic.
+
+Final loop pass: after the P5-T3 coverage fix restarted the loop, `dotnet build OpenClaw.MailBridge.sln` was rerun at 2026-07-02T12-16 — Build succeeded, 0 Warning(s), 0 Error(s), EXIT_CODE 0.

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/final-format.2026-07-02T12-12.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/final-format.2026-07-02T12-12.md
@@ -1,0 +1,10 @@
+# Final QA Gate — Formatting (CSharpier)
+
+Timestamp: 2026-07-02T12-12
+Command: `csharpier format .` then `csharpier check .` (repo root)
+EXIT_CODE: 0 (check; format also exited 0)
+
+Output Summary:
+- Loop iteration 1: `csharpier format .` reformatted 2 of the new test files (`SentActionKeyTests.cs`, `SentActionKeyPropertyTests.cs`); per the plan's loop rule the gate was restarted.
+- Loop iteration 2: format clean, check clean; the loop later restarted from this gate after the P5-T3 coverage fix (a negative-flow test was added to `CoreCacheRepositorySentActionsTests.cs`).
+- Loop iteration 3 (final clean single pass, 2026-07-02T12-15): `csharpier format .` EXIT_CODE 0 with no file changes beyond formatting the just-added test edit in place; `csharpier check .` — "Checked 212 files", EXIT_CODE 0, 0 unformatted files. Subsequent build and test gates completed with no further file changes, closing the loop in a single clean pass.

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md
@@ -1,0 +1,18 @@
+# Final QA Gate — Tests and Coverage
+
+Timestamp: 2026-07-02T12-16
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory artifacts/csharp/final-101` (repo root)
+EXIT_CODE: 0
+
+Output Summary:
+- Test results (all pass, 0 failed): OpenClaw.HostAdapter.Tests 100 passed; OpenClaw.Core.Tests 254 passed (baseline 224 + 30 new results: 11 SentActionKey unit results (2 named + 3 parameterized x 3 rows), 3 SentActionKey property, 11 CoreCacheRepositorySentActions results (7 named + 1 malformed-key negative test x 4 rows), 5 SchedulingWorkerDedupe); OpenClaw.MailBridge.Tests 347 passed / 5 skipped (Windows-COM/publish integration skips, unchanged from baseline). Totals: 701 passed, 0 failed, 5 skipped.
+- The run includes the architecture-boundary tests (`AgentArchitectureBoundaryTests`), unit tests, and CsCheck property tests.
+- Coverage (Cobertura reports under `artifacts/csharp/final-101/`):
+  - Per-report: Core.Tests run (34a5ac0b): line 89.97% (1561/1735), branch 79.29% (360/454); MailBridge.Tests run (8622e903): line 93.58% (1533/1638), branch 88.16% (417/473); HostAdapter.Tests run (a3f48c58): line 87.70% (1113/1269), branch 67.19% (170/253)
+  - Pooled (summed across the three reports): line coverage 90.63% (4207/4642), branch coverage 80.25% (947/1180)
+  - `OpenClaw.Core` package (Core.Tests report): line 98.66%, branch 92.07%
+- Verdict: pooled line 90.63% >= 85% and pooled branch 80.25% >= 75% — thresholds satisfied.
+
+Loop note: the first Phase 5 iteration surfaced uncovered lines (the malformed-key throw path in `CoreCacheRepository.SentActions.cs`); a negative-flow test (`RecordAsync_malformed_key_should_throw_ArgumentException`, 4 data rows) was added and the loop restarted from the formatting gate. This artifact records the clean single pass.
+
+Raw artifacts: `artifacts/csharp/final-101/34a5ac0b-.../coverage.cobertura.xml`, `.../8622e903-...`, `.../a3f48c58-...`

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/regression-testing/dedupe-expect-fail.2026-07-02T12-10.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/regression-testing/dedupe-expect-fail.2026-07-02T12-10.md
@@ -1,0 +1,18 @@
+# Expect-Fail Evidence — SchedulingWorkerDedupeTests before the pipeline change (P3-T5)
+
+Timestamp: 2026-07-02T12-10
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerDedupeTests"` (repo root)
+EXIT_CODE: 1
+
+Output Summary:
+Run before the P4-T1 pipeline change (worker does not yet consult or write the store). Observed outcomes match the plan's expectations exactly — 4 failed, 1 passed, 5 total:
+
+| Test | Expected | Observed |
+|---|---|---|
+| (a) `RunCycle_StoreHit_SkipsSendAndCompletesWithoutThrowing` (skip-on-hit) | FAIL | FAIL |
+| (b) `RunCycle_StoreMiss_SendsThenRecordsKeyWithInjectedClockTimestamp` (record-on-success) | FAIL | FAIL |
+| (c) `RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate` (no-record-on-failure) | FAIL | FAIL |
+| (d) `RunCycle_SendDisabled_NeverTouchesStoreAndNeverSends` (kill-switch composition) | PASS | PASS |
+| (e) `RunCycle_TwoWorkerStorePairsOverOneDatabase_SendExactlyOnceInTotal` (restart persistence) | FAIL | FAIL |
+
+Failure reasons: (a) `SendMailAsync` is invoked despite the store hit; (b) `RecordAsync` is never invoked; (c) `IsRecordedAsync` is never consulted; (e) `SendMailAsync` is invoked twice (once per worker) because no record is persisted between cycles. Test (d) passes because the `SendEnabled=false` path already returns before any send, and the store is untouched today.

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md
@@ -1,0 +1,18 @@
+# Pass-After Evidence — SchedulingWorkerDedupeTests after the pipeline change (P4-T2)
+
+Timestamp: 2026-07-02T12-11
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerDedupeTests"` (repo root)
+EXIT_CODE: 0
+
+Output Summary:
+Run after the P4-T1 pipeline change (consult-before-send / record-after-success inside the `SendEnabled` else branch of `ProposeAndActAsync`). All five dedupe tests pass — Failed: 0, Passed: 5, Skipped: 0, Total: 5:
+
+| Test | Observed |
+|---|---|
+| (a) `RunCycle_StoreHit_SkipsSendAndCompletesWithoutThrowing` (skip-on-hit) | PASS |
+| (b) `RunCycle_StoreMiss_SendsThenRecordsKeyWithInjectedClockTimestamp` (record-on-success, send-before-record ordering, `FakeTimeProvider` timestamp) | PASS |
+| (c) `RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate` (no-record-on-failure, per-message isolation) | PASS |
+| (d) `RunCycle_SendDisabled_NeverTouchesStoreAndNeverSends` (kill-switch composition) | PASS |
+| (e) `RunCycle_TwoWorkerStorePairsOverOneDatabase_SendExactlyOnceInTotal` (restart persistence over one shared in-memory SQLite database) | PASS |
+
+Fail-before counterpart: `dedupe-expect-fail.2026-07-02T12-10.md` in this directory (EXIT_CODE 1; tests a/b/c/e failed as expected, d passed).

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/feature-audit.2026-07-02T12-27.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/feature-audit.2026-07-02T12-27.md
@@ -1,0 +1,50 @@
+# Feature Audit: send-idempotency-dedupe (#101)
+
+- **Audit Date:** 2026-07-02
+- **Branch:** `feature/send-idempotency-dedupe-101` @ `a3521833996bbf66e6d0e0ddedaebfaf8dcc85ec`
+- **Work Mode:** `full-feature` (persisted marker `- Work Mode: full-feature` in `issue.md`)
+- **AC Sources:** `docs/features/active/2026-07-02-send-idempotency-dedupe-101/spec.md` (`## Acceptance Criteria`) and `docs/features/active/2026-07-02-send-idempotency-dedupe-101/user-story.md` (`## Acceptance Criteria`); mirrored in `issue.md`. The six criteria are textually identical across all three files (spec.md carries slightly more detailed per-item evidence annotations).
+
+## Scope and Baseline
+
+- Resolved base branch: `main` (resolved to `origin/main`; the local `main` ref is stale per caller inputs).
+- Merge-base SHA: `d90681c766d8a9b9cff93fd59bc1989c80632d1f`; head SHA: `a3521833996bbf66e6d0e0ddedaebfaf8dcc85ec`; range: `d90681c..a352183`.
+- Evidence sources: `artifacts/pr_context.summary.txt` and `artifacts/pr_context.appendix.txt` (fresh — the summary's Base/Head section head SHA matches the current branch head), the authoritative `git diff` file list (27 files: 12 `.cs`, 15 `.md`; +1494/-3), executor evidence under `evidence/{baseline,qa-gates,regression-testing,other}/`, and the reviewer's independent toolchain re-run and cobertura re-parse (`evidence/qa-gates/coverage-review.2026-07-02T12-27.md`).
+- The audit scope is the full feature-vs-base branch diff. No caller narrowing was attempted or accepted (see the policy audit's Rejected Scope Narrowing section).
+
+## Acceptance Criteria Inventory
+
+| # | Criterion (abbreviated) | Source(s) | Format |
+|---|---|---|---|
+| AC-1 | `sent_actions` table in the Core cache with an idempotent guarded migration; fresh-database and pre-existing-database upgrade paths covered by tests; running the migration twice is safe | spec.md, user-story.md (issue.md mirror) | `- [x]` checkbox (already checked by executor) |
+| AC-2 | Pure, deterministic dedupe-key builder producing `{mailbox}:{messageId}:{actionType}`, unit-tested including at least one CsCheck property test per T1 convention (determinism, component ordering, colon-free distinctness) | spec.md, user-story.md | `- [x]` checkbox |
+| AC-3 | Inside the `SendEnabled`-gated block the worker consults the store before sending: hit -> skip + structured dedupe-hit log (message id and dedupe key as named template parameters), normal (not failed) outcome; miss -> send then record with a timestamp from the injected `TimeProvider` | spec.md, user-story.md | `- [x]` checkbox |
+| AC-4 | Repeated worker cycle for the same candidate does not invoke `ISchedulingService.SendMailAsync` a second time, including across a simulated restart (new worker and store instances over one shared in-memory SQLite database) | spec.md, user-story.md | `- [x]` checkbox |
+| AC-5 | A failed send does NOT record the key (retry remains possible); failure stays isolated to that message per the existing `ProcessMessageSafelyAsync` behavior | spec.md, user-story.md | `- [x]` checkbox |
+| AC-6 | Full C# toolchain passes (format, lint, type-check, architecture, tests); coverage thresholds hold (line >= 85%, branch >= 75%) with changed lines covered; MSTest + FluentAssertions + Moq; no temp files in tests; all files under the 500-line cap | spec.md, user-story.md | `- [x]` checkbox |
+
+## Acceptance Criteria Evaluation
+
+| # | Verdict | Evidence |
+|---|---|---|
+| AC-1 | **PASS** | Diff: `sent_actions` DDL appended to `CreateTablesSql` in `CoreCacheRepository.Schema.cs` as `CREATE TABLE IF NOT EXISTS` (additive; same statement serves fresh and upgrade paths idempotently), plus the lazy once-per-instance ensure guard in `CoreCacheRepository.SentActions.cs`. Tests (all passing in the reviewer run): `InitializeAsync_twice_should_not_throw_and_sent_actions_should_exist` (migration twice is safe, table exists), `InitializeAsync_should_add_sent_actions_to_pre_existing_database` (upgrade path — database seeded with a pre-#101 shape, `sent_actions` absent before / present after), `Store_methods_should_work_on_fresh_database_without_InitializeAsync` (lazy ensure). |
+| AC-2 | **PASS** | `SentActionKey.Build` is a pure static function returning `$"{mailbox}:{messageId}:{actionType}"` with fail-fast per-component `ArgumentException` guards; the no-escaping/colon-free-distinctness limitation is documented in the XML remarks as the spec requires. Unit tests: 11 results (format, `ProposalReply` constant, 9 guard rows asserting parameter names). Property tests: 3 CsCheck properties — determinism, fixed component ordering under split, distinctness for colon-free triples — 1000 iterations each, exceeding the "at least one" T1 obligation. Reviewer cobertura: `SentActionKey.cs` 100% line / 100% branch. |
+| AC-3 | **PASS** | Implementation verified in diff: consult/skip/record sits entirely inside the pre-existing `SendEnabled` else-branch (`SchedulingWorker.Pipeline.cs` lines 129-157); hit path logs `LogInformation("Send for message {MessageId} already recorded under dedupe key {DedupeKey}; skipping.", ...)` with the required named template parameters and returns normally; miss path awaits `SendMailAsync` then `RecordAsync(dedupeKey, timeProvider.GetUtcNow(), ...)`. Tests: `RunCycle_StoreHit_SkipsSendAndCompletesWithoutThrowing` (skip + `NotThrowAsync` — normal, not failed, outcome), `RunCycle_StoreMiss_SendsThenRecordsKeyWithInjectedClockTimestamp` (records `Msg1Key` with the exact `FakeTimeProvider` value; call order `["send", "record"]` proven via callbacks). Fail-before EXIT 1 / pass-after EXIT 0 evidence: `evidence/regression-testing/dedupe-expect-fail.2026-07-02T12-10.md`, `dedupe-pass-after.2026-07-02T12-11.md`. Note: the log's message template and parameters are verified by code inspection rather than a capturing-logger assertion — recorded as a Minor, non-blocking finding in the code review; the criterion's behavioral requirements (skip, normal outcome, record-with-injected-timestamp) are each directly test-verified. |
+| AC-4 | **PASS** | `RunCycle_TwoWorkerStorePairsOverOneDatabase_SendExactlyOnceInTotal`: two worker/store pairs (fresh `CoreCacheRepository` instances, i.e., fresh lazy-ensure state) over one GUID-named shared in-memory SQLite database run two successive cycles on the same candidate; `SendMailAsync` verified `Times.Once` in total. This covers both the repeated-cycle case and the simulated-restart case in one test, exactly as the criterion specifies. Passing in the reviewer run. |
+| AC-5 | **PASS** | `RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate`: every send throws; the cycle does not throw (isolation via unchanged `ProcessMessageSafelyAsync` — `SchedulingWorker.cs` shows only the constructor-parameter addition in the diff); `RecordAsync` verified `Times.Never`; the second candidate is still hydrated. Correct-by-construction ordering: `RecordAsync` is only reachable after `SendMailAsync` completes (diff lines 152-157). Pre-existing `SchedulingWorkerTests` (13 tests) unregressed — the only change is the helper factory's default not-recorded store mock. |
+| AC-6 | **PASS** | Reviewer re-ran the full toolchain at branch head: `csharpier check .` EXIT 0 (212 files); `dotnet build` 0 warnings / 0 errors (analyzers + nullable as errors); NetArchTest 2/2; full solution tests 701 passed / 0 failed / 5 pre-existing env-gated skips; fresh coverage pooled 90.63% line / 80.25% branch (thresholds 85%/75%), T1 `OpenClaw.Core` package 98.66%/92.07%; new files 100%/100%; no changed-line regression vs independently re-parsed baseline (90.56%/80.05%; Pipeline.cs's 50% file branch rate is identical at baseline and attributable to two pre-existing untouched ternaries). MSTest + FluentAssertions + Moq throughout; no temp files (in-memory shared-cache SQLite only, reviewer-inspected); all 12 changed/new code files under 500 lines (max: Program.cs 329). The new dedupe logic's async body is uninstrumented under the pre-existing runsettings attribute exclusion and is behaviorally covered with fail-before/pass-after evidence (policy audit Section 8). |
+
+## Summary
+
+All six acceptance criteria evaluate to **PASS** against the full feature-vs-base diff, with each verdict backed by direct diff inspection, the reviewer's independent toolchain re-run and per-file cobertura re-measurement, and executor regression evidence. The policy audit (`policy-audit.2026-07-02T12-27.md`) is FULLY COMPLIANT with no Blocking findings; the code review (`code-review.2026-07-02T12-27.md`) records one Minor finding (dedupe-hit log content not test-asserted; follow-up recommended) and three Info observations, none requiring action on this branch. Remediation is not required. Recommendation: **Go for PR** targeting `main` (merge-commit policy). This feature closes the accepted duplicate-send interim risk carried from issue #99; the documented at-least-once window (crash between send and record) is an explicit, accepted Stage 0 trade-off.
+
+## Acceptance Criteria Check-off
+
+All six criteria were already checked off (`- [x]`) by the executor in all three source files (`spec.md`, `user-story.md`, and the `issue.md` mirror) at the time of this review. The reviewer independently verified each criterion as PASS above; per the acceptance-criteria-tracking protocol, no check-off edits were needed and none were made. No criteria were left unchecked; no phantom criteria were added.
+
+### Acceptance Criteria Status
+- Source: `docs/features/active/2026-07-02-send-idempotency-dedupe-101/spec.md`, `docs/features/active/2026-07-02-send-idempotency-dedupe-101/user-story.md` (mirror: `issue.md`)
+- Total AC items: 6
+- Checked off (delivered): 6
+- Remaining (unchecked): 0
+- Items remaining: none

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/issue.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/issue.md
@@ -1,0 +1,53 @@
+# send-idempotency-dedupe (Issue #101)
+
+- Date captured: 2026-07-02
+- Author: drmoisan
+- Status: Promoted -> docs/features/active/send-idempotency-dedupe/ (Issue #101)
+
+- Issue: #101
+- Issue URL: https://github.com/drmoisan/open-claw-bridge/issues/101
+- Last Updated: 2026-07-02
+- Work Mode: full-feature
+
+## Problem / Why
+
+With `HostAdapterSchedulingService.SendMailAsync` now wired (issue #99 / PR #100), a retried or repeated scheduling cycle can resend the same reply: no dedupe-key concept exists in `SchedulingWorker`'s pipeline, `MailRoutes`, or `SendMailRpcHandler`. The master specification requires idempotency keys for mail sends with an internal dedupe key shaped like `{tenantId}:{mailboxUpn}:{messageId}:{actionType}` (`docs/open-claw-approach.master.md` §6.3); the Local MVP equivalent is a persisted per-message/action guard consulted before send. This was recorded as the accepted interim risk in the #99 spec, to be closed by this feature. Identified as gap F6 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`.
+
+## Proposed Behavior
+
+- Add a persisted `sent_actions` unit to `CoreCacheRepository` (new table via the established guarded-migration pattern) keyed by a deterministic dedupe key: `{mailbox}:{messageId}:{actionType}` (local single-mailbox form of the master's key; tenant component deferred to Stage 1).
+- `SchedulingWorker.ProposeAndActAsync` consults the store before invoking `ISchedulingService.SendMailAsync`; if the key exists, the send is skipped and logged as a dedupe hit. On successful send, the key is recorded in the same cycle.
+- Dedupe state survives process restart (persisted in the Core SQLite cache, not in-memory).
+- Recording uses the deterministic clock seam (`TimeProvider`/injected clock) for the timestamp column.
+
+## Acceptance Criteria
+
+- [x] A `sent_actions` table exists in the Core cache with an idempotent guarded migration (fresh-database and pre-existing-database upgrade paths both covered by tests; running the migration twice is safe).
+  - Evidence: `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md` (all `CoreCacheRepositorySentActionsTests` pass, including migration idempotency, pre-existing-database upgrade, and lazy schema-ensure)
+- [x] A pure, deterministic dedupe-key builder produces `{mailbox}:{messageId}:{actionType}` and is unit-tested, including at least one CsCheck property test per T1 convention (determinism, component ordering, and distinctness for colon-free inputs).
+  - Evidence: `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md` (`SentActionKeyTests` + `SentActionKeyPropertyTests` all passing; 100% file coverage per `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md`)
+- [x] Inside the existing `SendEnabled`-gated block, `SchedulingWorker` consults the store before sending: on a hit it skips the send and logs a structured dedupe-hit message (message id and dedupe key as named template parameters), completing the message as a normal (not failed) outcome; on a miss it sends and then records the key with a timestamp from the injected `TimeProvider`.
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (fail-before counterpart: `evidence/regression-testing/dedupe-expect-fail.2026-07-02T12-10.md`)
+- [x] A repeated worker cycle for the same candidate message does not invoke `ISchedulingService.SendMailAsync` a second time, including across a simulated restart (new worker and store instances over the same in-memory shared-cache SQLite database).
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (`RunCycle_TwoWorkerStorePairsOverOneDatabase_SendExactlyOnceInTotal`)
+- [x] A failed send does NOT record the key (retry remains possible), and the failure stays isolated to that message per the existing `ProcessMessageSafelyAsync` behavior.
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (`RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate`)
+- [x] Full C# toolchain passes (format, lint, type-check, architecture, tests); coverage thresholds hold (line >= 85%, branch >= 75%) with changed lines covered; MSTest + FluentAssertions + Moq; no temp files in tests; all files remain under the 500-line cap.
+  - Evidence: `evidence/qa-gates/final-format.2026-07-02T12-12.md`, `evidence/qa-gates/final-build.2026-07-02T12-13.md`, `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md`, `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md`, `evidence/other/scope-and-size-verification.2026-07-02T12-18.md`
+
+## Constraints & Risks
+
+- Keep the store consult/record inside the existing `SendEnabled`-gated block so the kill switch remains the outer boundary.
+- No temp files in tests (in-memory shared-cache SQLite pattern); MSTest + FluentAssertions + Moq; CsCheck available for property tests; 500-line cap (new table logic goes in a new `CoreCacheRepository.SentActions.cs` partial).
+- Recording after send introduces a small at-least-once window (crash between send and record); document as accepted for Stage 0, consistent with the master's queue-retry semantics.
+
+## Test Conditions to Consider
+
+- [ ] Unit: dedupe-key builder determinism and component ordering.
+- [ ] Unit: repository record/exists round-trip, migration idempotency.
+- [ ] Unit: worker skip-on-hit, record-on-success, no-record-on-failure, kill-switch composition.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template)
+- [ ] Create active feature folder from the template

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/plan.2026-07-02T11-40.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/plan.2026-07-02T11-40.md
@@ -1,0 +1,125 @@
+# send-idempotency-dedupe - Plan
+
+- **Issue:** #101
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-07-02T11-40
+- **Status:** Draft
+- **Version:** 1.0
+- **Work Mode:** full-feature
+
+## Required References
+
+- General Coding Standards: [`.claude/rules/general-code-change.md`](../../../../.claude/rules/general-code-change.md)
+- General Unit Test Policy: [`.claude/rules/general-unit-test.md`](../../../../.claude/rules/general-unit-test.md)
+- C# Standards: [`.claude/rules/csharp.md`](../../../../.claude/rules/csharp.md)
+- Architecture Boundaries: [`.claude/rules/architecture-boundaries.md`](../../../../.claude/rules/architecture-boundaries.md)
+- Quality Tiers: [`.claude/rules/quality-tiers.md`](../../../../.claude/rules/quality-tiers.md)
+- Authoritative requirements: `docs/features/active/2026-07-02-send-idempotency-dedupe-101/spec.md` (6 acceptance criteria), with `issue.md` and `user-story.md` as supporting context
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Conventions Used Throughout This Plan
+
+- `<FEATURE>` = `docs/features/active/2026-07-02-send-idempotency-dedupe-101`
+- `<TS>` = execution-time ISO-8601 timestamp in `yyyy-MM-ddTHH-mm` form (fill in at execution)
+- All evidence artifacts go under `<FEATURE>/evidence/<kind>/` per `.claude/skills/evidence-and-timestamp-conventions/SKILL.md`. Raw tool intermediates (TRX, Cobertura XML, TestResults directories) go under `artifacts/csharp/`; evidence artifacts summarize them and record `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`.
+- CSharpier is the global tool (1.3.0): use `csharpier format .` / `csharpier check .` (not `dotnet csharpier`; the repo has no local tool manifest).
+- Test stack: MSTest + FluentAssertions + Moq + CsCheck + `FakeTimeProvider` (`Microsoft.Extensions.TimeProvider.Testing`). No temp files in tests; use the in-memory shared-cache SQLite pattern from `tests/OpenClaw.Core.Tests/CoreCacheRepositoryResponseStatusTests.cs`.
+- Diff-scope confinement (production code): only `src/OpenClaw.Core/Agent/SentActionKey.cs` (new), `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs` (new), `src/OpenClaw.Core/CoreCacheRepository.Schema.cs`, `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` (new), `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs`, `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs`, `src/OpenClaw.Core/Program.cs`. No changes under `src/OpenClaw.HostAdapter/`, `src/OpenClaw.MailBridge/`, or any `*.Contracts` wire surface.
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Baseline Capture & Policy Compliance
+
+- [x] [P0-T1] Read repository policies in the required order: `CLAUDE.md`-loaded rules, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/csharp.md`, `.claude/rules/architecture-boundaries.md`, `.claude/rules/quality-tiers.md`
+  - Acceptance: `<FEATURE>/evidence/baseline/phase0-instructions-read.md` exists with `Timestamp:`, `Policy Order:`, and the explicit list of files read
+- [x] [P0-T2] Capture the formatting baseline by running `csharpier check .` from the repo root
+  - Acceptance: `<FEATURE>/evidence/baseline/baseline-format.<TS>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (pass/fail and any unformatted-file count)
+- [x] [P0-T3] Capture the build/lint/type-check baseline by running `dotnet build OpenClaw.MailBridge.sln` from the repo root
+  - Acceptance: `<FEATURE>/evidence/baseline/baseline-build.<TS>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (warning/error counts; analyzers and nullable analysis run in this step)
+- [x] [P0-T4] Capture the test-and-coverage baseline by running `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory artifacts/csharp/baseline-101` from the repo root
+  - Acceptance: `<FEATURE>/evidence/baseline/baseline-test-coverage.<TS>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE:`, and an `Output Summary:` containing pass/fail counts and the numeric baseline line-coverage and branch-coverage percentages read from the generated Cobertura report under `artifacts/csharp/baseline-101/` (no placeholders such as UNVERIFIED)
+
+### Phase 1 — Pure Dedupe-Key Builder (SentActionKey)
+
+- [x] [P1-T1] Create `src/OpenClaw.Core/Agent/SentActionKey.cs`: a pure static class with `public const string ProposalReply = "proposal-reply";` and `public static string Build(string mailbox, string messageId, string actionType)` returning `{mailbox}:{messageId}:{actionType}` joined with `:` in that fixed order; throw `ArgumentException` (naming the offending parameter) for any null, empty, or whitespace-only component; document in XML docs that components are not escaped and key distinctness is guaranteed only for colon-free components
+  - Acceptance: file exists, compiles under `dotnet build OpenClaw.MailBridge.sln`, contains no clock or I/O dependency, and is under 500 lines
+- [x] [P1-T2] Create `tests/OpenClaw.Core.Tests/Agent/SentActionKeyTests.cs` with MSTest + FluentAssertions unit tests: (a) `Build("owner@contoso.com", "msg-1", SentActionKey.ProposalReply)` returns `"owner@contoso.com:msg-1:proposal-reply"`; (b) `ProposalReply` equals `"proposal-reply"`; (c) `Build` throws `ArgumentException` for null, empty, and whitespace-only values of each of the three components (parameterized via `[DataRow]`)
+  - Acceptance: file exists in the `tests/` tree (not colocated), each test has Arrange–Act–Assert structure and a descriptive name, and all tests in the file pass
+- [x] [P1-T3] Create `tests/OpenClaw.Core.Tests/Agent/SentActionKeyPropertyTests.cs` with CsCheck property tests: (a) determinism — the same `(mailbox, messageId, actionType)` triple always yields the same key; (b) component ordering — the produced key, split on `:` for colon-free inputs, yields the components in `{mailbox}:{messageId}:{actionType}` order; (c) distinctness — distinct colon-free non-whitespace component triples yield distinct keys; generators must exclude null/empty/whitespace and colon-containing strings where the property requires it
+  - Acceptance: file exists, uses CsCheck (already referenced by `OpenClaw.Core.Tests.csproj`), and all property tests pass with reproducible seeds on failure
+- [x] [P1-T4] Verify Phase 1 by running `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SentActionKey"` from the repo root
+  - Acceptance: exit code 0 with all `SentActionKey*` tests passing
+
+### Phase 2 — Store Contract, Schema, and Repository Partial
+
+- [x] [P2-T1] Create `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs` declaring `public interface ISentActionStore` with `Task<bool> IsRecordedAsync(string dedupeKey, CancellationToken ct);` and `Task RecordAsync(string dedupeKey, DateTimeOffset recordedAtUtc, CancellationToken ct);`, with XML docs stating the caller supplies the timestamp (the store has no clock dependency) and that `RecordAsync` is idempotent
+  - Acceptance: file exists alongside `ISchedulingService.cs`, compiles, interface-only (no executable behavior), under 500 lines
+- [x] [P2-T2] Update `src/OpenClaw.Core/CoreCacheRepository.Schema.cs` by appending the `sent_actions` DDL to `CreateTablesSql`: `CREATE TABLE IF NOT EXISTS sent_actions(dedupe_key TEXT PRIMARY KEY, mailbox TEXT NOT NULL, message_id TEXT NOT NULL, action_type TEXT NOT NULL, recorded_at_utc TEXT NOT NULL);`
+  - Acceptance: DDL appended verbatim inside `CreateTablesSql`; no existing table, column, or migration statement modified; file remains under 500 lines
+- [x] [P2-T3] Create `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs`: a new partial declaring `internal sealed partial class CoreCacheRepository : ISentActionStore` that implements `IsRecordedAsync` (exact-key `SELECT 1 FROM sent_actions WHERE dedupe_key = $key LIMIT 1`, parameterized) and `RecordAsync` (`INSERT INTO sent_actions(...) VALUES (...) ON CONFLICT(dedupe_key) DO NOTHING`, parameterized, storing the three components parsed from the key's fixed `{mailbox}:{messageId}:{actionType}` shape and `recorded_at_utc` as `recordedAtUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture)`), plus a lazy once-per-repository-instance schema-ensure guard that executes the `sent_actions` `CREATE TABLE IF NOT EXISTS` before the first store operation so the store is safe without a prior `InitializeAsync` call; follow the existing per-call `Open()`/parameterized-command pattern
+  - Acceptance: file exists, compiles, contains no `DateTime.UtcNow`/`DateTime.Now`/`TimeProvider` usage (timestamp is caller-supplied), and is under 500 lines
+- [x] [P2-T4] Create `tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs` (MSTest + FluentAssertions, in-memory shared-cache SQLite with anchor connections, no temp files) covering: (a) `IsRecordedAsync` returns false for an unknown key; (b) `RecordAsync` then `IsRecordedAsync` returns true; (c) duplicate `RecordAsync` for the same key does not throw and leaves one row; (d) `recorded_at_utc` round-trips the caller-supplied timestamp in ISO-8601 "O" form (read back via a direct query on the anchor connection); (e) migration idempotency — `InitializeAsync` twice does not throw and `sent_actions` exists; (f) pre-existing-database upgrade — seed a database with the current tables but without `sent_actions`, then `InitializeAsync` adds it; (g) lazy schema-ensure — store methods work on a fresh database with no prior `InitializeAsync` call
+  - Acceptance: file exists in the `tests/` tree, all seven scenarios present as individually named tests, all pass, file under 500 lines
+- [x] [P2-T5] Verify Phase 2 by running `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~CoreCacheRepositorySentActions"` from the repo root
+  - Acceptance: exit code 0 with all `CoreCacheRepositorySentActionsTests` passing
+
+### Phase 3 — Worker Seam Wiring and Expect-Fail Dedupe Tests (Test-First)
+
+- [x] [P3-T1] Update `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs` by adding `ISentActionStore sentActionStore` to the primary constructor (after `ISchedulingService schedulingService`, before `ISchedulingCandidateSource candidateSource` or in a position consistent with existing ordering); make no pipeline behavior change in this task
+  - Acceptance: constructor parameter added; no other production logic changed; file remains under 500 lines
+- [x] [P3-T2] Update `src/OpenClaw.Core/Program.cs` by registering `builder.Services.AddSingleton<ISentActionStore>(sp => sp.GetRequiredService<CoreCacheRepository>());` adjacent to the existing D5/D6 singleton registrations (lines 62–66 area)
+  - Acceptance: registration present; `dotnet build src/OpenClaw.Core/OpenClaw.Core.csproj` succeeds (the solution build is deferred to P3-T3, which updates the test project's `Worker(...)` helper to the new constructor shape); no other `Program.cs` change
+- [x] [P3-T3] Update the `Worker(...)` helper in `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs` to construct and pass a default `Mock<ISentActionStore>` whose `IsRecordedAsync` returns `false`, so all existing worker tests compile and keep their current behavior
+  - Acceptance: `dotnet build OpenClaw.MailBridge.sln` succeeds and `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerTests"` passes with no existing assertion weakened; file remains under 500 lines
+- [x] [P3-T4] Create `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` following the `SchedulingWorkerTests.cs` mock conventions (Moq, `FakeTimeProvider`, `NullLogger`, `Options(sendEnabled: ...)`) with five tests: (a) skip-on-hit — mocked `ISentActionStore.IsRecordedAsync` returns true; `SendMailAsync` is never invoked and the cycle completes without throwing; (b) record-on-success — on a miss, `RecordAsync` is invoked exactly once with the key `SentActionKey.Build("owner@contoso.com", "msg-1", SentActionKey.ProposalReply)` and the `FakeTimeProvider` timestamp, and the send occurs before the record (verify via Moq callback sequencing); (c) no-record-on-failure — `IsRecordedAsync` is consulted once, `SendMailAsync` throws, `RecordAsync` is never invoked, and the next candidate is still processed; (d) kill-switch composition — with `SendEnabled=false`, neither `IsRecordedAsync` nor `RecordAsync` is invoked and the existing "SendEnabled is false" behavior is unchanged; (e) restart persistence — using a real `CoreCacheRepository` store over one shared in-memory SQLite database, two successive worker/store instance pairs process the same candidate and `SendMailAsync` is invoked exactly once in total
+  - Acceptance: file exists in the `tests/` tree, compiles, contains all five tests with Arrange–Act–Assert structure and descriptive names, no temp files, file under 500 lines
+- [x] [P3-T5] [expect-fail] Run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerDedupeTests"` before the pipeline change lands and record the fail-before evidence: tests (a) skip-on-hit, (b) record-on-success, (c) no-record-on-failure, and (e) restart persistence are expected to FAIL (the worker does not yet consult or write the store); test (d) kill-switch composition is expected to PASS (the store is untouched today)
+  - Acceptance: `<FEATURE>/evidence/regression-testing/dedupe-expect-fail.<TS>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE:` (non-zero), and an `Output Summary:` listing each of the five tests with its observed outcome matching the expectations above
+
+### Phase 4 — Pipeline Consult-Before-Send / Record-After-Success
+
+- [x] [P4-T1] Update `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` inside the existing `SendEnabled`-gated `else` branch of `ProposeAndActAsync` (currently lines 120–132): build `var dedupeKey = SentActionKey.Build(MailboxUpn(), messageId, SentActionKey.ProposalReply);`; if `await sentActionStore.IsRecordedAsync(dedupeKey, cancellationToken)` is true, log one Information-level structured message with named template parameters `{MessageId}` and `{DedupeKey}` (matching the file's existing logging pattern) and return normally without sending; otherwise invoke `SendMailAsync` and, after it completes successfully, `await sentActionStore.RecordAsync(dedupeKey, timeProvider.GetUtcNow(), cancellationToken)`; a thrown send exception must propagate before the record step so `ProcessMessageSafelyAsync` isolation is unchanged; the `SendEnabled == false` path and its log line must be untouched
+  - Acceptance: consult/record logic lives entirely inside the `SendEnabled` `else` branch; no `DateTime.UtcNow` added; file remains under 500 lines
+- [x] [P4-T2] Run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerDedupeTests"` and record the pass-after evidence for the Phase 3 expect-fail tests
+  - Acceptance: `<FEATURE>/evidence/regression-testing/dedupe-pass-after.<TS>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and an `Output Summary:` showing all five dedupe tests passing
+- [x] [P4-T3] Run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorker"` to confirm the pre-existing worker suite (kill switches, failure isolation, send composition) shows no regression alongside the new dedupe suite
+  - Acceptance: exit code 0; all `SchedulingWorkerTests` and `SchedulingWorkerDedupeTests` tests pass with no assertion weakened
+
+### Phase 5 — Final QA Loop, Coverage Comparison, and Scope Verification
+
+Run P5-T1 through P5-T3 as the mandatory toolchain loop: if any step fails or changes files, fix and restart the loop from P5-T1 until all three complete cleanly in a single pass. `EXIT_CODE: SKIPPED` is not a valid outcome for any task in this phase.
+
+- [x] [P5-T1] Run `csharpier format .` then `csharpier check .` from the repo root (formatting gate)
+  - Acceptance: `<FEATURE>/evidence/qa-gates/final-format.<TS>.md` exists with `Timestamp:`, `Command:` (both commands), `EXIT_CODE: 0` for the check, and an `Output Summary:` stating whether `csharpier format` changed any files (a changed file restarts the loop)
+- [x] [P5-T2] Run `dotnet build OpenClaw.MailBridge.sln` from the repo root (lint + nullable type-check gate via the analyzer stack with `TreatWarningsAsErrors=true`)
+  - Acceptance: `<FEATURE>/evidence/qa-gates/final-build.<TS>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and an `Output Summary:` (0 warnings, 0 errors)
+- [x] [P5-T3] Run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory artifacts/csharp/final-101` from the repo root (full test gate including the architecture-boundary tests, unit tests, and property tests, in coverage mode)
+  - Acceptance: `<FEATURE>/evidence/qa-gates/final-test-coverage.<TS>.md` exists with `Timestamp:`, `Command:`, `EXIT_CODE: 0`, and an `Output Summary:` containing pass/fail counts and the numeric post-change line-coverage and branch-coverage percentages read from the Cobertura report under `artifacts/csharp/final-101/`
+- [x] [P5-T4] Produce the coverage comparison: read the baseline Cobertura report (`artifacts/csharp/baseline-101/`) and the final report (`artifacts/csharp/final-101/`) and record (a) baseline line/branch coverage, (b) post-change line/branch coverage, (c) per-file line coverage for every changed/new production file (`SentActionKey.cs`, `CoreCacheRepository.SentActions.cs`, `SchedulingWorker.cs`, `SchedulingWorker.Pipeline.cs`, `CoreCacheRepository.Schema.cs`, `Program.cs`), and (d) a verdict that line coverage >= 85%, branch coverage >= 75%, and changed-line coverage did not regress; `ISentActionStore.cs` is interface-only and may be noted as legitimately excluded from executable coverage
+  - Acceptance: `<FEATURE>/evidence/qa-gates/coverage-comparison.<TS>.md` exists with `Timestamp:`, both numeric coverage sets, per-file figures, and an explicit PASS/FAIL verdict per threshold; if any required numeric value is unavailable the task outcome is remediation-required, never PASS
+- [x] [P5-T5] Verify scope and size invariants: (a) every production file in the diff is one of the seven files listed in the Conventions section (no HostAdapter, MailBridge, or Contracts-wire changes) via `git diff --name-only` against the branch base; (b) every new or modified production and test file is under 500 lines via a line count; (c) no test creates temp files (inspect the two new SQLite test files for the in-memory shared-cache pattern only)
+  - Acceptance: `<FEATURE>/evidence/other/scope-and-size-verification.<TS>.md` exists with `Timestamp:`, the `git diff --name-only` file list, per-file line counts, and a PASS/FAIL verdict for each of (a)–(c)
+- [x] [P5-T6] Update `<FEATURE>/spec.md`, `<FEATURE>/issue.md`, and `<FEATURE>/user-story.md` acceptance-criteria checkboxes to reflect verified outcomes, citing the evidence artifact path for each criterion
+  - Acceptance: each of the six acceptance criteria is checked only where a named evidence artifact under `<FEATURE>/evidence/` supports it; no criterion is checked without cited evidence
+
+## Test Plan
+
+- Unit (pure): `tests/OpenClaw.Core.Tests/Agent/SentActionKeyTests.cs` (format, constant, `ArgumentException` per component) and `tests/OpenClaw.Core.Tests/Agent/SentActionKeyPropertyTests.cs` (CsCheck: determinism, component ordering, colon-free distinctness) — AC-2.
+- Unit (repository): `tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs` (record/exists round-trip, duplicate-record idempotency, timestamp round-trip, `InitializeAsync` idempotency, pre-existing-database upgrade, lazy schema-ensure) — AC-1; in-memory shared-cache SQLite, no temp files.
+- Unit (worker): `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` (skip-on-hit with structured log outcome, record-on-success with `FakeTimeProvider` timestamp and send-before-record ordering, no-record-on-failure with failure isolation, kill-switch composition, restart persistence over one shared database) — AC-3, AC-4, AC-5; existing `SchedulingWorkerTests.cs` guards against regression.
+- Toolchain: `csharpier format .`/`csharpier check .` → `dotnet build OpenClaw.MailBridge.sln` (analyzers + nullable) → `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"` (includes `AgentArchitectureBoundaryTests`) — AC-6.
+- Coverage evidence:
+  - Baseline artifact: `<FEATURE>/evidence/baseline/baseline-test-coverage.<TS>.md` (raw: `artifacts/csharp/baseline-101/`)
+  - Post-change artifact: `<FEATURE>/evidence/qa-gates/final-test-coverage.<TS>.md` (raw: `artifacts/csharp/final-101/`)
+  - Comparison artifact: `<FEATURE>/evidence/qa-gates/coverage-comparison.<TS>.md`
+- Fail-before/pass-after evidence: `<FEATURE>/evidence/regression-testing/dedupe-expect-fail.<TS>.md` (P3-T5) and `<FEATURE>/evidence/regression-testing/dedupe-pass-after.<TS>.md` (P4-T2).
+
+## Open Questions / Notes
+
+- `.claude/rules/csharp.md` names xUnit/NSubstitute as defaults, but the spec and the repository's actual test stack are MSTest + FluentAssertions + Moq (see `SchedulingWorkerTests.cs`, `CoreCacheRepositoryResponseStatusTests.cs`); this plan follows the established in-repo stack per the spec.
+- `CoreCacheRepository` is `internal sealed`; the new partial implements the public `ISentActionStore` interface, and the DI registration in `Program.cs` resolves the same singleton instance, matching the spec's D5/D6 pattern.
+- No README or configuration-doc changes are required: the feature adds no config keys, flags, routes, or CLI surface (spec "Inputs / Outputs").
+- The at-least-once window (crash between send and record) is accepted for Stage 0 per the spec; `RecordAsync`'s conflict-tolerant insert covers the recovery path. No task addresses exactly-once delivery (non-goal).
+- The dedupe key omits `{tenantId}` (local single-mailbox form); Stage 1 extends the builder rather than reinterpreting stored keys (spec "Constraints & Risks").

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/policy-audit.2026-07-02T12-27.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/policy-audit.2026-07-02T12-27.md
@@ -1,0 +1,457 @@
+# Policy Compliance Audit: send-idempotency-dedupe (#101)
+
+**Audit Date:** 2026-07-02
+**Code Under Test:** C# only. 3 new production `.cs` files in `src/OpenClaw.Core` (`Agent/SentActionKey.cs` pure static dedupe-key builder, 57 lines; `Agent/Contracts/ISentActionStore.cs` interface-only store contract, 29 lines; `CoreCacheRepository.SentActions.cs` store implementation partial with lazy schema-ensure, 106 lines), 4 modified production `.cs` files (`Agent/Runtime/SchedulingWorker.Pipeline.cs` consult/skip/record logic inside the `SendEnabled` else-branch; `Agent/Runtime/SchedulingWorker.cs` one constructor parameter; `CoreCacheRepository.Schema.cs` one appended `CREATE TABLE IF NOT EXISTS sent_actions` DDL statement; `Program.cs` one DI registration), 4 new test `.cs` files and 1 modified test `.cs` file. Plus feature scoping/evidence Markdown (feature folder for issue #101). No Python, PowerShell, TypeScript, Bash, or governed JSON files changed in the branch diff.
+
+**Scope:** Full feature branch `feature/send-idempotency-dedupe-101` @ `a3521833996bbf66e6d0e0ddedaebfaf8dcc85ec` versus resolved base `main` @ merge-base `d90681c766d8a9b9cff93fd59bc1989c80632d1f` (origin/main; the local `main` ref is stale per the caller inputs). Scope is feature-vs-base over the complete branch diff. Diff file breakdown (name-only): 12 `.cs`, 15 `.md` (27 files, +1494/-3). Work mode: `full-feature` (persisted marker `- Work Mode: full-feature` in `issue.md`); acceptance-criteria sources are `spec.md` and `user-story.md`.
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| C# | 7 production `.cs` + 5 test `.cs` | 706 (solution) / 254 (Core.Tests) | 701 pass, 0 fail, 5 env-gated skips | 90.56% line, 80.05% branch (pooled solution) | 90.63% line, 80.25% branch (pooled solution) | SentActionKey.cs 100% line / 100% branch; CoreCacheRepository.SentActions.cs 100% line / 100% branch (instrumented lines; async bodies behaviorally covered by 8 repository tests); ISentActionStore.cs interface-only (legitimately excluded per policy); all 4 modified files 100% line with no changed-line regression |
+
+**Note:** Python, PowerShell, Bash, TypeScript, and governed-JSON rows are omitted because the branch diff contains no changed files in those languages. Coverage verdicts are therefore C#-only; no other language has changed files on the branch. The C# coverage verdict is an explicit PASS.
+
+### Coverage Evidence Checklist
+
+- C# baseline coverage artifact: `docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/baseline/baseline-test-coverage.2026-07-02T11-59.md` (pooled 90.56% line / 80.05% branch; `OpenClaw.Core` package 98.63% line / 91.82% branch); reviewer independently re-parsed the executor baseline cobertura under `artifacts/csharp/baseline-101/` and confirmed the figures exactly
+- C# post-change coverage artifact: `docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md` and `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md` (pooled 90.63% line / 80.25% branch; `OpenClaw.Core` package 98.66% line / 92.07% branch)
+- Reviewer-regenerated cobertura (this audit, fresh `dotnet test` at branch head): `docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/coverage-review/{0a055268...,46036f31...,fed5a0ea...}/coverage.cobertura.xml`; independently parsed pooled 90.63% line (4207/4642) / 80.25% branch (947/1180), identical to executor evidence. Reviewer evidence: `docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/coverage-review.2026-07-02T12-27.md`
+- Per-language comparison summary: Section 1.2.1 below
+- TypeScript baseline coverage artifact: `N/A - out of scope`
+- TypeScript post-change coverage artifact: `N/A - out of scope`
+- PowerShell baseline coverage artifact: `N/A - out of scope`
+- PowerShell post-change coverage artifact: `N/A - out of scope`
+- Python / TypeScript / PowerShell coverage artifacts: `N/A - no changed files in those languages on the branch`
+
+**Non-negotiable verdict rule:** This audit includes numeric baseline and post-change coverage metrics for the only in-scope language (C#), plus per-changed-file line AND branch coverage re-measured by the reviewer from fresh cobertura. The C# coverage gate is met (pooled line 90.63% >= 85%, branch 80.25% >= 75%; both instrumented new files at 100% line / 100% branch; every instrumented changed line is covered; no regression — pooled coverage improved by +0.07pp line / +0.20pp branch).
+
+---
+
+## Executive Summary
+
+This feature branch closes issue #101 (gap F6, the accepted interim duplicate-send risk from #99): the scheduling worker now enforces send idempotency. A pure static builder (`SentActionKey.Build`) produces the deterministic dedupe key `{mailbox}:{messageId}:{actionType}` with fail-fast `ArgumentException` guards on each component; a new `sent_actions` table joins the Core SQLite cache via the established `CREATE TABLE IF NOT EXISTS` guarded-migration pattern plus a lazy once-per-instance schema-ensure guard that removes the hosted-service initialization-ordering dependency; `CoreCacheRepository` implements the new clock-free `ISentActionStore` (`IsRecordedAsync` exact-key lookup; `RecordAsync` conflict-tolerant `INSERT ... ON CONFLICT(dedupe_key) DO NOTHING` with caller-supplied timestamp stored in ISO-8601 round-trip form); and `SchedulingWorker.ProposeAndActAsync` consults the store before `SendMailAsync` and records after a successful send, entirely inside the existing `SendEnabled`-gated else-branch so the kill switch remains the outer boundary. A failed send records nothing, preserving retry via the unchanged `ProcessMessageSafelyAsync` isolation. No HostAdapter, MailBridge, contract, route, or schema-wire surface changed — verified against the full diff.
+
+The mandatory toolchain was independently re-run by the reviewer against the branch head `a352183` and passes in a single pass:
+- **Formatting:** `csharpier check .` (CSharpier 1.3.0) — "Checked 212 files", EXIT 0, no diffs.
+- **Lint + nullable type-check + analyzers:** `dotnet build OpenClaw.MailBridge.sln` — Build succeeded, 0 Warning(s), 0 Error(s) (AnalysisLevel=latest-all, AnalysisMode=All, TreatWarningsAsErrors=true per Directory.Build.props).
+- **Architecture-boundary tests:** NetArchTest suite in `OpenClaw.Core.Tests` — 2 passed, 0 failed.
+- **Tests + coverage:** full solution `dotnet test` with `--collect:"XPlat Code Coverage"` — 701 passed, 0 failed, 5 environment-gated skips (same skips as baseline); pooled coverage 90.63% line / 80.25% branch, above the uniform gates; T1 property-test obligation for the new pure function satisfied by `SentActionKeyPropertyTests` (3 CsCheck properties, 1000 iterations each, seed printed on failure per suite convention).
+- **Regression evidence:** fail-before artifact (EXIT 1; the five new dedupe tests failing before the worker seam existed) and pass-after artifact (EXIT 0) are present under `evidence/regression-testing/`.
+
+No Blocking findings. No material PARTIAL findings. One Minor finding (dedupe-hit log line verified by code inspection, not content-asserted in a test) and three informational observations (Section 8 and the code review). Remediation is not required. The feature is recommended Go for PR.
+
+**Policy documents evaluated:**
+- `.claude/rules/general-code-change.md`
+- `.claude/rules/general-unit-test.md`
+- `.claude/rules/quality-tiers.md`
+- `.claude/rules/architecture-boundaries.md`
+- `.claude/rules/csharp.md`
+- `.claude/rules/ci-workflows.md` (not triggered — no workflow changes)
+- `.claude/rules/benchmark-baselines.md` (not triggered — no baseline changes)
+- `.claude/rules/tonality.md`
+
+**Language-specific policies evaluated:**
+- C#: `.claude/rules/csharp.md`
+- N/A Python / PowerShell / Bash / TypeScript / governed JSON (no changed files on the branch)
+
+**Temporary artifacts cleanup:**
+- No temporary or throwaway scripts were introduced by this feature; the diff is seven production files, five test files, and documentation/evidence Markdown. The executor's raw cobertura intermediates under `artifacts/csharp/baseline-101/` and `artifacts/csharp/final-101/` are untracked (gitignored) and do not appear in the diff.
+
+---
+
+## Rejected Scope Narrowing
+
+None. The caller prompt instructed execution of the full `feature-review-workflow` contract, supplied the authoritative base branch (`main`), merge-base SHA (`d90681c`), the checked-out feature branch, and refreshed PR-context artifacts, and stated "Scope determination is your responsibility per your skill contract." No instruction attempted to narrow scope to a plan/task/phase subset, to a file subset, or to mark any in-scope language as out-of-scope or informational-only.
+
+Observation (not a narrowing instruction, recorded for completeness): the PR-context summary's "Changed files overview" reports "Core logic changes: 0 files" and categorizes the branch as docs/tooling only. That categorization is inaccurate; the authoritative `git diff d90681c..a352183` contains 7 production C# files and 5 test C# files. The audit used the authoritative git diff file list, not the summary categorization. No scope was narrowed.
+
+---
+
+## Evidence Location Compliance
+
+The branch diff was scanned for evidence files written under the non-canonical roots `artifacts/baselines/`, `artifacts/baseline/`, `artifacts/qa/`, `artifacts/qa-gates/`, `artifacts/evidence/`, `artifacts/coverage/`, `artifacts/regression-testing/`, or `artifacts/post-change/`.
+
+- Command: `git diff --name-only d90681c..HEAD | grep -E '^artifacts/(baselines|baseline|qa|qa-gates|evidence|coverage|regression-testing|post-change)/'`
+- Result: **NONE.** All feature evidence in the diff is written to the canonical `docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/<kind>/` locations (baseline, qa-gates, regression-testing, other). No files under `artifacts/` are tracked in the diff at all.
+- Verdict: **PASS** — no evidence-location violations. No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` events occurred during this review; the reviewer's own evidence was written to the canonical `evidence/qa-gates/` path.
+
+Note: the repository does not contain a `validate_evidence_locations.py` script (consistent with the prior #70, #80, #19, #18, and #99 audits); the scan was performed by direct diff inspection. The executor's untracked raw cobertura copies under `artifacts/csharp/baseline-101/` and `artifacts/csharp/final-101/` are non-evidence coverage tooling intermediates at a path the feature-review skill itself designates for C# coverage; the canonical feature evidence lives under `evidence/baseline/` and `evidence/qa-gates/`.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** — Tests run in any order | PASS | Every repository test builds its own uniquely-named in-memory shared-cache database (`Data Source=core-sa-<label>-<guid>` / `worker-dedupe-<guid>`); every worker test builds a fresh mock graph via `ServiceReturningContext()`/`CandidateSource()`/`Store()` helpers; property tests are pure. No shared mutable state. 254/254 Core.Tests pass in a single reviewer run. |
+| **Isolation** — Each test targets single behavior | PASS | Each dedupe test pins one seam behavior (hit-skip, miss-send-record ordering, failure no-record + isolation, kill-switch composition, restart persistence); each repository test pins one store behavior (round-trip, duplicate idempotency, timestamp form, migration idempotency, upgrade, malformed key, lazy ensure); each builder test pins format, constant, or one guard. |
+| **Fast Execution** | PASS | `OpenClaw.Core.Tests` completes 254 tests in ~1 s (reviewer run); all new tests are in-memory (mocks or in-memory SQLite). |
+| **Determinism** | PASS | No wall-clock reads, sleeps, timers, network, or filesystem in any new test. `FakeTimeProvider(Now)` supplies the clock; the recorded timestamp is asserted against the fake value. CsCheck property tests follow the suite's seeded-sample convention (failing seed printed on `Sample` failure, documented in the class XML doc). |
+| **Readability & Maintainability** | PASS | Descriptive names (`RunCycle_StoreMiss_SendsThenRecordsKeyWithInjectedClockTimestamp`, `InitializeAsync_should_add_sent_actions_to_pre_existing_database`), FluentAssertions with reason strings throughout, XML doc summaries on all four new test classes citing the AC anchors, Arrange/Act/Assert comments. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | PASS | Baseline pooled: 90.56% line, 80.05% branch; `OpenClaw.Core` package 98.63% line / 91.82% branch. Source: `evidence/baseline/baseline-test-coverage.2026-07-02T11-59.md`; independently re-parsed by the reviewer from `artifacts/csharp/baseline-101/` cobertura with identical results. |
+| **No Coverage Regression** | PASS | Post-change pooled: 90.63% line, 80.25% branch (+0.07pp / +0.20pp); Core package 98.66% / 92.07% (+0.03pp / +0.25pp). Independently confirmed from reviewer cobertura (this audit). |
+| **New Code Coverage** | PASS | Per-changed-file (reviewer cobertura, line AND branch): `SentActionKey.cs` (new) 100% line (21/21) / 100% branch (6/6). `CoreCacheRepository.SentActions.cs` (new) 100% line (10/10) / 100% branch (6/6) on instrumented lines; async method bodies are uninstrumented per the pre-existing runsettings attribute exclusion and are behaviorally covered by 8 repository tests including the 4-row malformed-key negative test (Section 8 informational note). `ISentActionStore.cs` (new) is interface-only with no executable lines — legitimately excluded per the type-only-module policy clarification. Modified files: `SchedulingWorker.Pipeline.cs` 100% line (20/20) / 50% branch (2/4) — both partial conditions are on pre-existing lines 170 and 177 untouched by this branch (diff hunks add lines 129-151 and 155-157 only) and the file was identically 20/20 line, 2/4 branch at baseline, so there is no changed-line regression; `SchedulingWorker.cs`, `CoreCacheRepository.Schema.cs`, and `Program.cs` all 100% line. New test files are excluded from coverage measurement per policy (`[*.Tests]*` exclude in `mailbridge.runsettings`). |
+| **Comprehensive Coverage** | PASS | Builder format/constant/guards + 3 properties; store round-trip, duplicate idempotency, UTC-normalized ISO-8601 timestamp form, migration idempotency, pre-existing-database upgrade, malformed-key rejection, lazy schema-ensure; worker hit-skip, miss-send-record ordering, failure no-record with next-candidate processing, kill-switch composition, restart persistence over one shared database. Existing `SchedulingWorkerTests` (13-line helper change only) unregressed. |
+| **Positive Flows** | PASS | Build returns the colon-joined key; record-then-read returns true; miss path sends then records `Msg1Key` with the `FakeTimeProvider` timestamp; restart test sends exactly once in total. |
+| **Negative Flows** | PASS | `ArgumentException` per builder component (null/empty/whitespace x 3 via `[DataRow]`, parameter name asserted); malformed dedupe keys rejected by `RecordAsync` (4 data rows, `WithParameterName("dedupeKey")`); send failure records nothing. |
+| **Edge Cases** | PASS | Duplicate `RecordAsync` leaves exactly one row; non-UTC offset timestamp normalized to UTC `O` form; fresh database without `InitializeAsync` served by the lazy ensure guard; pre-existing database upgraded in place; distinctness property constrained to colon-free inputs matching the documented builder contract. |
+| **Error Handling** | PASS | `RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate` proves the throw propagates to `ProcessMessageSafelyAsync`, nothing is recorded, and the second candidate is still processed; builder and store guards fail fast with named parameters. |
+| **Concurrency** | PASS (addressed) | The lazy schema-ensure guard's benign race (non-synchronized `bool` over idempotent `CREATE TABLE IF NOT EXISTS` DDL) is documented in the production XML doc; restart test exercises two repository instances over one shared database. No other new concurrency surface. |
+| **State Transitions** | PASS | Store state transition (unrecorded -> recorded -> skip) covered across cycles and across simulated restart; kill-switch-off leaves state untouched (`IsRecordedAsync`/`RecordAsync` both `Times.Never`). |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- C#: Baseline: 90.56% line, 80.05% branch (pooled solution) -> Post-change: 90.63% line, 80.25% branch. Change: +0.07% line, +0.20% branch. New/changed-code coverage: SentActionKey.cs 100% line / 100% branch and CoreCacheRepository.SentActions.cs 100% line / 100% branch on instrumented lines with async bodies behaviorally covered; ISentActionStore.cs interface-only per policy; all four modified files 100% line with the only partial branches on two pre-existing untouched lines identical at baseline; new test files excluded from measurement per policy. Disposition: PASS (line >= 85%, branch >= 75%, no regression on changed lines). Evidence: `evidence/baseline/baseline-test-coverage.2026-07-02T11-59.md`, `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md`, `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md`, reviewer re-run `evidence/qa-gates/coverage-review.2026-07-02T12-27.md`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | PASS | FluentAssertions reason strings on every assertion ("the record must happen only after a successful send", "a duplicate record must not add a second row"); call-order assertion compares full sequences (`callOrder.Should().Equal(["send", "record"], ...)`); CsCheck prints the failing seed. |
+| **Arrange-Act-Assert Pattern** | PASS | All new tests carry explicit `// Arrange` / `// Act` / `// Assert` sections with scenario comments tied to the ACs. |
+| **Document Intent** | PASS | XML docs on all four new test classes state the AC mapping (AC-1, AC-2, AC-3/4/5) and, for the property class, the T1 obligation and seed-print behavior. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | PASS | No network, filesystem, COM, or external process; SQLite is in-memory shared-cache only; all worker seams mocked with Moq. |
+| **Use Mocks/Stubs** | PASS | Moq mocks for `ISchedulingService`/`ISchedulingCandidateSource`/`ISentActionStore` per suite convention; the restart test deliberately uses the real store over in-memory SQLite to prove persistence, matching the established `CoreCacheRepositoryResponseStatusTests` pattern. |
+| **Environment Stability** | PASS | No temporary files (verified by executor evidence `scope-and-size-verification.2026-07-02T12-18.md` section (c) and reviewer inspection: every connection string is `Mode=Memory;Cache=Shared` with a GUID name); no mutable global state; no environment variables read. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | PASS | This audit serves as the required policy review. No outstanding items. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | PASS | Issue #101, `spec.md` v0.2 (behavior, dedupe-key contract, migration and lazy-ensure design, at-least-once trade-off), user-story scenarios, and the F6 gap-analysis reference define the change precisely. |
+| **Read existing change plans** | PASS | `evidence/baseline/phase0-instructions-read.md` records the policy-order read; `plan.2026-07-02T11-40.md` present. |
+| **Document the plan** | PASS | `plan.2026-07-02T11-40.md` with per-phase evidence under `evidence/**`; completed tasks recorded in the PR-context summary. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | PASS | One pure static builder, one two-method interface, one repository partial following the existing per-call connection pattern, ~26 lines of worker logic, one DDL statement, one DI line. No new dependencies, no new abstractions beyond the single store seam. |
+| **Reusability** | PASS | Dedupe key construction centralized in `SentActionKey` (constant + builder) rather than inline string interpolation; store behavior behind `ISentActionStore` so the worker tests mock it and the repository implements it alongside its existing roles. |
+| **Extensibility** | PASS | The Stage 1 `{tenantId}` extension path is documented on the spec and the builder; `actionType` is parameterized with a constant for the only Stage 0 action; the store interface is caller-clocked so future callers keep determinism. |
+| **Separation of concerns** | PASS | Pure key construction (no I/O) separate from persistence (repository partial) separate from orchestration (worker pipeline); the store has no clock dependency — the worker supplies `timeProvider.GetUtcNow()`. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | PASS | New table logic isolated in `CoreCacheRepository.SentActions.cs` (dedicated partial, per the file-size constraint strategy in spec); worker change confined to the `SendEnabled` else-branch; tests mirror the production layout. |
+| **Under 500 lines** | PASS | Reviewer-verified `wc -l`: SentActionKey.cs 57, ISentActionStore.cs 29, CoreCacheRepository.SentActions.cs 106, CoreCacheRepository.Schema.cs 253, SchedulingWorker.cs 104, SchedulingWorker.Pipeline.cs 195, Program.cs 329, SentActionKeyTests.cs 78, SentActionKeyPropertyTests.cs 81, CoreCacheRepositorySentActionsTests.cs 212, SchedulingWorkerTests.cs 319, SchedulingWorkerDedupeTests.cs 296. All under the 500-line cap; matches executor evidence `evidence/other/scope-and-size-verification.2026-07-02T12-18.md`. |
+| **Public vs internal** | PASS | `SentActionKey` and `ISentActionStore` are public within `OpenClaw.Core` (consumed by the worker and DI); `CoreCacheRepository` remains `internal sealed`; `ParseSentActionKey` and `EnsureSentActionsSchemaAsync` are private. |
+| **No circular dependencies** | PASS | No project-reference changes; NetArchTest boundary suite passes (2/2, reviewer run). |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | PASS | `SentActionKey.Build`, `ProposalReply`, `ISentActionStore.IsRecordedAsync`/`RecordAsync`, `EnsureSentActionsSchemaAsync`, `sentActionsSchemaEnsured`; test names state scenario and expectation. |
+| **Docs/docstrings** | PASS | Builder XML doc documents the no-escaping limitation and colon-free distinctness guarantee (spec requirement); interface doc states caller-supplied timestamps and `RecordAsync` idempotency; partial doc explains the lazy schema-ensure rationale; worker comment cites issue #101 and the isolation boundary. |
+| **Comment why, not what** | PASS | The worker comment explains why record-after-send preserves retry semantics; the ensure-guard doc explains why the benign race is harmless (idempotent DDL, flag only avoids round-trips). |
+
+### 2.5 After Making Changes — Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | PASS | Reviewer: `csharpier check .` — Checked 212 files, EXIT 0. Executor: `evidence/qa-gates/final-format.2026-07-02T12-12.md` EXIT 0. |
+| **2. Linting** | PASS | Reviewer: `dotnet build OpenClaw.MailBridge.sln` — 0 warnings, 0 errors (analyzers as errors). Executor additionally verified with `--no-incremental`. |
+| **3. Type checking** | PASS | Same build; nullable reference analysis runs as errors per Directory.Build.props; clean. |
+| **4. Architecture** | PASS | NetArchTest boundary tests: 2 passed, 0 failed (reviewer run). No COM, VSTO, or interop references added; the new code references only `Microsoft.Data.Sqlite` (already in use). |
+| **5. Testing** | PASS | Reviewer: full solution test run — 701 passed, 0 failed, 5 environment-gated skips (identical to baseline skips). Includes the T1 property-based tests for the new pure function. |
+| **6. Contract/schema checks** | N/A | No governed wire contract, DTO, route, or schema surface changed; the `sent_actions` table is internal Core-cache storage with an additive `CREATE TABLE IF NOT EXISTS` migration; `OpenClaw.HostAdapter.Contracts` and `OpenClaw.MailBridge.Contracts` are untouched in the diff. |
+| **7. Integration tests** | N/A | No adapter/external-system boundary changed; the integration-style condition (restart persistence over a real store) is covered in-memory per spec. |
+| **Full toolchain loop** | PASS | Reviewer re-ran format -> build -> arch -> test+coverage in a single clean pass with no file mutations; executor evidence records the closing single-pass loop after the P5-T3 coverage fix (`final-format.2026-07-02T12-12.md` loop notes, `final-build.2026-07-02T12-13.md`, `final-test-coverage.2026-07-02T12-16.md`). |
+| **Explicit reporting** | PASS | Commands and results documented here, in Appendix B, and in `evidence/qa-gates/coverage-review.2026-07-02T12-27.md`. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | PASS | `spec.md` Implementation Strategy enumerates exactly the seven production files delivered; the diff matches with zero extras. |
+| **Design choices explained** | PASS | Record-after-send at-least-once window, key-shape divergence from the master (`{tenantId}` deferred), redundant component columns for audit queries, and the lazy schema-ensure startup-ordering rationale are all documented in spec.md. |
+| **Update supporting documents** | PASS | Acceptance criteria checked off with per-item evidence in `spec.md`, `user-story.md`, and the `issue.md` mirror. |
+| **Provide next steps** | PASS | Spec Rollout: no new flag; `SendEnabled` remains the outer gate; fallback documented (delete `sent_actions` rows); Stage 1 key extension recorded. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+Only Section 3 C# applies. Python, PowerShell, Bash, TypeScript, and governed-JSON sections are omitted: no changed files in those categories on the branch.
+
+### Section 3-C#: C# Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting — CSharpier** | PASS | `csharpier check .` EXIT 0 (reviewer, CSharpier 1.3.0 global; the repo tool-manifest restore mismatch is a pre-existing environment accommodation also recorded in the #70, #80, #19, #18, and #99 audits). |
+| **Linting — .NET analyzers** | PASS | `dotnet build` clean: 0 warnings / 0 errors with AnalysisLevel=latest-all, AnalysisMode=All, TreatWarningsAsErrors=true. |
+| **Type Checking — Nullable** | PASS | Nullable enabled solution-wide; new code has no nullable warnings; `ExecuteScalarAsync` result checked with `is not null`; the tests' `null!` usages are the deliberate null-guard probes. |
+| **Null-safety** | PASS | `string.IsNullOrWhiteSpace` guards on every builder component; `ParseSentActionKey` rejects null/whitespace keys and whitespace components before persistence. |
+| **Async / resource safety** | PASS | `await using` on connections; `.ConfigureAwait(false)` on the new worker awaits per the file's existing pattern; caller token forwarded end-to-end (`OpenAsync(ct)`, `ExecuteScalarAsync(ct)`, `ExecuteNonQueryAsync(ct)`); no fire-and-forget, no blocking waits, no `async void`. |
+| **Naming / file-scoped namespaces** | PASS | File-scoped namespaces throughout; `Async` suffix; PascalCase publics; parameterized SQL with named `$` parameters matching repository convention. |
+| **Exceptions fail-fast** | PASS | `ArgumentException` with named parameters at the builder and at `ParseSentActionKey`; no catch blocks added anywhere in production; the send failure intentionally propagates to the existing isolation boundary. |
+| **Deterministic clock** | PASS | The recorded timestamp is `timeProvider.GetUtcNow()` from the worker's injected `TimeProvider`; the store is clock-free by design; no `DateTime.UtcNow` in the diff (grep clean). |
+| **No new suppressions** | PASS | The added C# diff lines contain no pragma or SuppressMessage entries and no banned-API usages (grep of all added lines for DateTime.Now/UtcNow, Random.Shared, Thread.Sleep, Task.Delay, pragma, SuppressMessage returned nothing). |
+
+Note on test framework: `.claude/rules/csharp.md` names xUnit/NSubstitute, but the repository's actual convention is MSTest + FluentAssertions + Moq (all existing suites; divergence recorded in `.claude/agent-memory/prd-feature/project_test_framework_discrepancy.md`). The new and modified tests follow the established repo convention, consistent with the prior validated #70, #80, #19, #18, and #99 audits. Pre-existing repo-wide divergence, not a finding against this branch.
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+Only C# tests changed. Python, PowerShell, and TypeScript sections are omitted.
+
+### Section 4-C#: C# Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Framework (repo convention: MSTest + FluentAssertions + Moq)** | PASS | `[TestClass]`/`[TestMethod]`/`[DataRow]`; FluentAssertions matchers with reason strings; Moq `Setup`/`Verify`/`Callback` per suite convention. |
+| **Test file location** | PASS | `tests/OpenClaw.Core.Tests/Agent/SentActionKey{,Property}Tests.cs` mirror `src/OpenClaw.Core/Agent/SentActionKey.cs`; `tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs` mirrors `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs`; `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` mirrors `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs`. No colocation in the production tree. |
+| **Coverage expectation** | PASS | Pooled 90.63% line / 80.25% branch; both instrumented new files 100%/100%; every instrumented changed line covered; no regression. |
+| **Property-based tests (T1 density)** | PASS | `OpenClaw.Core` is T1 (`quality-tiers.yml`); the one new pure function (`SentActionKey.Build`) has three CsCheck properties (determinism, fixed component ordering on split, distinctness for colon-free triples; 1000 iterations each; generators exclude colons and whitespace per the documented builder contract). CsCheck 4.7.0 was already referenced by `OpenClaw.Core.Tests`; no new dependency. |
+| **Mutation testing** | N/A | Mutation testing runs in pre-merge/nightly pipelines per policy, not the per-commit loop (same disposition as the validated #80 and #99 T1 audits). |
+| **Determinism (no sleeps, no wall clock)** | PASS | No `Thread.Sleep`/`Task.Delay`/`DateTime.Now`/timers in the diff; `FakeTimeProvider(Now)` everywhere a clock is needed; the recorded timestamp asserted equal to the fake `Now`; CsCheck prints the failing seed for reproducibility. |
+| **No temporary files** | PASS | In-memory shared-cache SQLite exclusively (GUID-named `Mode=Memory;Cache=Shared` sources); zero filesystem artifacts; verified by reviewer inspection and executor evidence. |
+| **Focused / isolated** | PASS | Fresh mock graph or fresh database per test; helper factories (`Options`, `Message`, `ServiceReturningContext`, `CandidateSource`, `Store`, `Worker`, `NewConnectionString`) build per-test state only. |
+
+---
+
+## 5. Test Coverage Detail
+
+### SentActionKeyTests (11 results: 2 named + 3 parameterized x 3 rows) and SentActionKeyPropertyTests (3 CsCheck properties, new files)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `Build_WithValidComponents_ReturnsColonJoinedKeyInFixedOrder` | Positive (format) | PASS |
+| `ProposalReply_Constant_IsProposalReplyLiteral` | Positive (constant) | PASS |
+| `Build_WithInvalidMailbox_ThrowsArgumentExceptionNamingMailbox` (3 rows) | Negative (null/empty/whitespace, parameter name) | PASS |
+| `Build_WithInvalidMessageId_ThrowsArgumentExceptionNamingMessageId` (3 rows) | Negative | PASS |
+| `Build_WithInvalidActionType_ThrowsArgumentExceptionNamingActionType` (3 rows) | Negative | PASS |
+| `Build_IsDeterministic_SameTripleAlwaysYieldsSameKey` | Property (1000 iterations) | PASS |
+| `Build_ColonFreeComponents_SplitYieldsComponentsInFixedOrder` | Property (ordering) | PASS |
+| `Build_DistinctColonFreeTriples_YieldDistinctKeys` | Property (distinctness) | PASS |
+
+### CoreCacheRepositorySentActionsTests (11 results: 7 named + 1 negative x 4 rows, new file)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `IsRecordedAsync_should_return_false_for_unknown_key` | Positive (miss) | PASS |
+| `RecordAsync_then_IsRecordedAsync_should_return_true` | Positive (round-trip) | PASS |
+| `RecordAsync_duplicate_key_should_not_throw_and_leave_one_row` | Edge (idempotent insert, row-count verified) | PASS |
+| `RecordAsync_should_round_trip_caller_supplied_timestamp_in_iso8601_o_form` | Edge (non-UTC offset normalized to UTC `O` form) | PASS |
+| `InitializeAsync_twice_should_not_throw_and_sent_actions_should_exist` | Migration idempotency (AC-1 fresh path) | PASS |
+| `InitializeAsync_should_add_sent_actions_to_pre_existing_database` | Migration upgrade path (AC-1) | PASS |
+| `RecordAsync_malformed_key_should_throw_ArgumentException` (4 rows) | Negative (fail-fast key-shape guard) | PASS |
+| `Store_methods_should_work_on_fresh_database_without_InitializeAsync` | Lazy schema-ensure guard | PASS |
+
+### SchedulingWorkerDedupeTests (5 tests, new file) and SchedulingWorkerTests (helper extended only)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `RunCycle_StoreHit_SkipsSendAndCompletesWithoutThrowing` | Dedupe hit skip, normal outcome (AC-3) | PASS |
+| `RunCycle_StoreMiss_SendsThenRecordsKeyWithInjectedClockTimestamp` | Miss path; send-before-record order proven via callbacks; `FakeTimeProvider` timestamp asserted (AC-3) | PASS |
+| `RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate` | Failure no-record + per-message isolation (AC-5) | PASS |
+| `RunCycle_SendDisabled_NeverTouchesStoreAndNeverSends` | Kill-switch composition (store untouched) | PASS |
+| `RunCycle_TwoWorkerStorePairsOverOneDatabase_SendExactlyOnceInTotal` | Restart persistence, real store, exactly-once total (AC-4) | PASS |
+| `SchedulingWorkerTests` helper `Worker(...)` extended with a default not-recorded store mock | Pre-existing suite unregressed (all pass) | PASS |
+
+**Coverage:** `SentActionKey.cs` 100% line / 100% branch; `CoreCacheRepository.SentActions.cs` 100% line / 100% branch (instrumented); all modified files 100% line. **Gap:** none attributable to this branch (the only partial branches, Pipeline.cs lines 170/177, are pre-existing untouched ternaries, identical at baseline).
+
+**Fail-before / pass-after:** `evidence/regression-testing/dedupe-expect-fail.2026-07-02T12-10.md` (EXIT 1; the five dedupe tests failing before the worker seam) and `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (EXIT 0).
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (solution, reviewer run) | 706 (701 passed, 5 env-gated skips) | PASS |
+| OpenClaw.Core.Tests | 254 passed / 254 | PASS |
+| Tests Failed | 0 | PASS |
+| Core.Tests Execution Time | ~1 s | PASS |
+| Pooled Code Coverage | 90.63% line, 80.25% branch | PASS |
+| `OpenClaw.Core` package coverage (T1) | 98.66% line, 92.07% branch | PASS |
+| Net new test results vs baseline | +30 (11 SentActionKey unit + 3 property + 11 repository + 5 worker dedupe) | PASS |
+
+---
+
+## 7. Code Quality Checks
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| CSharpier format | `csharpier check .` (CSharpier 1.3.0, reviewer) | Checked 212 files, EXIT 0 | PASS |
+| .NET analyzers + nullable | `dotnet build OpenClaw.MailBridge.sln` | 0 warnings, 0 errors | PASS |
+| Architecture (NetArchTest) | `dotnet test tests/OpenClaw.Core.Tests/... --filter "FullyQualifiedName~ArchitectureBoundary"` | 2 passed, 0 failed | PASS |
+| MSTest tests + coverage | `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"` | 701 passed, 0 failed, 5 skipped | PASS |
+
+**Notes:** The reviewer re-ran the full toolchain against branch head `a352183` on 2026-07-02. The 5 skips are the same environment-gated COM/publish tests skipped at baseline; none relate to this change.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+**None Blocking.** One Minor finding and two informational observations, recorded (none is a policy violation on this branch):
+
+- **Dedupe-hit log line not content-asserted (Minor).** AC-3 requires a structured dedupe-hit log with `{MessageId}` and `{DedupeKey}` named template parameters. The production code emits exactly that (`SchedulingWorker.Pipeline.cs` lines 144-148, verified by inspection), but `RunCycle_StoreHit_SkipsSendAndCompletesWithoutThrowing` uses `NullLogger` and asserts only the skip and normal completion. The behavioral core of the criterion (skip, normal outcome) is test-verified; the log content is inspection-verified. Recommended follow-up (non-blocking): assert the log event via a capturing logger. Detailed in the code review findings table.
+- **Async-body instrumentation exclusion (Informational).** The pre-existing `mailbridge.runsettings` coverlet setting `ExcludeByAttribute=...CompilerGeneratedAttribute...` excludes async state-machine bodies from instrumentation solution-wide. The new worker consult/record logic (Pipeline.cs lines 129-157) and the store's async method bodies therefore contribute no instrumented lines. This is an instrumentation-scope limitation, not a coverage regression; the runsettings file is byte-identical to base on this branch. The behavior is fully covered by the five dedupe tests and eight repository tests with fail-before/pass-after evidence. Same disposition as the accepted #99 audit; the recommended runsettings follow-up remains open.
+- **Pre-existing partial branches in Pipeline.cs (Informational).** File-level branch coverage is 50% (2/4) because of two pre-existing ternaries on untouched lines 170 (`MailboxUpn()` internal-domain fallback) and 177 (`BuildProposalReply` empty-slots message), identical at baseline. Not attributable to this branch; a follow-up test of the two uncovered arms would close it.
+
+### Approved Exceptions
+
+- **CSharpier invocation path:** the repo tool-manifest restore fails in this environment ("command csharpier ... package contains dotnet-csharpier"); the reviewer used the globally installed CSharpier 1.3.0, matching the accommodation recorded in the #70, #80, #19, #18, and #99 audits. The format check ran to EXIT 0 over all 212 files.
+- **MCP template/validator tools unavailable:** the MCP tools `resolve_policy_audit_template_asset` and `validate_orchestration_artifacts` are not available in this review environment. The artifact structure was reproduced from the most recent validator-passing artifact set (issue #99 review, 2026-07-02) and the recorded validator requirements (exact headings, Coverage Evidence Checklist literals, single-line Section 1.2.1 comparison). Documented best-effort assumption per the workflow's fail-soft guidance.
+- **GitHub CLI unavailable:** `gh` is not installed, so issue cross-verification in the PR-context artifacts is author-asserted only. Does not affect any gate in this audit.
+
+### Removed/Skipped Tests
+
+- **None.** No tests were removed, skipped, or weakened. `SchedulingWorkerTests.cs` changed only its private `Worker(...)` factory (adds a default not-recorded store mock so the 13 pre-existing worker tests keep their pre-dedupe behavior); all pre-existing assertions are intact and passing.
+
+---
+
+## 9. Summary of Changes
+
+### Commits in This Branch (vs base `d90681c`)
+
+Branch `feature/send-idempotency-dedupe-101`, head `a3521833996bbf66e6d0e0ddedaebfaf8dcc85ec`. Range: `d90681c766d8a9b9cff93fd59bc1989c80632d1f..a3521833996bbf66e6d0e0ddedaebfaf8dcc85ec` (27 files, +1494/-3).
+
+### Files Modified (categories)
+
+1. **`src/OpenClaw.Core/Agent/SentActionKey.cs`** (NEW) — pure static dedupe-key builder with `ProposalReply` constant, per-component fail-fast guards, and the documented no-escaping/colon-free-distinctness contract.
+2. **`src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs`** (NEW) — two-method clock-free store interface (`IsRecordedAsync`, idempotent `RecordAsync` with caller-supplied timestamp).
+3. **`src/OpenClaw.Core/CoreCacheRepository.SentActions.cs`** (NEW) — `ISentActionStore` implementation partial: exact-key `SELECT 1 ... LIMIT 1`, `INSERT ... ON CONFLICT(dedupe_key) DO NOTHING` with parsed component columns and ISO-8601 `O` timestamp, lazy once-per-instance schema-ensure guard, malformed-key `ArgumentException` guard.
+4. **`src/OpenClaw.Core/CoreCacheRepository.Schema.cs`** (MODIFIED) — `sent_actions` DDL appended to `CreateTablesSql` (additive `CREATE TABLE IF NOT EXISTS`).
+5. **`src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs`** (MODIFIED) — `ISentActionStore sentActionStore` added to the primary constructor.
+6. **`src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs`** (MODIFIED) — consult/skip-with-structured-log/record logic inside the `SendEnabled` else-branch; record uses `timeProvider.GetUtcNow()` after a successful send.
+7. **`src/OpenClaw.Core/Program.cs`** (MODIFIED) — singleton `ISentActionStore` registration resolving to the existing `CoreCacheRepository` instance.
+8. **`tests/OpenClaw.Core.Tests/`** — `Agent/SentActionKeyTests.cs` (NEW), `Agent/SentActionKeyPropertyTests.cs` (NEW, CsCheck), `CoreCacheRepositorySentActionsTests.cs` (NEW), `Agent/Runtime/SchedulingWorkerDedupeTests.cs` (NEW), `Agent/Runtime/SchedulingWorkerTests.cs` (helper factory extended only).
+9. **`docs/features/active/2026-07-02-send-idempotency-dedupe-101/**`** (NEW, 15 files) — issue/spec/user-story/plan and canonical evidence (baseline, qa-gates, regression-testing, other).
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: FULLY COMPLIANT
+
+The C# change passes formatting, linting, nullable type-checking, architecture-boundary enforcement, the full unit-test suite, and the uniform coverage gates, all independently re-run by the reviewer at branch head. The T1 property-test obligation for the new pure function is satisfied with three CsCheck properties. Fail-before/pass-after regression evidence is present and discriminates the new dedupe seam exactly. No evidence-location or file-size violations. No new suppressions or banned APIs; the deterministic clock seam is used for the recorded timestamp. The `modified-workflow-needs-green-run` rule does not fire (verified: no `.github/workflows/`, `scripts/benchmarks/`, or `.github/actions/` paths in the diff). The `benchmark-baselines` and `ci-workflows` rules are not triggered.
+
+**Fail-closed reminder:** All required baseline and post-change coverage metrics are present and independently re-verified; the audit is marked PASS because no required artifact, metric, or gate is missing or failing.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- Before Making Changes: PASS (spec/plan/policy-order evidence present)
+- Design Principles: PASS (one pure builder + one two-method seam + one repository partial; no new dependencies)
+- Module & File Structure: PASS (all files under 500 lines)
+- Naming, Docs, Comments: PASS
+- Toolchain Execution: PASS (single clean pass, reviewer re-verified)
+- Summarize & Document: PASS
+
+#### Language-Specific Code Change Policy (Section 3) — C#
+- Tooling & Baseline: PASS
+- Design & Type-Safety: PASS
+- Error Handling: PASS (fail-fast guards; no new catch blocks; failure propagates to the existing isolation boundary)
+- Deterministic Clock: PASS (injected `TimeProvider`; clock-free store)
+
+#### General Unit Test Policy (Section 1)
+- Core Principles: PASS
+- Coverage & Scenarios: PASS (90.63%/80.25% pooled; new files 100%/100%; changed lines covered; no regression)
+- Test Structure: PASS
+- External Dependencies: PASS (Moq seams + in-memory SQLite, no temp files)
+- Policy Audit: PASS
+
+#### Language-Specific Unit Test Policy (Section 4) — C#
+- Framework & Location: PASS (MSTest + FluentAssertions + Moq repo convention; tests/ mirror)
+- Determinism: PASS (FakeTimeProvider; seeded property sampling with seed printing; no sleeps/wall clock)
+- T1 obligations: PASS (three property tests for the new pure function; mutation gate is pipeline-stage, not per-commit)
+
+---
+
+### Metrics Summary
+
+- 701/701 runnable solution tests passing (5 pre-existing environment-gated skips)
+- 90.63% pooled line coverage, 80.25% pooled branch coverage (gates: 85%/75%)
+- T1 `OpenClaw.Core` package: 98.66% line / 92.07% branch
+- New files: SentActionKey.cs 100%/100%, CoreCacheRepository.SentActions.cs 100%/100% (instrumented)
+- Build: 0 warnings / 0 errors (analyzers + nullable as errors)
+- Architecture boundary: 2/2 NetArchTest tests pass
+
+---
+
+### Recommendation
+
+**Ready for merge — Go.** All toolchain stages, coverage gates, regression evidence, and policy requirements pass against branch head `a352183`. No remediation inputs are required. This feature closes the accepted duplicate-send interim risk carried from #99; the at-least-once window (crash between send and record) is explicitly documented and accepted for Stage 0.
+
+---
+
+## Appendix A: Test Inventory
+
+C# test changes in this feature (all in `tests/OpenClaw.Core.Tests/`):
+
+1. `Agent/SentActionKeyTests.cs` (NEW, 78 lines) — `Build_WithValidComponents_ReturnsColonJoinedKeyInFixedOrder`, `ProposalReply_Constant_IsProposalReplyLiteral`, and three parameterized guard tests (`Build_WithInvalidMailbox_...`, `Build_WithInvalidMessageId_...`, `Build_WithInvalidActionType_...`; 3 `[DataRow]` rows each asserting the named parameter).
+2. `Agent/SentActionKeyPropertyTests.cs` (NEW, 81 lines) — three CsCheck properties (`Build_IsDeterministic_SameTripleAlwaysYieldsSameKey`, `Build_ColonFreeComponents_SplitYieldsComponentsInFixedOrder`, `Build_DistinctColonFreeTriples_YieldDistinctKeys`; 1000 iterations each; colon-free non-whitespace generators; failing seed printed per suite convention).
+3. `CoreCacheRepositorySentActionsTests.cs` (NEW, 212 lines) — round-trip, duplicate idempotency with row-count verification, ISO-8601 `O` UTC timestamp round-trip, `InitializeAsync` idempotency, pre-existing-database upgrade, 4-row malformed-key negative test, lazy schema-ensure. In-memory shared-cache SQLite exclusively.
+4. `Agent/Runtime/SchedulingWorkerDedupeTests.cs` (NEW, 296 lines) — hit-skip, miss-send-record with proven call order and `FakeTimeProvider` timestamp, failure no-record with next-candidate isolation, kill-switch store-untouched composition, restart persistence over one shared in-memory database with a real `CoreCacheRepository` store.
+5. `Agent/Runtime/SchedulingWorkerTests.cs` (MODIFIED, helper only) — private `Worker(...)` factory now supplies a default not-recorded `ISentActionStore` mock; all 13 pre-existing tests unchanged and passing.
+
+Reviewer run: `OpenClaw.Core.Tests` 254 passed, 0 failed; solution total 701 passed, 0 failed, 5 env-gated skipped.
+
+---
+
+## Appendix B: Toolchain Commands Reference (C#)
+
+```bash
+# Formatting (reviewer, CSharpier 1.3.0 global — repo tool-manifest accommodation)
+csharpier check .
+
+# Lint + nullable type-check + analyzers (as errors per Directory.Build.props)
+dotnet build OpenClaw.MailBridge.sln
+
+# Architecture-boundary tests (subset)
+dotnet test tests/OpenClaw.Core.Tests/OpenClaw.Core.Tests.csproj --no-build --filter "FullyQualifiedName~ArchitectureBoundary"
+
+# Tests + coverage (full solution; reviewer results directory is the canonical evidence path)
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory "docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/qa-gates/coverage-review"
+
+# Regression subsets (executor fail-before / pass-after evidence)
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerDedupeTests"
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SentActionKey"
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~CoreCacheRepositorySentActions"
+
+# Evidence-location scan
+git diff --name-only d90681c766d8a9b9cff93fd59bc1989c80632d1f..HEAD | grep -E '^artifacts/(baselines|baseline|qa|qa-gates|evidence|coverage|regression-testing|post-change)/'
+
+# Banned-API / suppression scan over added C# lines
+git diff d90681c766d8a9b9cff93fd59bc1989c80632d1f..HEAD -- 'src/*.cs' 'tests/*.cs' | grep -E '^\+' | grep -E 'DateTime\.(Now|UtcNow)|Random\.Shared|Thread\.Sleep|Task\.Delay|pragma|SuppressMessage'
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-07-02
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/spec.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/spec.md
@@ -1,0 +1,133 @@
+# send-idempotency-dedupe — Spec
+
+- **Issue:** #101
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-07-02T11-40
+- **Status:** Draft
+- **Version:** 0.2
+
+## Overview
+
+With `HostAdapterSchedulingService.SendMailAsync` now wired (issue #99 / PR #100), a retried or repeated scheduling cycle can resend the same reply: no dedupe-key concept exists in `SchedulingWorker`'s pipeline, `MailRoutes`, or `SendMailRpcHandler`. The master specification requires idempotency keys for mail sends with an internal dedupe key shaped like `{tenantId}:{mailboxUpn}:{messageId}:{actionType}` (`docs/open-claw-approach.master.md` §6.3); the Local MVP equivalent is a persisted per-message/action guard consulted before send. This was recorded as the accepted interim risk in the #99 spec, to be closed by this feature. Identified as gap F6 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`.
+
+## Behavior
+
+- Add a persisted `sent_actions` unit to `CoreCacheRepository` (new table via the established guarded-migration pattern) keyed by a deterministic dedupe key: `{mailbox}:{messageId}:{actionType}` (local single-mailbox form of the master's key; the `{tenantId}` component is deferred to Stage 1).
+- `SchedulingWorker.ProposeAndActAsync` consults the store before invoking `ISchedulingService.SendMailAsync`. The consult/record logic lives entirely inside the existing `SendEnabled`-gated `else` branch (`SchedulingWorker.Pipeline.cs`, currently lines 120–132), so the kill switch remains the outer boundary:
+  - **Dedupe hit:** the key is already recorded. The send is skipped, a structured dedupe-hit message is logged (`LogInformation` with named template parameters `{MessageId}` and `{DedupeKey}`, matching the file's existing logging pattern), and the message completes as a normal — not failed — processing outcome (the method returns normally).
+  - **Dedupe miss:** `SendMailAsync` is invoked; on success the key is recorded in the same cycle with a timestamp taken from the injected `TimeProvider` (`timeProvider.GetUtcNow()`).
+  - **Failed send:** `SendMailAsync` throws before the record step runs, so nothing is recorded and retry remains possible. The exception propagates to the existing `ProcessMessageSafelyAsync` isolation boundary in `SchedulingWorker.cs`, which logs and continues with the next candidate — unchanged behavior.
+- Dedupe state survives process restart (persisted in the Core SQLite cache, not in-memory).
+- When `SendEnabled` is false, the store is neither consulted nor written; the existing "SendEnabled is false" log line is unchanged.
+
+### Dedupe key
+
+- Format: `{mailbox}:{messageId}:{actionType}`, joined with `:` in that fixed order.
+- `mailbox` — the worker's `MailboxUpn()` value (derived from `AgentPolicyOptions.InternalDomain`, e.g. `owner@contoso.com`).
+- `messageId` — the candidate message identifier already threaded through `ProposeAndActAsync`.
+- `actionType` — a fixed constant for the only Stage 0 outbound action: `proposal-reply`, exposed as a constant on the key builder.
+- The builder is a pure static class (`SentActionKey` in `OpenClaw.Core.Agent`, file `src/OpenClaw.Core/Agent/SentActionKey.cs`) with a single `Build(string mailbox, string messageId, string actionType)` method. It throws `ArgumentException` for null, empty, or whitespace-only components (fail fast per `.claude/rules/general-code-change.md`).
+- Ambiguity note: components are not escaped. In practice `mailbox` is a UPN and `actionType` is a fixed constant, neither of which contains `:`; message identifiers are bridge EntryID strings (hex). Key distinctness therefore holds for all real inputs; the property test asserts distinctness for colon-free inputs and this limitation is documented on the builder.
+
+## Inputs / Outputs
+
+- Inputs (CLI flags, files, env vars): none new. Existing configuration is reused: `OpenClaw:AgentPolicy:SendEnabled` (kill switch, unchanged semantics) and `OpenClaw:Storage:DbPath` (location of the Core SQLite cache that now also holds `sent_actions`).
+- Outputs (artifacts, logs, telemetry):
+  - New rows in the `sent_actions` table of the Core cache database (one per successful send).
+  - New structured log line (Information) on a dedupe hit: message template with `{MessageId}` and `{DedupeKey}` named parameters.
+- Config keys and defaults: no new keys; no default changes.
+- Versioning or backward-compatibility constraints: the migration is additive (new table only). Existing databases upgrade in place via `CREATE TABLE IF NOT EXISTS`; no existing table, column, or row is modified. No wire-contract (`OpenClaw.MailBridge.Contracts` / HostAdapter HTTP surface) change.
+
+## API / CLI Surface
+
+No HTTP route, CLI command, or wire-contract change. The new surface is internal to `OpenClaw.Core`:
+
+- `ISentActionStore` (new interface, `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs`, alongside `ISchedulingService`):
+  ```csharp
+  public interface ISentActionStore
+  {
+      Task<bool> IsRecordedAsync(string dedupeKey, CancellationToken ct);
+      Task RecordAsync(string dedupeKey, DateTimeOffset recordedAtUtc, CancellationToken ct);
+  }
+  ```
+  The worker depends on this abstraction so unit tests mock it with Moq, matching the existing `ISchedulingService`/`ISchedulingCandidateSource` conventions in `SchedulingWorkerTests.cs`. The store takes the timestamp as a parameter — the caller supplies `timeProvider.GetUtcNow()` — so the repository gains no clock dependency and the timestamp is deterministic under `FakeTimeProvider`.
+- `SentActionKey` (new pure static builder, see Behavior): `SentActionKey.Build(mailbox, messageId, actionType)` and the `SentActionKey.ProposalReply` action-type constant.
+- Contracts and validation rules: `Build` rejects null/empty/whitespace components with `ArgumentException`. `RecordAsync` is idempotent (`INSERT ... ON CONFLICT DO NOTHING`), so a duplicate record during the accepted at-least-once window does not throw.
+
+## Data & State
+
+- Data transformations and invariants:
+  - Key construction is a pure transformation of `(mailbox, messageId, actionType)`; same inputs always produce the same key.
+  - Invariant: a key present in `sent_actions` means the corresponding send completed successfully at least once; the worker never sends again for that key.
+- Caching or persistence details — new table in the Core SQLite cache:
+  ```sql
+  CREATE TABLE IF NOT EXISTS sent_actions(
+      dedupe_key TEXT PRIMARY KEY,
+      mailbox TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      action_type TEXT NOT NULL,
+      recorded_at_utc TEXT NOT NULL
+  );
+  ```
+  - `dedupe_key` is the primary key (exact-match lookup). The component columns (`mailbox`, `message_id`, `action_type`) are stored redundantly for audit/debug queries, following the repository's habit of readable columns.
+  - `recorded_at_utc` is stored as an ISO-8601 round-trip string (`UtcDateTime.ToString("O")`), matching every other timestamp column in the repository (`ToDbValue` convention).
+  - Implementation lives in a new partial, `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs`, which declares `CoreCacheRepository : ISentActionStore` and follows the existing per-call `Open()`/parameterized-command pattern. This keeps `CoreCacheRepository.cs` (271 lines) and `CoreCacheRepository.Schema.cs` (253 lines) under the 500-line cap.
+- Migration or backfill requirements:
+  - The DDL above is appended to `CreateTablesSql` in `CoreCacheRepository.Schema.cs`. Because it is `CREATE TABLE IF NOT EXISTS`, the same statement covers both the fresh-database path and the pre-existing-database upgrade path idempotently — the same guarantee the PRAGMA-guarded ALTER pattern provides for column additions. No backfill: an empty table is the correct initial state (nothing has been dedupe-recorded yet).
+  - Startup-ordering guard: `CoreCacheRepository.InitializeAsync` is currently awaited only inside `MessagePollingWorker`/`CalendarPollingWorker` `ExecuteAsync`, which run concurrently with `SchedulingWorker`. To remove the ordering dependency, the `SentActions` partial ensures its own schema before first use (a lazy, once-per-repository-instance `CREATE TABLE IF NOT EXISTS sent_actions...` execution guarded by an initialization flag). This is cheap, idempotent, and keeps the store safe regardless of which hosted service touches the database first.
+
+## Constraints & Risks
+
+- Keep the store consult/record inside the existing `SendEnabled`-gated block so the kill switch remains the outer boundary. When `SendEnabled` is false the store is not touched.
+- No temp files in tests (in-memory shared-cache SQLite pattern, as in `CoreCacheRepositoryResponseStatusTests.cs`); MSTest + FluentAssertions + Moq (the repository's actual test stack); CsCheck for property tests (already referenced by `OpenClaw.Core.Tests.csproj`); 500-line cap (new table logic goes in the new `CoreCacheRepository.SentActions.cs` partial; new worker dedupe tests go in a new test file rather than growing `SchedulingWorkerTests.cs`, currently 311 lines).
+- Recording after send introduces a small at-least-once window (crash between send and record could resend once on restart). Accepted for Stage 0, consistent with the master's queue-retry semantics (§6.3); `RecordAsync`'s conflict-tolerant insert makes the recovery path safe. Exactly-once delivery is a non-goal.
+- Deterministic clock: the recorded timestamp comes from the worker's injected `TimeProvider`; production code adds no `DateTime.UtcNow` call (banned API per `.claude/rules/csharp.md`).
+- No HostAdapter, MailBridge, or Contracts-wire changes. Dedupe is enforced at the worker call site only; `SendMailRpcHandler`/`MailRoutes` remain dedupe-unaware in Stage 0.
+- Key-shape divergence from the master (§6.3): the local key omits `{tenantId}`. Recorded explicitly so Stage 1 (multi-tenant/Graph) knows to extend the builder rather than reinterpret stored keys.
+
+## Implementation Strategy
+
+- Implementation scope (what changes, not sequencing):
+  - `src/OpenClaw.Core/Agent/SentActionKey.cs` — new pure static key builder + `ProposalReply` constant.
+  - `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs` — new interface (see API surface).
+  - `src/OpenClaw.Core/CoreCacheRepository.Schema.cs` — append `sent_actions` DDL to `CreateTablesSql`.
+  - `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` — new partial implementing `ISentActionStore` (`IsRecordedAsync` exact-key `SELECT 1 ... LIMIT 1`; `RecordAsync` `INSERT ... ON CONFLICT(dedupe_key) DO NOTHING`), plus the lazy schema-ensure guard.
+  - `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs` — add `ISentActionStore sentActionStore` to the primary constructor.
+  - `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` — consult/skip/record logic inside the `SendEnabled` `else` branch of `ProposeAndActAsync` (file is 169 lines; stays well under cap).
+  - `src/OpenClaw.Core/Program.cs` — register `builder.Services.AddSingleton<ISentActionStore>(sp => sp.GetRequiredService<CoreCacheRepository>());` next to the existing D5/D6 registrations (both are singletons, so the store shares the repository instance and connection string).
+- New classes/functions/commands to add or update: listed above; no removals, no public wire-surface changes.
+- Dependency changes (new/removed packages) and rationale: none. `Microsoft.Data.Sqlite`, Moq, FluentAssertions, CsCheck, and `Microsoft.Extensions.TimeProvider.Testing` are already in use.
+- Logging/telemetry additions and locations: one new Information-level structured log line (dedupe hit) in `SchedulingWorker.Pipeline.cs`, using the file's existing message-template style. No new log line on the record step (the send itself is the observable action).
+- Rollout plan (feature flags, staged deploys, fallback path): no new flag. The existing `SendEnabled` kill switch remains the outer gate; with sends disabled the feature is inert. Fallback: deleting rows from `sent_actions` (or the dev database) re-enables sending for affected keys; the additive migration requires no rollback script.
+
+## Acceptance Criteria
+
+- [x] A `sent_actions` table exists in the Core cache with an idempotent guarded migration (fresh-database and pre-existing-database upgrade paths both covered by tests; running the migration twice is safe).
+  - Evidence: `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md` (all `CoreCacheRepositorySentActionsTests` pass, including `InitializeAsync_twice_...`, `InitializeAsync_should_add_sent_actions_to_pre_existing_database`, and the lazy schema-ensure test)
+- [x] A pure, deterministic dedupe-key builder produces `{mailbox}:{messageId}:{actionType}` and is unit-tested, including at least one CsCheck property test per T1 convention (determinism, component ordering, and distinctness for colon-free inputs).
+  - Evidence: `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md` (`SentActionKeyTests` 11 results + `SentActionKeyPropertyTests` 3 CsCheck properties, all passing; `SentActionKey.cs` 100% line/branch coverage per `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md`)
+- [x] Inside the existing `SendEnabled`-gated block, `SchedulingWorker` consults the store before sending: on a hit it skips the send and logs a structured dedupe-hit message (message id and dedupe key as named template parameters), completing the message as a normal (not failed) outcome; on a miss it sends and then records the key with a timestamp from the injected `TimeProvider`.
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (skip-on-hit and record-on-success tests pass; fail-before counterpart `evidence/regression-testing/dedupe-expect-fail.2026-07-02T12-10.md`)
+- [x] A repeated worker cycle for the same candidate message does not invoke `ISchedulingService.SendMailAsync` a second time, including across a simulated restart (new worker and store instances over the same in-memory shared-cache SQLite database).
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (`RunCycle_TwoWorkerStorePairsOverOneDatabase_SendExactlyOnceInTotal` passes)
+- [x] A failed send does NOT record the key (retry remains possible), and the failure stays isolated to that message per the existing `ProcessMessageSafelyAsync` behavior.
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (`RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate` passes; existing `SchedulingWorkerTests` unregressed per P4-T3 run recorded in the plan)
+- [x] Full C# toolchain passes (format, lint, type-check, architecture, tests); coverage thresholds hold (line >= 85%, branch >= 75%) with changed lines covered; MSTest + FluentAssertions + Moq; no temp files in tests; all files remain under the 500-line cap.
+  - Evidence: `evidence/qa-gates/final-format.2026-07-02T12-12.md`, `evidence/qa-gates/final-build.2026-07-02T12-13.md`, `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md`, `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md`, `evidence/other/scope-and-size-verification.2026-07-02T12-18.md`
+
+## Definition of Done
+
+- [ ] Acceptance criteria documented and mapped to tests or demos
+- [ ] Behavior matches acceptance criteria in all documented environments
+- [ ] Tests updated/added (unit/integration as applicable)
+- [ ] Edge cases and error handling covered by tests
+- [ ] Docs updated (README, docs/features/active/... links)
+- [ ] Telemetry/logging added or updated (if applicable)
+- [ ] Toolchain pass completed (format → lint → type-check → test)
+
+## Seeded Test Conditions (from potential)
+
+- [ ] Unit: dedupe-key builder determinism and component ordering (`tests/OpenClaw.Core.Tests/Agent/SentActionKeyTests.cs`); CsCheck property tests — same inputs yield the same key, output preserves `{mailbox}:{messageId}:{actionType}` ordering, distinct colon-free component triples yield distinct keys (`tests/OpenClaw.Core.Tests/Agent/SentActionKeyPropertyTests.cs`); `ArgumentException` for null/empty/whitespace components.
+- [ ] Unit: repository record/exists round-trip (unknown key reads false; recorded key reads true; duplicate `RecordAsync` does not throw; `recorded_at_utc` round-trips the supplied timestamp), migration idempotency (`InitializeAsync` twice; pre-existing database created without `sent_actions` then upgraded), and lazy schema-ensure (store methods work without a prior `InitializeAsync` call) — `tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs`, in-memory shared-cache SQLite, no temp files.
+- [ ] Unit: worker skip-on-hit (mocked `ISentActionStore` returns true; `SendMailAsync` never invoked; cycle completes without throwing), record-on-success (`RecordAsync` invoked once with the built key and the `FakeTimeProvider` timestamp, after the send), no-record-on-failure (`SendMailAsync` throws; `RecordAsync` never invoked; next candidate still processed), kill-switch composition (`SendEnabled=false`: store neither consulted nor written), and restart persistence (real store over one shared in-memory database, two worker/store instances, second cycle performs zero sends) — new file `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` following `SchedulingWorkerTests.cs` mock conventions.

--- a/docs/features/active/2026-07-02-send-idempotency-dedupe-101/user-story.md
+++ b/docs/features/active/2026-07-02-send-idempotency-dedupe-101/user-story.md
@@ -1,0 +1,69 @@
+# `send-idempotency-dedupe` — User Story
+
+- Issue: #101
+- Owner: drmoisan
+- Status: Draft
+- Last Updated: 2026-07-02T11-40
+
+## Story Statement
+
+- As the mailbox owner whose inbox the scheduling assistant acts on, I want the assistant to send each scheduling reply exactly one time per message and action, so that my correspondents never receive duplicate proposal emails when the worker's polling loop revisits the same message.
+- As the mailbox owner operating the assistant locally, I want the sent-reply record to survive process restarts and transient send failures, so that a restart never causes a re-send of an already-delivered reply, and a genuinely failed send remains eligible for retry on the next cycle.
+
+## Problem / Why
+
+With `HostAdapterSchedulingService.SendMailAsync` now wired (issue #99 / PR #100), a retried or repeated scheduling cycle can resend the same reply: no dedupe-key concept exists in `SchedulingWorker`'s pipeline, `MailRoutes`, or `SendMailRpcHandler`. The master specification requires idempotency keys for mail sends with an internal dedupe key shaped like `{tenantId}:{mailboxUpn}:{messageId}:{actionType}` (`docs/open-claw-approach.master.md` §6.3); the Local MVP equivalent is a persisted per-message/action guard consulted before send. This was recorded as the accepted interim risk in the #99 spec, to be closed by this feature. Identified as gap F6 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`.
+
+## Personas & Scenarios
+
+- Persona: **The mailbox owner (Dan)** — a single-mailbox user running the Local MVP assistant against his own inbox with `SendEnabled` turned on.
+  - Who the user is: the owner of the mailbox the assistant reads from and replies on behalf of; also the operator who starts, stops, and restarts the Core service on his machine.
+  - What they care about: the assistant's outbound mail must be trustworthy. A duplicate "Proposed times: ..." reply to a colleague is embarrassing and erodes confidence in letting the assistant send at all.
+  - Their constraints: the worker polls on a cycle (`SchedulingWorker` re-runs every minute) and the same candidate message legitimately reappears in consecutive cycles; the process restarts routinely (deploys, reboots), so any in-memory "already sent" marker is insufficient.
+  - Their goals and frustrations: goal — leave `SendEnabled` on with confidence; frustration — today the only safe posture after any restart or repeated cycle is to assume a double-send is possible, because nothing records what was already sent.
+  - Their context and motivations: this is the accepted interim risk from issue #99; closing it is the precondition for treating the read-and-reply loop as safe for daily use.
+
+- Scenario: **Repeated cycle over the same candidate message.**
+  - Who is acting: the `SchedulingWorker` background service, on behalf of the mailbox owner.
+  - What triggered the action: a colleague's meeting-request message is selected as a scheduling candidate; the worker's cycle runs, triages it to a decision requiring action, proposes slots, and — `SendEnabled` being true — sends the proposal reply. One minute later the next cycle runs and selects the same message again (the candidate source has no send-awareness).
+  - What steps do they take: on the first cycle the worker finds no `sent_actions` record for `{mailbox}:{messageId}:proposal-reply`, sends the reply, and records the key with a clock-seam timestamp. On the second cycle the worker finds the key already recorded, logs a structured dedupe-hit message, and skips the send.
+  - What obstacles or decisions occur: the dedupe hit is a normal, expected outcome — it is logged at Information level and the message counts as processed, not failed; the worker moves on to the next candidate.
+  - What outcome do they expect: the colleague receives exactly one proposal email, regardless of how many cycles revisit the message.
+
+- Scenario: **Restart between cycles.**
+  - Who is acting: the mailbox owner restarting the Core service; then the `SchedulingWorker` in the new process.
+  - What triggered the action: a routine restart (deploy, reboot) after a cycle that already sent a proposal reply for message `msg-1`.
+  - What steps do they take: the owner stops and restarts the service. The new process's first scheduling cycle selects `msg-1` again, consults the persisted `sent_actions` table in the Core SQLite cache, finds the key recorded, and skips the send.
+  - What obstacles or decisions occur: none for the owner — persistence in the database (not process memory) makes the restart invisible to dedupe behavior.
+  - What outcome do they expect: no second email after the restart.
+
+- Scenario: **Transient send failure, then retry.**
+  - Who is acting: the `SchedulingWorker`, with the HostAdapter temporarily unreachable.
+  - What triggered the action: the worker attempts the proposal-reply send and `SendMailAsync` throws.
+  - What steps do they take: because recording happens only after a successful send, no key is written. The existing failure isolation logs the error and continues with the next candidate. On a later cycle, the send is attempted again and, on success, the key is recorded.
+  - What obstacles or decisions occur: a crash in the narrow window between a successful send and the record step could allow one re-send after restart — the accepted Stage 0 at-least-once trade-off, matching the master's queue-retry semantics.
+  - What outcome do they expect: a failed send is retried until it succeeds; a successful send is never repeated (outside the documented at-least-once window).
+
+## Acceptance Criteria
+
+- [x] A `sent_actions` table exists in the Core cache with an idempotent guarded migration (fresh-database and pre-existing-database upgrade paths both covered by tests; running the migration twice is safe).
+  - Evidence: `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md` (all `CoreCacheRepositorySentActionsTests` pass, including migration idempotency, pre-existing-database upgrade, and lazy schema-ensure)
+- [x] A pure, deterministic dedupe-key builder produces `{mailbox}:{messageId}:{actionType}` and is unit-tested, including at least one CsCheck property test per T1 convention (determinism, component ordering, and distinctness for colon-free inputs).
+  - Evidence: `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md` (`SentActionKeyTests` + `SentActionKeyPropertyTests` all passing; 100% file coverage per `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md`)
+- [x] Inside the existing `SendEnabled`-gated block, `SchedulingWorker` consults the store before sending: on a hit it skips the send and logs a structured dedupe-hit message (message id and dedupe key as named template parameters), completing the message as a normal (not failed) outcome; on a miss it sends and then records the key with a timestamp from the injected `TimeProvider`.
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (fail-before counterpart: `evidence/regression-testing/dedupe-expect-fail.2026-07-02T12-10.md`)
+- [x] A repeated worker cycle for the same candidate message does not invoke `ISchedulingService.SendMailAsync` a second time, including across a simulated restart (new worker and store instances over the same in-memory shared-cache SQLite database).
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (`RunCycle_TwoWorkerStorePairsOverOneDatabase_SendExactlyOnceInTotal`)
+- [x] A failed send does NOT record the key (retry remains possible), and the failure stays isolated to that message per the existing `ProcessMessageSafelyAsync` behavior.
+  - Evidence: `evidence/regression-testing/dedupe-pass-after.2026-07-02T12-11.md` (`RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate`)
+- [x] Full C# toolchain passes (format, lint, type-check, architecture, tests); coverage thresholds hold (line >= 85%, branch >= 75%) with changed lines covered; MSTest + FluentAssertions + Moq; no temp files in tests; all files remain under the 500-line cap.
+  - Evidence: `evidence/qa-gates/final-format.2026-07-02T12-12.md`, `evidence/qa-gates/final-build.2026-07-02T12-13.md`, `evidence/qa-gates/final-test-coverage.2026-07-02T12-16.md`, `evidence/qa-gates/coverage-comparison.2026-07-02T12-16.md`, `evidence/other/scope-and-size-verification.2026-07-02T12-18.md`
+
+## Non-Goals
+
+- No `{tenantId}` component in the dedupe key (multi-tenant/Graph is Stage 1; the local key is `{mailbox}:{messageId}:{actionType}`).
+- No changes to `OpenClaw.HostAdapter`, `OpenClaw.MailBridge`, or any wire contract — `SendMailRpcHandler` and `MailRoutes` remain dedupe-unaware; dedupe is enforced at the `SchedulingWorker` call site only.
+- No calendar-write idempotency (no calendar-write path exists yet; master §6.3's `transactionId` guidance applies when Stage 2 adds one).
+- No exactly-once guarantee: the crash window between a successful send and the record step is accepted for Stage 0 (at-least-once, per the master's queue-retry semantics).
+- No audit-log table, retention/cleanup policy, or admin/query surface for `sent_actions` beyond the store interface the worker consumes.
+- No change to kill-switch semantics: `SendEnabled=false` still suppresses all sends and, with this feature, also leaves the dedupe store untouched.

--- a/src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs
+++ b/src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs
@@ -1,0 +1,29 @@
+namespace OpenClaw.Core.Agent;
+
+/// <summary>
+/// Durable send-idempotency store (issue #101). The scheduling worker consults the store
+/// before sending an outbound action and records the action after a successful send so a
+/// restart does not resend the same proposal. The store has no clock dependency: the
+/// caller supplies the timestamp for <see cref="RecordAsync"/>.
+/// </summary>
+public interface ISentActionStore
+{
+    /// <summary>Returns whether the given dedupe key has already been recorded.</summary>
+    /// <param name="dedupeKey">The dedupe key built by <see cref="SentActionKey.Build"/>.</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns><see langword="true"/> when the key is recorded; otherwise <see langword="false"/>.</returns>
+    Task<bool> IsRecordedAsync(string dedupeKey, CancellationToken ct);
+
+    /// <summary>
+    /// Records the given dedupe key. Idempotent: recording an already-recorded key
+    /// succeeds without error and leaves a single record.
+    /// </summary>
+    /// <param name="dedupeKey">The dedupe key built by <see cref="SentActionKey.Build"/>.</param>
+    /// <param name="recordedAtUtc">
+    /// The caller-supplied UTC timestamp of the recorded action (the store has no clock
+    /// dependency).
+    /// </param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>A task that completes when the record is durable.</returns>
+    Task RecordAsync(string dedupeKey, DateTimeOffset recordedAtUtc, CancellationToken ct);
+}

--- a/src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs
+++ b/src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs
@@ -126,8 +126,34 @@ public sealed partial class SchedulingWorker
         }
         else
         {
+            // Send idempotency (issue #101): consult the durable store before sending and
+            // record after a successful send so a restart does not resend the proposal. A
+            // thrown send exception propagates before the record step, preserving the
+            // ProcessMessageSafelyAsync per-message isolation.
+            var dedupeKey = SentActionKey.Build(
+                MailboxUpn(),
+                messageId,
+                SentActionKey.ProposalReply
+            );
+            if (
+                await sentActionStore
+                    .IsRecordedAsync(dedupeKey, cancellationToken)
+                    .ConfigureAwait(false)
+            )
+            {
+                logger.LogInformation(
+                    "Send for message {MessageId} already recorded under dedupe key {DedupeKey}; skipping.",
+                    messageId,
+                    dedupeKey
+                );
+                return;
+            }
+
             await schedulingService
                 .SendMailAsync(BuildProposalReply(context, slots), cancellationToken)
+                .ConfigureAwait(false);
+            await sentActionStore
+                .RecordAsync(dedupeKey, timeProvider.GetUtcNow(), cancellationToken)
                 .ConfigureAwait(false);
         }
 

--- a/src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs
+++ b/src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs
@@ -18,6 +18,7 @@ namespace OpenClaw.Core.Agent.Runtime;
 /// </summary>
 public sealed partial class SchedulingWorker(
     ISchedulingService schedulingService,
+    ISentActionStore sentActionStore,
     ISchedulingCandidateSource candidateSource,
     IOptions<AgentPolicyOptions> policyOptions,
     TimeProvider timeProvider,

--- a/src/OpenClaw.Core/Agent/SentActionKey.cs
+++ b/src/OpenClaw.Core/Agent/SentActionKey.cs
@@ -1,0 +1,57 @@
+namespace OpenClaw.Core.Agent;
+
+/// <summary>
+/// Pure, clock-free builder for send-idempotency dedupe keys. A dedupe key identifies
+/// one outbound action for one message in one mailbox so the scheduling worker can
+/// consult the sent-action store before sending and record after a successful send.
+/// </summary>
+/// <remarks>
+/// Components are joined with <c>:</c> in the fixed order
+/// <c>{mailbox}:{messageId}:{actionType}</c> and are <b>not</b> escaped; key
+/// distinctness is therefore guaranteed only for colon-free components.
+/// </remarks>
+public static class SentActionKey
+{
+    /// <summary>The action type for an outbound proposal reply.</summary>
+    public const string ProposalReply = "proposal-reply";
+
+    /// <summary>
+    /// Builds the dedupe key <c>{mailbox}:{messageId}:{actionType}</c> for the supplied
+    /// components.
+    /// </summary>
+    /// <param name="mailbox">The mailbox UPN the action is performed for.</param>
+    /// <param name="messageId">The identifier of the message the action responds to.</param>
+    /// <param name="actionType">The action type (for example <see cref="ProposalReply"/>).</param>
+    /// <returns>The colon-joined dedupe key.</returns>
+    /// <exception cref="ArgumentException">
+    /// A component is <see langword="null"/>, empty, or whitespace-only.
+    /// </exception>
+    public static string Build(string mailbox, string messageId, string actionType)
+    {
+        if (string.IsNullOrWhiteSpace(mailbox))
+        {
+            throw new ArgumentException(
+                "Value must not be null, empty, or whitespace-only.",
+                nameof(mailbox)
+            );
+        }
+
+        if (string.IsNullOrWhiteSpace(messageId))
+        {
+            throw new ArgumentException(
+                "Value must not be null, empty, or whitespace-only.",
+                nameof(messageId)
+            );
+        }
+
+        if (string.IsNullOrWhiteSpace(actionType))
+        {
+            throw new ArgumentException(
+                "Value must not be null, empty, or whitespace-only.",
+                nameof(actionType)
+            );
+        }
+
+        return $"{mailbox}:{messageId}:{actionType}";
+    }
+}

--- a/src/OpenClaw.Core/CoreCacheRepository.Schema.cs
+++ b/src/OpenClaw.Core/CoreCacheRepository.Schema.cs
@@ -101,7 +101,8 @@ CREATE TABLE IF NOT EXISTS ingest_runs(
     started_at_utc TEXT NOT NULL,
     finished_at_utc TEXT NOT NULL,
     error_message TEXT NULL
-);";
+);
+CREATE TABLE IF NOT EXISTS sent_actions(dedupe_key TEXT PRIMARY KEY, mailbox TEXT NOT NULL, message_id TEXT NOT NULL, action_type TEXT NOT NULL, recorded_at_utc TEXT NOT NULL);";
 
     /// <summary>
     /// The issue-#72 columns added to the Core <c>events</c> table on existing databases via

--- a/src/OpenClaw.Core/CoreCacheRepository.SentActions.cs
+++ b/src/OpenClaw.Core/CoreCacheRepository.SentActions.cs
@@ -1,0 +1,106 @@
+using System.Globalization;
+using Microsoft.Data.Sqlite;
+using OpenClaw.Core.Agent;
+
+namespace OpenClaw.Core;
+
+/// <summary>
+/// <see cref="ISentActionStore"/> implementation for <see cref="CoreCacheRepository"/>
+/// (issue #101). Persists send-idempotency records in the <c>sent_actions</c> table using
+/// the repository's per-call connection pattern. Timestamps are caller-supplied; this
+/// partial has no clock dependency. A lazy once-per-instance schema-ensure guard creates
+/// the <c>sent_actions</c> table before the first store operation so the store is safe on
+/// databases that have not run <see cref="InitializeAsync"/> since the table was added.
+/// </summary>
+internal sealed partial class CoreCacheRepository : ISentActionStore
+{
+    private const string CreateSentActionsTableSql =
+        "CREATE TABLE IF NOT EXISTS sent_actions(dedupe_key TEXT PRIMARY KEY, mailbox TEXT NOT NULL, message_id TEXT NOT NULL, action_type TEXT NOT NULL, recorded_at_utc TEXT NOT NULL);";
+
+    private bool sentActionsSchemaEnsured;
+
+    /// <inheritdoc />
+    public async Task<bool> IsRecordedAsync(string dedupeKey, CancellationToken ct)
+    {
+        await using var connection = Open();
+        await connection.OpenAsync(ct);
+        await EnsureSentActionsSchemaAsync(connection, ct);
+
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT 1 FROM sent_actions WHERE dedupe_key = $key LIMIT 1;";
+        command.Parameters.AddWithValue("$key", dedupeKey);
+        return await command.ExecuteScalarAsync(ct) is not null;
+    }
+
+    /// <inheritdoc />
+    public async Task RecordAsync(
+        string dedupeKey,
+        DateTimeOffset recordedAtUtc,
+        CancellationToken ct
+    )
+    {
+        var (mailbox, messageId, actionType) = ParseSentActionKey(dedupeKey);
+
+        await using var connection = Open();
+        await connection.OpenAsync(ct);
+        await EnsureSentActionsSchemaAsync(connection, ct);
+
+        var command = connection.CreateCommand();
+        command.CommandText =
+            @"
+INSERT INTO sent_actions(dedupe_key, mailbox, message_id, action_type, recorded_at_utc)
+VALUES($dedupe_key, $mailbox, $message_id, $action_type, $recorded_at_utc)
+ON CONFLICT(dedupe_key) DO NOTHING;";
+        command.Parameters.AddWithValue("$dedupe_key", dedupeKey);
+        command.Parameters.AddWithValue("$mailbox", mailbox);
+        command.Parameters.AddWithValue("$message_id", messageId);
+        command.Parameters.AddWithValue("$action_type", actionType);
+        command.Parameters.AddWithValue(
+            "$recorded_at_utc",
+            recordedAtUtc.UtcDateTime.ToString("O", CultureInfo.InvariantCulture)
+        );
+        await command.ExecuteNonQueryAsync(ct);
+    }
+
+    /// <summary>
+    /// Parses the fixed <c>{mailbox}:{messageId}:{actionType}</c> key shape produced by
+    /// <see cref="SentActionKey.Build"/> into its three components.
+    /// </summary>
+    /// <exception cref="ArgumentException">The key does not have three non-empty components.</exception>
+    private static (string Mailbox, string MessageId, string ActionType) ParseSentActionKey(
+        string dedupeKey
+    )
+    {
+        var parts = string.IsNullOrWhiteSpace(dedupeKey) ? [] : dedupeKey.Split(':', 3);
+        if (parts.Length != 3 || parts.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException(
+                $"Dedupe key must have the shape {{mailbox}}:{{messageId}}:{{actionType}}; got '{dedupeKey}'.",
+                nameof(dedupeKey)
+            );
+        }
+
+        return (parts[0], parts[1], parts[2]);
+    }
+
+    /// <summary>
+    /// Lazily ensures the <c>sent_actions</c> table exists, once per repository instance.
+    /// The DDL is <c>CREATE TABLE IF NOT EXISTS</c>, so a concurrent duplicate execution
+    /// is harmless; the flag only avoids repeated DDL round-trips.
+    /// </summary>
+    private async Task EnsureSentActionsSchemaAsync(
+        SqliteConnection connection,
+        CancellationToken ct
+    )
+    {
+        if (sentActionsSchemaEnsured)
+        {
+            return;
+        }
+
+        var command = connection.CreateCommand();
+        command.CommandText = CreateSentActionsTableSql;
+        await command.ExecuteNonQueryAsync(ct);
+        sentActionsSchemaEnsured = true;
+    }
+}

--- a/src/OpenClaw.Core/Program.cs
+++ b/src/OpenClaw.Core/Program.cs
@@ -62,6 +62,7 @@ builder
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<SchedulingDtoMapper>();
 builder.Services.AddSingleton<ISchedulingService, HostAdapterSchedulingService>();
+builder.Services.AddSingleton<ISentActionStore>(sp => sp.GetRequiredService<CoreCacheRepository>());
 builder.Services.AddSingleton<ISchedulingCandidateSource, CacheSchedulingCandidateSource>();
 builder.Services.AddHostedService<SchedulingWorker>();
 

--- a/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OpenClaw.Core.Agent;
+using OpenClaw.Core.Agent.Runtime;
+using OpenClaw.HostAdapter.Contracts;
+using SendMailRequest = OpenClaw.Core.Agent.SendMailRequest;
+
+namespace OpenClaw.Core.Tests.Agent.Runtime;
+
+/// <summary>
+/// Unit tests for the <see cref="SchedulingWorker"/> send-idempotency dedupe seam
+/// (issue #101, AC-3/AC-4/AC-5): consult-before-send skip, record-after-success with the
+/// injected clock timestamp, no-record-on-failure with per-message isolation, kill-switch
+/// composition, and restart persistence over one shared in-memory SQLite database.
+/// </summary>
+[TestClass]
+public sealed class SchedulingWorkerDedupeTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 8, 8, 0, 0, TimeSpan.Zero);
+
+    private static readonly string Msg1Key = SentActionKey.Build(
+        "owner@contoso.com",
+        "msg-1",
+        SentActionKey.ProposalReply
+    );
+
+    private static AgentPolicyOptions Options(bool sendEnabled) =>
+        new()
+        {
+            InternalDomains = new[] { "contoso.com" },
+            InternalDomain = "contoso.com",
+            SendEnabled = sendEnabled,
+            CalendarWriteEnabled = false,
+            NoMeetingBlocks = Array.Empty<string>(),
+            MinNoticeMinutes = 0,
+            PreferredDays = Array.Empty<string>(),
+        };
+
+    private static SchedulingMessageDto Message(string id) =>
+        new(
+            Id: id,
+            Subject: "Project sync",
+            BodyPreview: "Let us meet",
+            BodyContent: null,
+            BodyContentType: null,
+            From: new AttendeeDto("Colleague", "colleague@contoso.com"),
+            Sender: new AttendeeDto("Colleague", "colleague@contoso.com"),
+            ToRecipients: Array.Empty<AttendeeDto>(),
+            CcRecipients: Array.Empty<AttendeeDto>(),
+            ConversationId: "conv-1",
+            ReceivedDateTime: Now,
+            MeetingMessageType: "meetingRequest",
+            Importance: "normal"
+        );
+
+    private static Mock<ISchedulingService> ServiceReturningContext(params string[] ids)
+    {
+        var service = new Mock<ISchedulingService>();
+        foreach (var id in ids)
+        {
+            service
+                .Setup(s => s.GetSchedulingMessageAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Message(id));
+            service
+                .Setup(s => s.GetEventForMessageAsync(id, It.IsAny<CancellationToken>()))
+                .ReturnsAsync((SchedulingEventDto?)null);
+        }
+
+        service
+            .Setup(s => s.GetMailboxSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new MailboxSettingsDto(
+                    "UTC",
+                    new[]
+                    {
+                        DayOfWeek.Monday,
+                        DayOfWeek.Tuesday,
+                        DayOfWeek.Wednesday,
+                        DayOfWeek.Thursday,
+                        DayOfWeek.Friday,
+                    },
+                    new TimeOnly(9, 0),
+                    new TimeOnly(17, 0)
+                )
+            );
+        service
+            .Setup(s =>
+                s.GetFreeBusyAsync(
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(
+                new FreeBusyScheduleDto("owner@contoso.com", Array.Empty<BusyIntervalDto>())
+            );
+        return service;
+    }
+
+    private static Mock<ISchedulingCandidateSource> CandidateSource(params string[] ids)
+    {
+        var source = new Mock<ISchedulingCandidateSource>();
+        source
+            .Setup(s => s.GetCandidateMessageIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ids);
+        return source;
+    }
+
+    private static Mock<ISentActionStore> Store(bool isRecorded)
+    {
+        var store = new Mock<ISentActionStore>();
+        store
+            .Setup(s => s.IsRecordedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(isRecorded);
+        store
+            .Setup(s =>
+                s.RecordAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Returns(Task.CompletedTask);
+        return store;
+    }
+
+    private static SchedulingWorker Worker(
+        Mock<ISchedulingService> service,
+        ISentActionStore sentActionStore,
+        Mock<ISchedulingCandidateSource> source,
+        AgentPolicyOptions options
+    ) =>
+        new(
+            service.Object,
+            sentActionStore,
+            source.Object,
+            Microsoft.Extensions.Options.Options.Create(options),
+            new FakeTimeProvider(Now),
+            NullLogger<SchedulingWorker>.Instance
+        );
+
+    [TestMethod]
+    public async Task RunCycle_StoreHit_SkipsSendAndCompletesWithoutThrowing()
+    {
+        // Arrange: the store already has the msg-1 proposal-reply key recorded.
+        var service = ServiceReturningContext("msg-1");
+        var store = Store(isRecorded: true);
+        var worker = Worker(service, store.Object, CandidateSource("msg-1"), Options(true));
+
+        // Act
+        var act = async () => await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync("a dedupe hit is a normal skip, not a failure");
+        service.Verify(
+            s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+
+    [TestMethod]
+    public async Task RunCycle_StoreMiss_SendsThenRecordsKeyWithInjectedClockTimestamp()
+    {
+        // Arrange: capture call order via Moq callbacks so send-before-record is provable.
+        var callOrder = new List<string>();
+        var service = ServiceReturningContext("msg-1");
+        service
+            .Setup(s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("send"))
+            .Returns(Task.CompletedTask);
+        var store = Store(isRecorded: false);
+        store
+            .Setup(s =>
+                s.RecordAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback(() => callOrder.Add("record"))
+            .Returns(Task.CompletedTask);
+        var worker = Worker(service, store.Object, CandidateSource("msg-1"), Options(true));
+
+        // Act
+        await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert
+        store.Verify(s => s.RecordAsync(Msg1Key, Now, It.IsAny<CancellationToken>()), Times.Once);
+        callOrder
+            .Should()
+            .Equal(["send", "record"], "the record must happen only after a successful send");
+    }
+
+    [TestMethod]
+    public async Task RunCycle_SendFailure_DoesNotRecordAndProcessesNextCandidate()
+    {
+        // Arrange: every send throws; two candidates exercise the isolation path.
+        var service = ServiceReturningContext("msg-1", "msg-2");
+        service
+            .Setup(s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("send failed"));
+        var store = Store(isRecorded: false);
+        var worker = Worker(
+            service,
+            store.Object,
+            CandidateSource("msg-1", "msg-2"),
+            Options(true)
+        );
+
+        // Act
+        var act = async () => await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert
+        await act.Should().NotThrowAsync("per-message isolation must survive a send failure");
+        store.Verify(s => s.IsRecordedAsync(Msg1Key, It.IsAny<CancellationToken>()), Times.Once);
+        store.Verify(
+            s =>
+                s.RecordAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+        service.Verify(
+            s => s.GetSchedulingMessageAsync("msg-2", It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [TestMethod]
+    public async Task RunCycle_SendDisabled_NeverTouchesStoreAndNeverSends()
+    {
+        // Arrange: SendEnabled=false composes with dedupe — the store stays untouched.
+        var service = ServiceReturningContext("msg-1");
+        var store = Store(isRecorded: false);
+        var worker = Worker(service, store.Object, CandidateSource("msg-1"), Options(false));
+
+        // Act
+        await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert
+        store.Verify(
+            s => s.IsRecordedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+        store.Verify(
+            s =>
+                s.RecordAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+        service.Verify(
+            s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+
+    [TestMethod]
+    public async Task RunCycle_TwoWorkerStorePairsOverOneDatabase_SendExactlyOnceInTotal()
+    {
+        // Arrange: a real CoreCacheRepository store over one shared in-memory database
+        // simulates a process restart; the second worker must observe the first record.
+        var connectionString =
+            $"Data Source=worker-dedupe-{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+        var service = ServiceReturningContext("msg-1");
+        service
+            .Setup(s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var firstStore = new OpenClaw.Core.CoreCacheRepository(connectionString);
+        using var secondStore = new OpenClaw.Core.CoreCacheRepository(connectionString);
+        var firstWorker = Worker(service, firstStore, CandidateSource("msg-1"), Options(true));
+        var secondWorker = Worker(service, secondStore, CandidateSource("msg-1"), Options(true));
+
+        // Act: two successive cycles process the same candidate across a "restart".
+        await firstWorker.RunSchedulingCycleAsync(CancellationToken.None);
+        await secondWorker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert
+        service.Verify(
+            s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+}

--- a/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs
@@ -124,14 +124,23 @@ public sealed class SchedulingWorkerTests
         Mock<ISchedulingService> service,
         Mock<ISchedulingCandidateSource> source,
         AgentPolicyOptions options
-    ) =>
-        new(
+    )
+    {
+        // Default store: nothing is recorded, so existing worker tests keep their
+        // pre-dedupe behavior.
+        var sentActionStore = new Mock<ISentActionStore>();
+        sentActionStore
+            .Setup(s => s.IsRecordedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        return new(
             service.Object,
+            sentActionStore.Object,
             source.Object,
             Microsoft.Extensions.Options.Options.Create(options),
             new FakeTimeProvider(Now),
             NullLogger<SchedulingWorker>.Instance
         );
+    }
 
     [TestMethod]
     public async Task RunCycle_SendDisabled_NeverInvokesSendMail()

--- a/tests/OpenClaw.Core.Tests/Agent/SentActionKeyPropertyTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/SentActionKeyPropertyTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using CsCheck;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.Core.Agent;
+
+namespace OpenClaw.Core.Tests.Agent;
+
+/// <summary>
+/// Property-based tests for the pure dedupe-key builder <see cref="SentActionKey"/>
+/// (issue #101, AC-2): determinism, fixed component ordering, and distinctness for
+/// colon-free component triples. CsCheck prints the failing seed on a <c>Sample</c>
+/// failure, satisfying the determinism print-seed requirement.
+/// </summary>
+[TestClass]
+public sealed class SentActionKeyPropertyTests
+{
+    // Colon-free, non-whitespace component: at least one character, drawn from a
+    // range that excludes ':' and whitespace so the ordering and distinctness
+    // properties hold by the builder's documented contract.
+    private static readonly Gen<string> GenComponent = Gen.Char[
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789@._-+"
+        ]
+        .Array[1, 20]
+        .Select(chars => new string(chars));
+
+    private static readonly Gen<(string Mailbox, string MessageId, string ActionType)> GenTriple =
+        Gen.Select(GenComponent, GenComponent, GenComponent);
+
+    [TestMethod]
+    public void Build_IsDeterministic_SameTripleAlwaysYieldsSameKey()
+    {
+        GenTriple.Sample(
+            t =>
+            {
+                var first = SentActionKey.Build(t.Mailbox, t.MessageId, t.ActionType);
+                var second = SentActionKey.Build(t.Mailbox, t.MessageId, t.ActionType);
+
+                first.Should().Be(second);
+            },
+            iter: 1000
+        );
+    }
+
+    [TestMethod]
+    public void Build_ColonFreeComponents_SplitYieldsComponentsInFixedOrder()
+    {
+        GenTriple.Sample(
+            t =>
+            {
+                var key = SentActionKey.Build(t.Mailbox, t.MessageId, t.ActionType);
+
+                var parts = key.Split(':');
+                parts.Should().HaveCount(3);
+                parts[0].Should().Be(t.Mailbox);
+                parts[1].Should().Be(t.MessageId);
+                parts[2].Should().Be(t.ActionType);
+            },
+            iter: 1000
+        );
+    }
+
+    [TestMethod]
+    public void Build_DistinctColonFreeTriples_YieldDistinctKeys()
+    {
+        Gen.Select(GenTriple, GenTriple)
+            .Where(pair => pair.Item1 != pair.Item2)
+            .Sample(
+                pair =>
+                {
+                    var (a, b) = pair;
+                    var keyA = SentActionKey.Build(a.Mailbox, a.MessageId, a.ActionType);
+                    var keyB = SentActionKey.Build(b.Mailbox, b.MessageId, b.ActionType);
+
+                    keyA.Should().NotBe(keyB);
+                },
+                iter: 1000
+            );
+    }
+}

--- a/tests/OpenClaw.Core.Tests/Agent/SentActionKeyTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/SentActionKeyTests.cs
@@ -1,0 +1,78 @@
+using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.Core.Agent;
+
+namespace OpenClaw.Core.Tests.Agent;
+
+/// <summary>
+/// Unit tests for the pure dedupe-key builder <see cref="SentActionKey"/> (issue #101,
+/// AC-2): key format, the <see cref="SentActionKey.ProposalReply"/> constant, and
+/// argument validation for each of the three components.
+/// </summary>
+[TestClass]
+public sealed class SentActionKeyTests
+{
+    [TestMethod]
+    public void Build_WithValidComponents_ReturnsColonJoinedKeyInFixedOrder()
+    {
+        // Arrange
+        var mailbox = "owner@contoso.com";
+        var messageId = "msg-1";
+
+        // Act
+        var key = SentActionKey.Build(mailbox, messageId, SentActionKey.ProposalReply);
+
+        // Assert
+        key.Should().Be("owner@contoso.com:msg-1:proposal-reply");
+    }
+
+    [TestMethod]
+    public void ProposalReply_Constant_IsProposalReplyLiteral()
+    {
+        // Arrange / Act / Assert
+        SentActionKey.ProposalReply.Should().Be("proposal-reply");
+    }
+
+    [TestMethod]
+    [DataRow(null, DisplayName = "null mailbox")]
+    [DataRow("", DisplayName = "empty mailbox")]
+    [DataRow("   ", DisplayName = "whitespace-only mailbox")]
+    public void Build_WithInvalidMailbox_ThrowsArgumentExceptionNamingMailbox(string? mailbox)
+    {
+        // Arrange
+        var act = () => SentActionKey.Build(mailbox!, "msg-1", SentActionKey.ProposalReply);
+
+        // Act / Assert
+        act.Should().Throw<ArgumentException>().WithParameterName("mailbox");
+    }
+
+    [TestMethod]
+    [DataRow(null, DisplayName = "null messageId")]
+    [DataRow("", DisplayName = "empty messageId")]
+    [DataRow("   ", DisplayName = "whitespace-only messageId")]
+    public void Build_WithInvalidMessageId_ThrowsArgumentExceptionNamingMessageId(string? messageId)
+    {
+        // Arrange
+        var act = () =>
+            SentActionKey.Build("owner@contoso.com", messageId!, SentActionKey.ProposalReply);
+
+        // Act / Assert
+        act.Should().Throw<ArgumentException>().WithParameterName("messageId");
+    }
+
+    [TestMethod]
+    [DataRow(null, DisplayName = "null actionType")]
+    [DataRow("", DisplayName = "empty actionType")]
+    [DataRow("   ", DisplayName = "whitespace-only actionType")]
+    public void Build_WithInvalidActionType_ThrowsArgumentExceptionNamingActionType(
+        string? actionType
+    )
+    {
+        // Arrange
+        var act = () => SentActionKey.Build("owner@contoso.com", "msg-1", actionType!);
+
+        // Act / Assert
+        act.Should().Throw<ArgumentException>().WithParameterName("actionType");
+    }
+}

--- a/tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs
+++ b/tests/OpenClaw.Core.Tests/CoreCacheRepositorySentActionsTests.cs
@@ -1,0 +1,212 @@
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.Core.Agent;
+
+namespace OpenClaw.Core.Tests;
+
+/// <summary>
+/// Unit tests for the <see cref="ISentActionStore"/> implementation on
+/// <see cref="OpenClaw.Core.CoreCacheRepository"/> (issue #101, AC-1): record/exists
+/// round-trip, duplicate-record idempotency, caller-supplied timestamp round-trip,
+/// migration idempotency, pre-existing-database upgrade, and the lazy schema-ensure
+/// guard. Uses in-memory shared-cache SQLite so no temp files are created.
+/// </summary>
+[TestClass]
+public sealed class CoreCacheRepositorySentActionsTests
+{
+    private static readonly string Key = SentActionKey.Build(
+        "owner@contoso.com",
+        "msg-1",
+        SentActionKey.ProposalReply
+    );
+
+    private static string NewConnectionString(string label) =>
+        $"Data Source=core-sa-{label}-{Guid.NewGuid():N};Mode=Memory;Cache=Shared";
+
+    private static async Task<bool> TableExistsAsync(SqliteConnection connection, string table)
+    {
+        var command = connection.CreateCommand();
+        command.CommandText =
+            "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = $name;";
+        command.Parameters.AddWithValue("$name", table);
+        return Convert.ToInt32(await command.ExecuteScalarAsync()) == 1;
+    }
+
+    [TestMethod]
+    public async Task IsRecordedAsync_should_return_false_for_unknown_key()
+    {
+        // Arrange
+        using var repo = new OpenClaw.Core.CoreCacheRepository(NewConnectionString("unknown"));
+        await repo.InitializeAsync();
+
+        // Act
+        var recorded = await repo.IsRecordedAsync(Key, CancellationToken.None);
+
+        // Assert
+        recorded.Should().BeFalse("no action has been recorded for the key");
+    }
+
+    [TestMethod]
+    public async Task RecordAsync_then_IsRecordedAsync_should_return_true()
+    {
+        // Arrange
+        using var repo = new OpenClaw.Core.CoreCacheRepository(NewConnectionString("roundtrip"));
+        await repo.InitializeAsync();
+        var recordedAt = new DateTimeOffset(2026, 7, 2, 10, 30, 0, TimeSpan.Zero);
+
+        // Act
+        await repo.RecordAsync(Key, recordedAt, CancellationToken.None);
+        var recorded = await repo.IsRecordedAsync(Key, CancellationToken.None);
+
+        // Assert
+        recorded.Should().BeTrue("the key was just recorded");
+    }
+
+    [TestMethod]
+    public async Task RecordAsync_duplicate_key_should_not_throw_and_leave_one_row()
+    {
+        // Arrange
+        var connectionString = NewConnectionString("duplicate");
+        using var repo = new OpenClaw.Core.CoreCacheRepository(connectionString);
+        await repo.InitializeAsync();
+        var first = new DateTimeOffset(2026, 7, 2, 10, 30, 0, TimeSpan.Zero);
+        var second = new DateTimeOffset(2026, 7, 2, 11, 45, 0, TimeSpan.Zero);
+
+        // Act
+        await repo.RecordAsync(Key, first, CancellationToken.None);
+        var duplicate = async () => await repo.RecordAsync(Key, second, CancellationToken.None);
+
+        // Assert
+        await duplicate.Should().NotThrowAsync("RecordAsync is idempotent for a duplicate key");
+
+        await using var check = new SqliteConnection(connectionString);
+        await check.OpenAsync();
+        var count = check.CreateCommand();
+        count.CommandText = "SELECT COUNT(*) FROM sent_actions WHERE dedupe_key = $key;";
+        count.Parameters.AddWithValue("$key", Key);
+        Convert
+            .ToInt32(await count.ExecuteScalarAsync())
+            .Should()
+            .Be(1, "a duplicate record must not add a second row");
+    }
+
+    [TestMethod]
+    public async Task RecordAsync_should_round_trip_caller_supplied_timestamp_in_iso8601_o_form()
+    {
+        // Arrange: a non-UTC offset verifies the store normalizes to UTC before formatting.
+        var connectionString = NewConnectionString("timestamp");
+        using var repo = new OpenClaw.Core.CoreCacheRepository(connectionString);
+        await repo.InitializeAsync();
+        var recordedAt = new DateTimeOffset(2026, 7, 2, 12, 30, 0, TimeSpan.FromHours(2));
+
+        // Act
+        await repo.RecordAsync(Key, recordedAt, CancellationToken.None);
+
+        // Assert: read back via a direct query on a second connection to the shared database.
+        await using var check = new SqliteConnection(connectionString);
+        await check.OpenAsync();
+        var query = check.CreateCommand();
+        query.CommandText = "SELECT recorded_at_utc FROM sent_actions WHERE dedupe_key = $key;";
+        query.Parameters.AddWithValue("$key", Key);
+        var stored = (string?)await query.ExecuteScalarAsync();
+        stored
+            .Should()
+            .Be(
+                "2026-07-02T10:30:00.0000000Z",
+                "the caller-supplied timestamp must be stored as UTC in round-trip (O) form"
+            );
+    }
+
+    [TestMethod]
+    public async Task InitializeAsync_twice_should_not_throw_and_sent_actions_should_exist()
+    {
+        // Arrange
+        var connectionString = NewConnectionString("initialize");
+        using var repo = new OpenClaw.Core.CoreCacheRepository(connectionString);
+
+        // Act
+        await repo.InitializeAsync();
+        var secondInit = async () => await repo.InitializeAsync();
+
+        // Assert
+        await secondInit.Should().NotThrowAsync("schema initialization must be idempotent");
+
+        await using var check = new SqliteConnection(connectionString);
+        await check.OpenAsync();
+        (await TableExistsAsync(check, "sent_actions"))
+            .Should()
+            .BeTrue("InitializeAsync must create the sent_actions table");
+    }
+
+    [TestMethod]
+    public async Task InitializeAsync_should_add_sent_actions_to_pre_existing_database()
+    {
+        // Arrange: seed an existing database that has a current table but no sent_actions
+        // (the pre-#101 shape). The anchor connection keeps the in-memory database alive.
+        var connectionString = NewConnectionString("upgrade");
+        await using var anchor = new SqliteConnection(connectionString);
+        await anchor.OpenAsync();
+        var seed = anchor.CreateCommand();
+        seed.CommandText =
+            @"
+CREATE TABLE IF NOT EXISTS poll_cursors(
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    observed_at_utc TEXT NOT NULL
+);";
+        await seed.ExecuteNonQueryAsync();
+        (await TableExistsAsync(anchor, "sent_actions"))
+            .Should()
+            .BeFalse("the seeded database must not have sent_actions before the upgrade");
+
+        using var repo = new OpenClaw.Core.CoreCacheRepository(connectionString);
+
+        // Act
+        await repo.InitializeAsync();
+
+        // Assert
+        (await TableExistsAsync(anchor, "sent_actions"))
+            .Should()
+            .BeTrue("InitializeAsync must add sent_actions to a pre-existing database");
+    }
+
+    [TestMethod]
+    [DataRow("", DisplayName = "empty key")]
+    [DataRow("no-colon-key", DisplayName = "no separators")]
+    [DataRow("owner@contoso.com:msg-1", DisplayName = "two components only")]
+    [DataRow("owner@contoso.com: :proposal-reply", DisplayName = "whitespace component")]
+    public async Task RecordAsync_malformed_key_should_throw_ArgumentException(string key)
+    {
+        // Arrange: keys that do not match the fixed {mailbox}:{messageId}:{actionType}
+        // shape must fail fast instead of persisting an unparseable row.
+        using var repo = new OpenClaw.Core.CoreCacheRepository(NewConnectionString("malformed"));
+        await repo.InitializeAsync();
+        var recordedAt = new DateTimeOffset(2026, 7, 2, 10, 30, 0, TimeSpan.Zero);
+
+        // Act
+        var act = async () => await repo.RecordAsync(key, recordedAt, CancellationToken.None);
+
+        // Assert
+        (
+            await act.Should().ThrowAsync<ArgumentException>("the key shape is invalid")
+        ).WithParameterName("dedupeKey");
+    }
+
+    [TestMethod]
+    public async Task Store_methods_should_work_on_fresh_database_without_InitializeAsync()
+    {
+        // Arrange: no InitializeAsync call; the lazy schema-ensure guard must create the table.
+        using var repo = new OpenClaw.Core.CoreCacheRepository(NewConnectionString("lazy"));
+        var recordedAt = new DateTimeOffset(2026, 7, 2, 10, 30, 0, TimeSpan.Zero);
+
+        // Act
+        var missBeforeRecord = await repo.IsRecordedAsync(Key, CancellationToken.None);
+        await repo.RecordAsync(Key, recordedAt, CancellationToken.None);
+        var hitAfterRecord = await repo.IsRecordedAsync(Key, CancellationToken.None);
+
+        // Assert
+        missBeforeRecord.Should().BeFalse("nothing is recorded on a fresh database");
+        hitAfterRecord.Should().BeTrue("the lazy schema-ensure guard makes the store usable");
+    }
+}


### PR DESCRIPTION
## Summary

- Closes the duplicate-send risk accepted at the #99 merge: outbound scheduling replies are now idempotent across retried cycles and process restarts.
- Adds a pure, deterministic dedupe-key builder `SentActionKey` producing `{mailbox}:{messageId}:{actionType}` — the Local MVP form of the master specification's idempotency key (`docs/open-claw-approach.master.md` §6.3); the tenant component is deferred to Stage 1.
- Adds `ISentActionStore` and a persisted `sent_actions` table in the Core SQLite cache (`CoreCacheRepository.SentActions` partial) with an idempotent migration and clock-free, caller-supplied timestamps.
- `SchedulingWorker` consults the store before sending (inside the `SendEnabled`-gated block), skips with a structured dedupe-hit log on a hit, and records the key only after a successful send — a failed send records nothing, so retry remains possible.
- 701 tests passing; pooled coverage 90.63% line / 80.25% branch; new production files at 100% line/branch.

## Why

With the send path wired (PR #100), a retried or repeated scheduling cycle could resend the same reply — recorded as the accepted interim risk in the #99 spec, to be closed by this feature. The master specification requires idempotency keys for mail sends (§6.3). Tracked as gap F6 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`; issue #101.

## What Changed

**Production (`OpenClaw.Core` only)**
- `src/OpenClaw.Core/Agent/SentActionKey.cs` (new) — pure static key builder.
- `src/OpenClaw.Core/Agent/Contracts/ISentActionStore.cs` (new) — store abstraction the worker depends on.
- `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` (new) — `sent_actions` persistence (exists/record, `INSERT ... ON CONFLICT DO NOTHING`, lazy schema-ensure).
- `src/OpenClaw.Core/CoreCacheRepository.Schema.cs` — `sent_actions` DDL appended to `CreateTablesSql`.
- `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.cs` / `SchedulingWorker.Pipeline.cs` — consult-before-send / record-after-success inside the `SendEnabled` gate.
- `src/OpenClaw.Core/Program.cs` — DI registration forwarding the existing repository singleton.

**Tests**
- `SentActionKeyTests` + `SentActionKeyPropertyTests` (CsCheck, existing dependency).
- `CoreCacheRepositorySentActionsTests` — round-trip, migration idempotency, restart persistence (shared-cache in-memory SQLite), malformed-key negative rows.
- `SchedulingWorkerDedupeTests` — skip-on-hit, record-on-success, no-record-on-failure, restart-simulating no-second-send, kill-switch composition; observed failing before the pipeline change and passing after.

**Docs / evidence**
- `docs/features/active/2026-07-02-send-idempotency-dedupe-101/` — issue/spec/user-story, plan (two preflight iterations; build-order fix), baseline/regression/QA-gate evidence, audit artifacts (all MCP-validated).

## Architecture / How It Fits Together

The dedupe guard is a Runtime-layer concern between the deterministic policy decision and the send action: `SchedulingWorker` → (`SendEnabled` gate) → `ISentActionStore.ExistsAsync` → `ISchedulingService.SendMailAsync` → `ISentActionStore.RecordAsync`. Persistence lives in the same Core SQLite cache as the event/message stores, so dedupe state shares the cache's lifecycle and survives restarts.

## Verification

**Completed** (evidence under `docs/features/active/2026-07-02-send-idempotency-dedupe-101/evidence/`):
- Expect-fail (EXIT 1: skip-on-hit, record-on-success, no-record-on-failure, restart-persistence failing; kill-switch composition passing) and pass-after (EXIT 0, 5/5).
- Final toolchain single pass: format clean, build 0 warnings / 0 errors, 701 passed / 0 failed / 5 pre-existing environment-gated skips.
- Coverage: pooled 90.63% line / 80.25% branch (no regression); T1 `OpenClaw.Core` 98.66% / 92.07%; `SentActionKey.cs` and `CoreCacheRepository.SentActions.cs` 100% line/branch.
- Independent feature review at branch head: zero blocking findings, Go; audit artifacts pass the MCP orchestration-artifact validator.

**Recommended**:
- `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SentAction|FullyQualifiedName~SchedulingWorkerDedupe"`

## Backward Compatibility / Migration Notes

- Additive `sent_actions` table via `CREATE TABLE IF NOT EXISTS`; safe on fresh and existing databases. No wire-contract, HostAdapter, or MailBridge changes.
- `SchedulingWorker` gains a constructor dependency (`ISentActionStore`), registered in DI; no caller-visible API change.

## Risks and Mitigations

- At-least-once window (crash between send and record) documented as accepted for Stage 0, consistent with the master's queue-retry semantics.
- Dedupe-hit log content is verified by inspection, not by a capturing-logger assertion (Minor review follow-up; not merge-blocking).

## Review Guide

1. `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` (the guard placement)
2. `src/OpenClaw.Core/CoreCacheRepository.SentActions.cs` and the DDL append
3. `src/OpenClaw.Core/Agent/SentActionKey.cs`
4. Test suites; docs/evidence are mechanical.

## Follow-ups

- Capturing-logger assertion for the dedupe-hit log (Minor).
- Program continues per `docs/research/2026-07-01-open-claw-vision-gap-analysis.md` (next: F7 ordinary-scheduling-mail candidate source + calendarView fallback matching).

## GitHub Auto-close

- Closes #101
