### PR TITLE
feat(core): triage ordinary scheduling mail with calendarView fallback matching

### DIFF
--- a/.claude/agent-memory/feature-review/feedback_per-file-coverage-masking.md
+++ b/.claude/agent-memory/feature-review/feedback_per-file-coverage-masking.md
@@ -43,6 +43,14 @@ converts async methods, per-line cobertura cannot attest the changed lines — v
 explicitly in the audit (accepted disposition on the #99 review; pre-existing setting, not a
 finding against the branch, but recommend the runsettings follow-up as Info).
 
+Async masking recurred on #103 (2026-07-02): SchedulingWorker.Pipeline.cs showed identical
+instrumented figures (20/20 line, 2/4 branch) before and after a +63-line async fallback was
+added — the entire new body was invisible to cobertura. Same accepted disposition as #99:
+behavioral verification (fail-before EXIT-1 evidence + branch-both-ways tests incl. opt-out
+DataRows) with the exclusion stated explicitly in the audit. Useful technique: map the
+partial-condition line numbers to source at BOTH baseline and head to prove the residual
+branch misses are the same pre-existing members merely shifted by the added lines.
+
 Masking also happens at the BRANCH level, not just line level: on issue #18 (2026-07-02) the
 executor's coverage-comparison reported per-file LINE only; the new OutlookScanner.Redaction.cs
 was 100% line but 71.43% branch (10/14) — a Blocking FAIL against the 75% new-file gate — hidden

--- a/.claude/agent-memory/feature-review/project_review-env-fallbacks.md
+++ b/.claude/agent-memory/feature-review/project_review-env-fallbacks.md
@@ -28,9 +28,11 @@ Two environment gaps recur when running feature review in this repo's worktrees:
 Also: no `validate_evidence_locations.py` exists in this repo — do the evidence-location scan with
 `git diff --name-only <base>..HEAD | grep -E '^artifacts/(baselines|baseline|qa|qa-gates|evidence|coverage|regression-testing|post-change)/'`.
 
-Third recurring quirk — **PR-context summary misclassifies C# branches as docs-only.** On both the
-#99 and #101 reviews (2026-07-02) `artifacts/pr_context.summary.txt` "Changed files overview"
-reported "Core logic changes: 0 files" while the authoritative git diff contained 7+ production
-and 4-5 test `.cs` files. Never scope from the summary's file categorization; always use
+Third recurring quirk — **PR-context summary misclassifies C# branches as docs-only.** On the
+#99, #101, and #103 reviews (2026-07-02) `artifacts/pr_context.summary.txt` "Changed files overview"
+reported "Core logic changes: 0 files" while the authoritative git diff contained 4-7+ production
+and 4-6 test `.cs` files. Never scope from the summary's file categorization; always use
 `git diff --stat <merge-base>..HEAD` and record the mismatch as an observation under Rejected
-Scope Narrowing (accepted pattern on both reviews).
+Scope Narrowing (accepted pattern on all three reviews). Newest accepted artifact-set templates
+after #99: #101 `2026-07-02-send-idempotency-dedupe-101/*.2026-07-02T12-27.md` and #103
+`2026-07-02-ordinary-mail-candidates-103/*.2026-07-02T13-36.md`.

--- a/.claude/agent-memory/orchestrator/MEMORY.md
+++ b/.claude/agent-memory/orchestrator/MEMORY.md
@@ -1,5 +1,7 @@
 # Orchestrator Memory Index
 
+- [OpenClaw delivery loop](project_openclaw-delivery-loop.md) — validated per-feature loop (PRs 96-102): hooks force full-feature docs; pr-author receipt recipe; origin/main for merge-base.
+- [OpenClaw vision program status](project_openclaw-vision-program-status.md) — 4-epic/20-feature program; F1-F6 done as of 2026-07-02; queue + resume instructions.
 - [Surface consequential decisions](feedback_surface-consequential-decisions.md) — confirm only NOVEL irreversible forks; policy-defined steps (PR open, commits, CI monitoring) run autonomously.
 - [Harness governance](project_harness-governance.md) — harness is now version-controlled (Issue #66/PR #68); `.claude/rules/*` is canonical; AGENTS.md + .github/instructions match it.
 - [Core agent = namespace not project](project_core-agent-namespace-not-project.md) — new logic for OpenClaw.Core folds into a namespace, not a new project (arch rule 6); enforce with namespace NetArchTest.

--- a/.claude/agent-memory/orchestrator/project_openclaw-delivery-loop.md
+++ b/.claude/agent-memory/orchestrator/project_openclaw-delivery-loop.md
@@ -1,0 +1,18 @@
+---
+name: openclaw-delivery-loop
+description: Validated per-feature delivery loop for open-claw-bridge (worked for PRs 96-102); hook constraints, promotion mechanics, pr-author receipt recipe
+metadata:
+  type: project
+---
+
+Validated per-feature delivery loop in open-claw-bridge (proven on F1-F6 / PRs #96, #97, #98, #100, #102 during the vision-program session of 2026-07-01/02):
+
+1. `git fetch origin main && git checkout -b <type>/<short-name>-<issue> origin/main` (worktree's local `main` is stale — always use `origin/main` for branch base AND merge-base; executors/reviewers must be told this explicitly).
+2. Existing issue: `new_active_feature_folder` directly. New feature: `new_potential_entry` -> fill the potential file (Read scaffold first; Write tool requires a read) -> `potential_to_issue` (creates the GitHub issue) -> `new_active_feature_folder`.
+3. Always `full-feature`/`full-bug` mode with a `prd-feature` delegation producing issue.md + spec.md + user-story.md. **Why:** `enforce-prd-feature-before-planner` and `enforce-feature-folder-order` hooks require spec.md AND user-story.md unconditionally (no minor-audit exemption), despite the promotion-lifecycle skill saying minor-audit folders must omit them. For bugs, user-story.md is justified in-file as a planner-gate requirement.
+4. atomic-planner writes into the scaffolded `plan.<ts>.md` (in place); validate with `validate_orchestration_artifacts(plan)`; atomic-executor preflight (`DIRECTIVE: PREFLIGHT VALIDATION ONLY`) -> revise via planner in place if CHANGES REQUIRED -> execute (`DIRECTIVE: FULL EXECUTION AUTHORIZED`, "do not commit").
+5. Orchestrator commits (conventional message + Refs + trailers), refreshes `collect_pr_context(base=main)`, delegates feature-review with merge-base/folder/context/AC-source only (no scope language). Blocking findings -> R1-R5 remediation loop with `remediation_loop.cycles[]` checkpoint shape.
+6. PR: no pr-author subagent exists — the orchestrator itself follows the pr-author SKILL: refresh collect_pr_context, Write `artifacts/pr_body_<N>.md`, then receipt via `pwsh -NoProfile -Command '...Get-FileHash...'` (single-quote the whole -Command for bash), then `gh pr create --body-file artifacts/pr_body_<N>.md`. Hook verifies receipt.
+7. CI poll: `gh pr checks <n> --json bucket,name,state` in a sleep-20 loop; merge with `gh pr merge <n> --merge` (merge commit only); auto-close needs `- Closes #N` bullets (multiple allowed).
+
+**How to apply:** reuse this loop verbatim for the remaining program features (F7-F20 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`); resume position lives in `artifacts/orchestration/orchestrator-state.json` (gitignored, local to the worktree). Related: [[openclaw-vision-program-status]].

--- a/.claude/agent-memory/orchestrator/project_openclaw-vision-program-status.md
+++ b/.claude/agent-memory/orchestrator/project_openclaw-vision-program-status.md
@@ -1,0 +1,17 @@
+---
+name: openclaw-vision-program-status
+description: OpenClaw vision-delivery program (docs/open-claw-approach.master.md) - epic/feature queue and completion status as of 2026-07-02
+metadata:
+  type: project
+---
+
+Program: deliver the full OpenClaw vision (`docs/open-claw-approach.master.md`) as 4 epics / 20 features. Roadmap + gap analysis: `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`. Checkpoint: `artifacts/orchestration/orchestrator-state.json` (gitignored — exists only in the worktree where the session ran).
+
+**Why:** user directive 2026-07-01: orchestrate end-to-end epics until the entire vision is delivered; each feature must pass audit + CI, merge via merge commit, then next feature.
+
+Status as of 2026-07-02 (F6 done):
+- Epic A (data integrity) COMPLETE: F1 #80/PR96, F2 #19/PR97, F3 #82 closed-by-verification (no PR), F4 #18+#20/PR98 (1 remediation cycle; epic #21 closed).
+- Epic B (Stage 0 runtime): F5 #99/PR100 (send wired; SendEnabled default false), F6 #101/PR102 (sent_actions dedupe) done. Remaining: F7 ordinary-mail candidate source + calendarView fallback matching, F8 recurring 1:1 move-history persistence, F9 structured audit log for outbound actions, F10 ENABLE_ORGANIZER_RESCHEDULE / ENABLE_ATTENDEE_PROPOSE_NEW_TIME flag scaffolding.
+- Epic C (Stage 1 cloud groundwork, F11-F17) and Epic D (Stage 2 writes/audit, F18-F20) not started. All tenant-dependent verification ships as mocked-Graph tests + human runbooks (`human_interaction` exceptions) — this environment/CI has no Azure tenant credentials (research Automation Feasibility section is authoritative).
+
+**How to apply:** on resume, read the checkpoint first; if absent (new worktree), reconstruct position from this memory + closed issues/PRs; continue the queue in order using [[openclaw-delivery-loop]].

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/code-review.2026-07-02T13-36.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/code-review.2026-07-02T13-36.md
@@ -1,0 +1,77 @@
+# Code Review: ordinary-mail-candidates (#103)
+
+**Review Date:** 2026-07-02
+**Branch:** `feature/ordinary-mail-candidates-103` @ `0f346d5e74a5543526ba8e642fe684b73475dba3`
+**Base:** `main` @ merge-base `3dae644d98dcb564767002a51503e6b9944e4eab` (origin/main)
+**Scope:** Full branch diff — 4 production `.cs`, 6 test `.cs`, feature docs/evidence Markdown, orchestrator agent-memory Markdown (29 files, +1934/-5)
+
+## Executive Summary
+
+The implementation is small, well-factored, and closely follows the spec's design decisions. The candidate widening is a one-literal change with the doc updated as required. `RelatedEventMatcher` is a faithful pure port of master Section 9.2 with named constants, set semantics, and a deliberately stronger deterministic tie-break (documented as spec decision D1); it reuses the existing normalization helpers and the `GeneratedRegex` pattern. The pipeline fallback is one guarded block plus one private method, keeps all I/O behind the `ISchedulingService` seam, derives the window from the injected `TimeProvider`, and logs per the spec (LogDebug attempt/no-match, LogInformation match with score via the internal with-score overload — avoiding recomputation). Tests are strong: 30 new test cases including four genuine CsCheck properties, a real in-memory SQLite repository suite, and fail-before evidence for both delivered behaviors. No Blocking or Major findings; three Minor/Info observations below, none requiring remediation.
+
+## Findings Table
+
+| Severity | File | Location | Finding | Recommendation | Rationale | Evidence |
+|----------|------|----------|---------|----------------|-----------|----------|
+| Minor | src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs | line 22 (unchanged) | Production class reads `DateTimeOffset.UtcNow` directly to anchor the lookback window; the new `CacheSchedulingCandidateSourceTests` are therefore forced to seed rows relative to real now instead of a `FakeTimeProvider`. Pre-existing line, not introduced by this branch. | Follow-up (out of feature scope): inject `TimeProvider` into `CacheSchedulingCandidateSource` and pin the new tests to a fixed epoch, per the csharp.md clock-seam rule. | The csharp.md clock-seam rule prefers injected `TimeProvider` for all time reads; the current anchor makes the four repository tests wall-clock-relative (deterministic in practice only because margins are generous: 1-4h offsets vs a 48h window, -100h stale row). | Diff hunk for `CacheSchedulingCandidateSource.cs` shows the `sinceUtc` line as unchanged context; test class XML doc documents the accommodation. |
+| Info | src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs | lines 29-40, 74-123 | The new fallback code is `async` and contributes zero instrumented coverage lines because the pre-existing `mailbridge.runsettings` `ExcludeByAttribute=CompilerGeneratedAttribute` filter omits async state-machine bodies. Per-line cobertura cannot attest the changed lines in this file. | Keep the existing behavioral-verification disposition (7 fallback tests + fail-before evidence). Repo follow-up (already recommended on the #99 review): evaluate removing `CompilerGeneratedAttribute` from `ExcludeByAttribute` so async bodies contribute per-line data. | Instrumentation-scope masking is a known pattern in this repo (accepted disposition on #99); the runsettings file is byte-identical to base on this branch, so this is not a finding against the branch. | Reviewer cobertura parse: `SchedulingWorker.Pipeline.cs` 20/20 instrumented lines at baseline and post-change; the new method bodies absent from both reports. `evidence/qa-gates/coverage-review.2026-07-02T13-36.md`. |
+| Info | src/OpenClaw.Core/Agent/RelatedEventMatcher.cs | lines 180, 186, 189 (`PrecedesInTieBreak`) | Five of 48 branch condition-arms are uncovered — all nullable-lifted compiler branches in the tie-break: the lifted `Start` comparison arms and the null arms of `candidate.Id ?? string.Empty` / `current.Id ?? string.Empty` (no test ties two qualifying events where one has a null `Id`). File is at 89.58% branch, above the 75% gate. | Optional hardening: add one tie-break row with `Start` equal and one event's `Id` null to pin the documented "null treated as empty string" rule directly. | Uncovered branch arms usually name an untested scenario; here the scenario is the null-`Id` tie-break the spec explicitly documents, so a directed row would make the documented rule regression-proof. Not a gate failure. | Reviewer cobertura parse: partial conditions {180: 8/10, 186: 1/2, 189: 2/4}. |
+
+## Implementation Audit
+
+### C# implementation audit
+
+#### What changed well
+
+- **Candidate widening (AC-1)** is exactly the minimal spec-prescribed edit: the `ListMessagesAsync` kind literal and the XML summary. Lookback, limit, and ordering code untouched (verified in diff — 3-line production hunk).
+- **`RelatedEventMatcher` (AC-2)** uses named constants for the weights/threshold/token-length, `HashSet` set semantics matching the master's `Set`, `StringComparer.Ordinal` after explicit `ToLowerInvariant()` (correct, culture-safe), and reuses `MeetingContextNormalizer.EmailOf` so message-side and event-side email normalization are identical. The organizer exclusion is documented with the reference rationale. The internal `ChooseMostLikelyRelatedEventWithScore` overload gives the pipeline the score for logging without a second scoring pass — a clean minimal-surface solution.
+- **Tie-break determinism** is a documented, deliberate deviation from the reference's first-wins loop (spec D1): earliest `Start` (null last), then ordinal `Id` (null as empty). The implementation in `PrecedesInTieBreak` matches the documented rule case-by-case, and the property suite pins permutation invariance, which is the observable guarantee the deviation exists to provide.
+- **Pipeline fallback (AC-4/AC-5)** is guarded (`meetingEvent is null && options.CalendarViewFallbackDays > 0`), derives both window bounds from `timeProvider.GetUtcNow()` (no wall-clock APIs), forwards the cancellation token, uses `.ConfigureAwait(false)` per file convention, and flows the result into the identical `MeetingContextNormalizer.Normalize` call — no duplicate normalize path and no new exception handling.
+- **Logging** matches the spec exactly: LogDebug on attempt (message id + ISO window bounds) and no-match; LogInformation on match (message id, event id, score).
+
+#### Type safety and API notes
+
+- Null contracts are explicit: `ArgumentNullException.ThrowIfNull` on both public inputs; degenerate content (null subject, null ids, empty attendee lists) never throws — pinned by unit tests.
+- Public surface additions are minimal and spec-sanctioned: one public static method and one options property. Everything else is `internal`/`private`.
+- `AgentPolicyOptions.CalendarViewFallbackDays` keeps the options bag's no-validator convention; the non-positive opt-out is documented in the XML doc and enforced at the use site.
+
+#### Error handling and logging
+
+- No catch blocks added; failure degradation intentionally reuses the existing envelope-to-empty-list mapping in `HostAdapterSchedulingService.GetCalendarViewAsync` and the existing `ProcessMessageSafelyAsync` per-message isolation. Test `RunCycle_FailureEnvelopeMappedToEmptyWindow_ProceedsWithoutException` pins the degradation observable.
+
+## Test Quality Audit
+
+### Reviewed test and QA artifacts
+
+- `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherTests.cs` (NEW) — 14 scenario tests, AAA with because-messages.
+- `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherPropertyTests.cs` (NEW) — 4 CsCheck properties, 1000 iterations, overlapping generator pools so accept and reject branches are both sampled; permutation via seeded Fisher-Yates (generated seed, reproducible).
+- `tests/OpenClaw.Core.Tests/Agent/Runtime/CacheSchedulingCandidateSourceTests.cs` (NEW) — real `CoreCacheRepository` on in-memory shared-cache SQLite; no temp files; unique database name per test.
+- `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerFallbackTests.cs` (NEW) — `FakeTimeProvider` pinned epoch; exact window-bound verification (`Now`..`Now.AddDays(14)`); hydration proven through the outbound reply subject (behavioral observable, not implementation introspection).
+- `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` / `SchedulingWorkerTests.cs` (MODIFIED) — explicit `GetCalendarViewAsync` empty-window stubs added (the spec called out that relying on Moq loose defaults would be fragile); new cross-cycle ordinary-mail dedupe test with a stateful store double and an exact recorded-key-set assertion.
+- Executor evidence set under `evidence/` (baseline, qa-gates, regression-testing) — timestamps, commands, and exit codes present in every artifact; coverage-comparison numbers independently reproduced by the reviewer to the hundredth.
+
+### Quality assessment
+
+- **Fail-before discrimination:** both expect-fail artifacts name the exact failing tests and the exact production gap (widening: 2 of 4 fail pre-change with the behavior-preserving pair passing — a precise discriminator; fallback: 3 of 3 fail pre-change). This is regression evidence of the right shape.
+- **Scenario completeness:** positive, negative, boundary (exact threshold 4 vs score 3), normalization, determinism (both tie-break axes), opt-out edge values (0 and -1), error degradation, and cross-cycle state are all covered. The dedupe test asserts consult-count, record-count, key equality, and the full recorded-key set.
+- **No weakening:** no test deleted; the shared-stub additions strengthen explicitness. Assertions carry specific expected values (exact id sequences, exact reply subjects, exact window bounds).
+- **Minor observations:** the null-`Id` tie-break arm is untested (Findings Table, Info); the candidate-source tests are wall-clock-relative due to the pre-existing production anchor (Findings Table, Minor).
+
+## Security / Correctness Checks
+
+- No secrets, credentials, or `.env` content in the diff.
+- No new external input surface: the matcher consumes already-hydrated DTOs; the window fetch goes through the existing authenticated seam.
+- Regex safety: `[^a-z0-9]+` split via `GeneratedRegex` is linear-time; no catastrophic backtracking risk; inputs are message/event subjects (bounded).
+- Side-effect safety unchanged: sends remain behind `SendEnabled` (default off) plus the #101 dedupe store; calendar writes behind `CalendarWriteEnabled`; the fallback itself is read-only compute-plus-logs.
+- Volume risk (widened candidate set) is bounded by `Defaults.Limit` and documented as an accepted Local-MVP risk with a named follow-up (per-kind quota) in the spec.
+
+## Research Log
+
+- Verified the master-reference fidelity claims against the spec's D1 description: weights (+2/+3), threshold (4), token rule (lowercase, non-alphanumeric split, length >= 4, distinct), participant sources (From, Sender, To, Cc), attendee union (required+optional+resource, organizer excluded) — all present in the implementation exactly.
+- Verified the tie-break partial branches by mapping cobertura line numbers to source: 180 (compound lifted-`Start` condition), 186 (lifted `<`), 189 (two `?? string.Empty` arms).
+- Verified the pipeline's two partially-covered branches are pre-existing: baseline cobertura lines 170/177 = post-change 233/240 = `MailboxUpn()` ternary and `BuildProposalReply` slots ternary (both outside the diff hunks).
+- Confirmed `ISchedulingService` is byte-identical to base (`GetCalendarViewAsync` pre-existed for this purpose), so no contract change occurred.
+
+## Verdict
+
+**Approve — no blockers.** One Minor follow-up (TimeProvider injection for the candidate source) and two Info observations (async instrumentation scope; optional null-Id tie-break row), none of which gate the merge. Code quality, test quality, determinism, and seam discipline all meet repository policy.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/baseline-csharpier-check.2026-07-02T13-02.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/baseline-csharpier-check.2026-07-02T13-02.md
@@ -1,0 +1,6 @@
+# Baseline — CSharpier Check
+
+Timestamp: 2026-07-02T13-02
+Command: `csharpier check .`
+EXIT_CODE: 0
+Output Summary: Checked 212 files in 442ms; zero formatting violations. Clean tree at baseline.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/baseline-dotnet-build.2026-07-02T13-02.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/baseline-dotnet-build.2026-07-02T13-02.md
@@ -1,0 +1,6 @@
+# Baseline — dotnet build (lint/type gate)
+
+Timestamp: 2026-07-02T13-02
+Command: `dotnet build OpenClaw.MailBridge.sln`
+EXIT_CODE: 0
+Output Summary: Build succeeded — 0 Warning(s), 0 Error(s) with TreatWarningsAsErrors and full analyzer stack enabled. All 9 projects built (Contracts, HostAdapter.Contracts, Client, MailBridge, Core, HostAdapter, and 3 test projects). Analyzer and nullable gates clean at baseline.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/baseline-dotnet-test.2026-07-02T13-02.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/baseline-dotnet-test.2026-07-02T13-02.md
@@ -1,0 +1,14 @@
+# Baseline — dotnet test with coverage
+
+Timestamp: 2026-07-02T13-02
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+EXIT_CODE: 0
+Output Summary:
+- OpenClaw.HostAdapter.Tests: Passed 100, Failed 0, Skipped 0 (total 100)
+- OpenClaw.Core.Tests: Passed 254, Failed 0, Skipped 0 (total 254)
+- OpenClaw.MailBridge.Tests: Passed 347, Failed 0, Skipped 5 (total 352)
+- Suite total: 701 passed, 0 failed, 5 skipped (706 total)
+- Pooled line coverage: 90.63% (4207/4642 lines covered across the three Cobertura reports)
+- Pooled branch coverage: 80.25% (947/1180 branches covered)
+- Per-report: Core.Tests line 89.97% / branch 79.29%; MailBridge.Tests line 93.58% / branch 88.16%; HostAdapter.Tests line 87.70% / branch 67.19%
+- Raw Cobertura copies: `artifacts/csharp/baseline-2026-07-02T13-02/coverage.{core,mailbridge,hostadapter}.cobertura.xml`

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/phase0-instructions-read.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/phase0-instructions-read.md
@@ -1,0 +1,26 @@
+# Phase 0 — Policy Instructions Read
+
+Timestamp: 2026-07-02T13-02
+
+Policy Order:
+1. `CLAUDE.md`-loaded standing rules (auto-loaded project instructions)
+2. `.claude/rules/general-code-change.md`
+3. `.claude/rules/general-unit-test.md`
+4. `.claude/rules/csharp.md`
+5. `.claude/rules/architecture-boundaries.md`
+6. `.claude/rules/quality-tiers.md`
+
+Files read:
+- `.claude/rules/general-code-change.md` (auto-loaded, confirmed in context)
+- `.claude/rules/general-unit-test.md` (auto-loaded, confirmed in context)
+- `.claude/rules/csharp.md` (read in full)
+- `.claude/rules/architecture-boundaries.md` (read in full)
+- `.claude/rules/quality-tiers.md` (auto-loaded, confirmed in context)
+- `.claude/rules/tonality.md` (auto-loaded, confirmed in context)
+- `.claude/rules/ci-workflows.md` (auto-loaded, confirmed in context)
+- `.claude/rules/benchmark-baselines.md` (auto-loaded, confirmed in context)
+- `.claude/rules/orchestrator-state.md` (auto-loaded, confirmed in context)
+
+Notes:
+- `.claude/rules/csharp.md` names xUnit/NSubstitute; the plan (Open Questions) documents that `tests/OpenClaw.Core.Tests` is established on MSTest + Moq + FluentAssertions + CsCheck and the spec mandates that stack. This plan follows the repository's established convention.
+- CSharpier is invoked as the global tool (`csharpier format .` / `csharpier check .`), version 1.3.0; there is no local dotnet-tools manifest entry.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-comparison.2026-07-02T13-21.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-comparison.2026-07-02T13-21.md
@@ -1,0 +1,35 @@
+# Coverage Comparison — Baseline vs Post-Change (#103)
+
+Timestamp: 2026-07-02T13-21
+Sources:
+- Baseline (P0-T4): `artifacts/csharp/baseline-2026-07-02T13-02/coverage.{core,mailbridge,hostadapter}.cobertura.xml`
+- Post-change (P5-T4): `artifacts/csharp/final-2026-07-02T13-21/coverage.{core,mailbridge,hostadapter}.cobertura.xml`
+
+## Pooled (all three test projects)
+
+| Metric | Baseline | Post-change | Delta |
+|---|---|---|---|
+| Line coverage | 90.63% (4207/4642) | 90.81% (4298/4733) | +0.18 pp |
+| Branch coverage | 80.25% (947/1180) | 80.62% (990/1228) | +0.37 pp |
+
+## Core package (OpenClaw.Core, the changed assembly)
+
+| Metric | Baseline | Post-change | Delta |
+|---|---|---|---|
+| Line coverage | 89.97% (1561/1735) | 90.47% (1652/1826) | +0.50 pp |
+| Branch coverage | 79.29% (360/454) | 80.27% (403/502) | +0.98 pp |
+
+## Changed production files (post-change, Core Cobertura)
+
+| File | Line coverage | Branch coverage | Notes |
+|---|---|---|---|
+| `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs` (new) | 100.00% (91/91) | 89.58% (43/48) | New pure matcher; every instrumented line covered by 14 unit + 4 property tests. |
+| `src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs` | 100.00% (5/5) | n/a (no branches) | Identical to baseline (100%); the changed kind-literal line is covered by 4 new tests. |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` | 100.00% (20/20 instrumented) | 50.00% (2/4 instrumented) | Identical instrumented figures to baseline (20/20, 2/4 — the residual branch miss is the pre-existing `MailboxUpn` ternary, untouched by this change). The new fallback code is `async` and therefore compiled into a CompilerGenerated state machine that the pre-existing runsettings instrumentation exclusion omits from the denominator (same treatment as every other async pipeline member at baseline). Its behavior is directly verified by 7 `SchedulingWorkerFallbackTests` (window bounds, match hydration, no-match, non-positive opt-out x2, sub-threshold, failure degradation). |
+| `src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs` | not instrumented | n/a | Auto-property accessors are CompilerGenerated and excluded from instrumentation at baseline and post-change alike (file absent from both reports). The new `CalendarViewFallbackDays` default (14) and opt-out are verified behaviorally by `RunCycle_LookupMiss_FetchesCalendarViewFromNowToNowPlusFourteenDays` and `RunCycle_NonPositiveFallbackDays_NeverFetchesCalendarView`. |
+
+## Threshold Verdicts
+
+- Line coverage >= 85%: **PASS** (pooled 90.81%; Core package 90.47%)
+- Branch coverage >= 75%: **PASS** (pooled 80.62%; Core package 80.27%)
+- No coverage regression on changed lines: **PASS** — every changed file's instrumented coverage is equal to or better than baseline (candidate source 100% -> 100%; pipeline 100%/50% -> 100%/50% with the sole branch miss pre-existing and untouched; matcher is new at 100% line / 89.58% branch); pooled and Core-package coverage both increased.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-review.2026-07-02T13-36.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-review.2026-07-02T13-36.md
@@ -1,0 +1,37 @@
+# Reviewer Coverage Re-Run — Feature Review (#103)
+
+Timestamp: 2026-07-02T13-36
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory "docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-review"`
+EXIT_CODE: 0
+Branch head: `0f346d5e74a5543526ba8e642fe684b73475dba3`; merge base: `3dae644d98dcb564767002a51503e6b9944e4eab` (origin/main)
+
+## Test Results
+
+- OpenClaw.HostAdapter.Tests: 100 passed, 0 failed, 0 skipped
+- OpenClaw.Core.Tests: 284 passed, 0 failed, 0 skipped
+- OpenClaw.MailBridge.Tests: 347 passed, 0 failed, 5 skipped (environment-gated COM/publish tests, same as baseline)
+- Suite total: 731 passed, 0 failed, 5 skipped (736 total)
+
+## Independently Parsed Coverage (fresh cobertura, this run)
+
+Reports: three `coverage.cobertura.xml` files under `evidence/qa-gates/coverage-review/{2300629f...,4f1a1449...,75d17a89...}/`.
+
+Pooled (per-line max across reports, deduped duplicate class entries per partial-class file):
+
+- Line: 4298/4733 = 90.81% (baseline 4207/4642 = 90.63%; +0.18 pp)
+- Branch: 990/1228 = 80.62% (baseline 947/1180 = 80.25%; +0.37 pp)
+
+These pooled figures are identical to the executor evidence in `evidence/qa-gates/coverage-comparison.2026-07-02T13-21.md` — the match is the verification.
+
+## Per-Changed-File (line AND branch, reviewer-parsed)
+
+| File | Line | Branch | Notes |
+|---|---|---|---|
+| `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs` (new) | 100.00% (91/91) | 89.58% (43/48) | Partial conditions at lines 180, 186, 189 are nullable-lifted compiler branches in the tie-break (`Start` lifted comparison, `Id ?? string.Empty` null arms). Gate: PASS (>= 85 / >= 75). |
+| `src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs` | 100.00% (5/5) | n/a (no branch points) | Identical to baseline (100%). No regression. |
+| `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` | 100.00% (20/20 instrumented) | 50.00% (2/4 instrumented) | Identical to baseline (20/20, 2/4). The two partial conditions (post-change lines 233, 240) are the pre-existing `MailboxUpn` and `BuildProposalReply` ternaries — verified by inspecting baseline lines 170/177, which are the same members shifted by the +63 added lines. The new fallback code is `async` and excluded from instrumentation by the pre-existing runsettings `CompilerGeneratedAttribute` filter; it is behaviorally verified by the 7 `SchedulingWorkerFallbackTests` cases plus fail-before evidence (`expect-fail-worker-fallback.2026-07-02T13-11.md`, EXIT 1). |
+| `src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs` | not instrumented | n/a | Auto-property accessors are CompilerGenerated; file absent from baseline and post-change reports alike. The new `CalendarViewFallbackDays` default and opt-out are behaviorally verified by `RunCycle_LookupMiss_FetchesCalendarViewFromNowToNowPlusFourteenDays` and `RunCycle_NonPositiveFallbackDays_NeverFetchesCalendarView(0,-1)`. |
+
+## Baseline Cross-Check
+
+Executor baseline cobertura at `artifacts/csharp/baseline-2026-07-02T13-02/` parsed with the same tool: pooled 90.63% line (4207/4642), 80.25% branch (947/1180); `SchedulingWorker.Pipeline.cs` 20/20 line, 2/4 branch; `RelatedEventMatcher.cs` not present (new file). Confirms no regression on changed lines.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-csharpier-check.2026-07-02T13-21.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-csharpier-check.2026-07-02T13-21.md
@@ -1,0 +1,6 @@
+# Final QA — CSharpier Check
+
+Timestamp: 2026-07-02T13-21
+Command: `csharpier check .`
+EXIT_CODE: 0
+Output Summary: Checked 217 files in 546ms; zero formatting violations after the format loop settled.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-csharpier-format.2026-07-02T13-21.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-csharpier-format.2026-07-02T13-21.md
@@ -1,0 +1,6 @@
+# Final QA — CSharpier Format
+
+Timestamp: 2026-07-02T13-21
+Command: `csharpier format .`
+EXIT_CODE: 0
+Output Summary: First loop pass reformatted a subset of the new feature files (matcher, matcher tests, candidate-source tests, dedupe tests); loop restarted per plan rule. Final pass: "Formatted 217 files in 412ms" with zero content changes (verified by the immediately following `csharpier check .` exiting 0 and `git status` showing only the intended feature edits). Files reformatted on the final pass: 0.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-dotnet-build.2026-07-02T13-21.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-dotnet-build.2026-07-02T13-21.md
@@ -1,0 +1,6 @@
+# Final QA — dotnet build (lint/type gate)
+
+Timestamp: 2026-07-02T13-21
+Command: `dotnet build OpenClaw.MailBridge.sln`
+EXIT_CODE: 0
+Output Summary: Build succeeded — 0 Warning(s), 0 Error(s) with TreatWarningsAsErrors, full analyzer stack, and nullable analysis enabled. All 9 projects built, including the new `RelatedEventMatcher.cs` and the modified pipeline/options/candidate-source files.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-dotnet-test.2026-07-02T13-21.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-dotnet-test.2026-07-02T13-21.md
@@ -1,0 +1,15 @@
+# Final QA — dotnet test with coverage
+
+Timestamp: 2026-07-02T13-21
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`
+EXIT_CODE: 0
+Output Summary:
+- OpenClaw.HostAdapter.Tests: Passed 100, Failed 0, Skipped 0 (total 100)
+- OpenClaw.Core.Tests: Passed 284, Failed 0, Skipped 0 (total 284; +30 vs baseline — 14 matcher unit, 4 matcher property, 4 candidate-source, 7 fallback, 1 ordinary-mail dedupe)
+- OpenClaw.MailBridge.Tests: Passed 347, Failed 0, Skipped 5 (total 352)
+- Suite total: 731 passed, 0 failed, 5 skipped (736 total)
+- Pooled post-change line coverage: 90.81% (4298/4733)
+- Pooled post-change branch coverage: 80.62% (990/1228)
+- Per-report: Core.Tests line 90.47% / branch 80.27%; MailBridge.Tests line 93.58% / branch 88.16%; HostAdapter.Tests line 87.70% / branch 67.19%
+- Architecture-boundary tests, unit tests, property tests, and dedupe tests all run in this suite.
+- Raw Cobertura copies: `artifacts/csharp/final-2026-07-02T13-21/coverage.{core,mailbridge,hostadapter}.cobertura.xml`

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-scope-and-caps.2026-07-02T13-21.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-scope-and-caps.2026-07-02T13-21.md
@@ -1,0 +1,22 @@
+# Final QA — Scope and Size Caps
+
+Timestamp: 2026-07-02T13-21
+Command: `git fetch origin main --quiet; git diff --name-only origin/main...HEAD; git status --porcelain; wc -l <touched .cs files>`
+EXIT_CODE: 0
+Output Summary:
+- The branch has no commits yet (the orchestrator handles commits), so `git diff --name-only origin/main...HEAD` is empty; scope was verified from `git status --porcelain` (tracked modifications + untracked additions).
+- Changed production files (exactly the Conventions-enumerated set):
+  - `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs` (new) — 191 lines
+  - `src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs` — 95 lines
+  - `src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs` — 29 lines
+  - `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` — 258 lines
+- Changed/new test files (Phases 1-4 set):
+  - `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherTests.cs` (new) — 257 lines
+  - `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherPropertyTests.cs` (new) — 273 lines
+  - `tests/OpenClaw.Core.Tests/Agent/Runtime/CacheSchedulingCandidateSourceTests.cs` (new) — 175 lines
+  - `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerFallbackTests.cs` (new) — 312 lines
+  - `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs` — 330 lines
+  - `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` — 364 lines
+- Feature-folder evidence/docs: `docs/features/active/2026-07-02-ordinary-mail-candidates-103/**` (plan checklist, spec AC check-offs, evidence artifacts) and raw intermediates under `artifacts/csharp/`.
+- Non-feature working-tree entries owned by the orchestrator session (not produced by plan execution): `.claude/agent-memory/orchestrator/MEMORY.md` (modified) and two `.claude/agent-memory/orchestrator/project_*.md` files (untracked). No production or test file outside the plan scope was touched by this execution.
+- Verdict: no out-of-scope production file in the change set; every touched `.cs` file is <= 500 lines (max observed: 364).

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/regression-testing/expect-fail-candidate-widening.2026-07-02T13-11.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/regression-testing/expect-fail-candidate-widening.2026-07-02T13-11.md
@@ -1,0 +1,12 @@
+# Expect-Fail Evidence — Candidate Widening (P2-T1)
+
+Timestamp: 2026-07-02T13-11
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~CacheSchedulingCandidateSourceTests"`
+EXIT_CODE: 1
+Output Summary:
+- Failed: 2, Passed: 2, Total: 4 (OpenClaw.Core.Tests.dll)
+- Failing tests (expected — production still filters `item_kind = 'meeting'`):
+  - `GetCandidateMessageIds_returns_mail_alongside_meeting_within_window` (mail-inclusion assertion)
+  - `GetCandidateMessageIds_preserves_recency_ordering_across_kinds` (mail rows absent from result)
+- Passing tests (behavior-preserving pre/post change): lookback exclusion, limit cap.
+- This is the required fail-before state for P2-T2 (kind literal `"meeting"` -> `"all"`).

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/regression-testing/expect-fail-worker-fallback.2026-07-02T13-11.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/regression-testing/expect-fail-worker-fallback.2026-07-02T13-11.md
@@ -1,0 +1,12 @@
+# Expect-Fail Evidence — Worker CalendarView Fallback (P3-T1)
+
+Timestamp: 2026-07-02T13-11
+Command: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerFallbackTests"`
+EXIT_CODE: 1
+Output Summary:
+- Failed: 3, Passed: 0, Total: 3 (OpenClaw.Core.Tests.dll)
+- Failing tests (expected — fallback not yet implemented in `SchedulingWorker.Pipeline.cs`):
+  - `RunCycle_LookupMiss_FetchesCalendarViewFromNowToNowPlusFourteenDays` (GetCalendarViewAsync never invoked)
+  - `RunCycle_WindowEventClearsThreshold_HydratesEventContextIntoSendPath` (reply subject remains message-derived)
+  - `RunCycle_EmptyWindow_ProceedsMessageOnlyWithoutThrowing` (GetCalendarViewAsync Times.Once verification fails)
+- File compiles against current production types only; this is the required fail-before state for P3-T4.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/feature-audit.2026-07-02T13-36.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/feature-audit.2026-07-02T13-36.md
@@ -1,0 +1,52 @@
+# Feature Audit: ordinary-mail-candidates (#103)
+
+**Audit Date:** 2026-07-02
+**Branch:** `feature/ordinary-mail-candidates-103` @ `0f346d5e74a5543526ba8e642fe684b73475dba3`
+**Work Mode:** `full-feature` (persisted marker `- Work Mode: full-feature` in `issue.md`)
+**AC Sources:** `spec.md` and `user-story.md` (identical AC sets; mirrored in `issue.md`)
+
+## Scope and Baseline
+
+- Resolved base branch: `main` (origin/main; the local `main` ref is stale per caller inputs).
+- Merge-base SHA: `3dae644d98dcb564767002a51503e6b9944e4eab`; branch head: `0f346d5e74a5543526ba8e642fe684b73475dba3` (single commit).
+- Evidence sources: `artifacts/pr_context.summary.txt` and `artifacts/pr_context.appendix.txt` (refreshed for this head), the authoritative `git diff 3dae644..0f346d5` (29 files, +1934/-5; 4 production `.cs`, 6 test `.cs`), executor evidence under `docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/`, and the reviewer's independent toolchain re-run at branch head (format EXIT 0; build 0/0; 731 tests passed / 0 failed / 5 env-gated skips; fresh cobertura parsed per changed file — `evidence/qa-gates/coverage-review.2026-07-02T13-36.md`).
+- Note: the PR-context summary's file categorization ("Core logic changes: 0 files") is inaccurate for this branch; the audit scoped from the authoritative git diff (recorded in the policy audit's Rejected Scope Narrowing section).
+
+## Acceptance Criteria Inventory
+
+Seven checkbox criteria, identical in `spec.md` (lines 123-129) and `user-story.md` (lines 45-51), mirrored in `issue.md` (lines 25-31). All arrived checked `[x]` by the executor.
+
+1. AC-1 — Candidate source returns ordinary mail alongside meeting messages (kind `"all"`), preserving lookback/limit/ordering; new unit test against in-memory SQLite `CoreCacheRepository`.
+2. AC-2 — New pure static `RelatedEventMatcher` ports Section 9.2 exactly (tokens >= 4 chars at +2, participant emails at +3, threshold 4, tie-break earliest `Start` null-last then ordinal `Id`); unit tests cover the named rows.
+3. AC-3 — CsCheck property tests: null-or-score>=4, permutation invariance, case-insensitivity, duplicate set semantics.
+4. AC-4 — On direct-lookup miss, `SchedulingWorker.ProcessMessageAsync` fetches `GetCalendarViewAsync(now, now + CalendarViewFallbackDays)`; new `AgentPolicyOptions` value default 14; `now` from injected `TimeProvider`; non-positive skips; verified with mocked service and `FakeTimeProvider`.
+5. AC-5 — No-match falls through to message-only `Normalize(mailboxUpn, message, null)` without a new exception path; a match hydrates through the same `Normalize` call.
+6. AC-6 — Widened candidates re-listed every cycle; sends deduplicated by the #101 store with unchanged key shape; dedupe tests extended with an ordinary-mail scenario.
+7. AC-7 — Full C# toolchain passes; coverage thresholds hold with changed lines covered; all touched files <= 500 lines.
+
+## Acceptance Criteria Evaluation
+
+| # | Criterion | Verdict | Evidence |
+|---|-----------|---------|----------|
+| AC-1 | Candidate widening to `item_kind = 'mail'` with unchanged lookback/limit/ordering | PASS | Diff: kind literal `"meeting"` -> `"all"` plus doc update, nothing else changed in the method. Repository predicate for `"all"` pre-existed. 4 new tests against a real in-memory shared-cache SQLite `CoreCacheRepository` (inclusion, lookback, limit, ordering). Fail-before evidence: `expect-fail-candidate-widening.2026-07-02T13-11.md` EXIT 1 with exactly the 2 widening-discriminating tests failing and the 2 behavior-preserving tests passing. Reviewer re-run green. |
+| AC-2 | Pure `RelatedEventMatcher` exact Section 9.2 port with deterministic tie-break | PASS | `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs` (new, 191 lines): lowercase split on `[^a-z0-9]+`, length >= 4, distinct; participants From/Sender/To/Cc via `MeetingContextNormalizer.EmailOf`; attendee union required+optional+resource, organizer excluded; +2/+3 weights; threshold 4; tie-break earliest `Start` (null last) then ordinal `Id` (null as empty) in `PrecedesInTieBreak`. 14 unit tests cover every named row (subject-only, attendee-only, combined, sub-threshold, exact-threshold, empty-input, both tie-break axes). Reviewer-parsed coverage 100.00% line / 89.58% branch. |
+| AC-3 | CsCheck property/invariant tests for the matcher | PASS | `RelatedEventMatcherPropertyTests.cs` (new): 4 properties at 1000 iterations — result null-or-score>=4; permutation invariance (seeded Fisher-Yates shuffle); case-insensitivity (uppercasing subjects/emails); duplicate tokens/emails do not change the score. Genuine CsCheck `Gen`/`Sample` usage matching the suite convention; satisfies the T1 property-test density gate for the new pure function. |
+| AC-4 | Calendar-view fallback with `CalendarViewFallbackDays` (default 14), TimeProvider-derived `now`, non-positive opt-out | PASS | Diff: guarded block in `ProcessMessageAsync` (`meetingEvent is null && options.CalendarViewFallbackDays > 0`) and `ChooseRelatedEventFromWindowAsync` using `timeProvider.GetUtcNow()` for both bounds. `AgentPolicyOptions.CalendarViewFallbackDays` default 14 with Section 9.2 XML doc. Tests: exact window-bounds verification against `FakeTimeProvider` `Now`..`Now.AddDays(14)`; opt-out DataRows (0, -1) verify the fetch never happens. Fail-before evidence: `expect-fail-worker-fallback.2026-07-02T13-11.md` EXIT 1 (3 discriminating tests). |
+| AC-5 | No-match falls through to message-only triage via the same `Normalize` call; match hydrates identically | PASS | Diff shows a single `MeetingContextNormalizer.Normalize(MailboxUpn(), message, meetingEvent)` call downstream of the fallback — no duplicate normalize path, no new catch blocks. Tests: empty window, all-below-threshold, and failure-envelope-mapped-to-empty-window each proceed without exception and produce the message-derived reply subject; the match test proves event hydration through the event-derived reply subject (`Re: Project sync planning`). |
+| AC-6 | Cross-cycle re-listing with unchanged #101 dedupe key shape, ordinary-mail dedupe scenario | PASS | `RunCycle_OrdinaryMailAcrossTwoCycles_SendsOnceWithUnchangedKeyShape` (new): plain-mail candidate (null `MeetingMessageType`) re-listed across two cycles with a stateful `ISentActionStore` double; asserts `SendMailAsync` exactly once, `IsRecordedAsync(mailKey)` exactly twice, `RecordAsync(mailKey, Now)` exactly once, and the recorded key set equals exactly `[SentActionKey.Build("owner@contoso.com", "mail-1", SentActionKey.ProposalReply)]` — the unchanged #101 key shape. No production change to `SentActionKey` (absent from diff). |
+| AC-7 | Full toolchain + coverage thresholds + 500-line caps | PASS | Reviewer re-ran at head `0f346d5`: `csharpier check .` EXIT 0 (217 files); `dotnet build` 0 warnings / 0 errors (analyzers + nullable as errors); NetArchTest boundary tests inside the 284/284 Core.Tests pass; full suite 731 passed / 0 failed / 5 env-gated skips; pooled coverage 90.81% line / 80.62% branch (gates 85/75); no regression (+0.18pp/+0.37pp; per-file figures equal or exceed baseline); all 10 touched `.cs` files <= 500 lines (max 364, `wc -l` reviewer-verified). Async-fallback instrumentation exclusion documented and behaviorally covered (policy audit Section 8). |
+
+## Summary
+
+All seven acceptance criteria evaluate PASS with independently re-verified evidence: the diff delivers exactly the spec's implementation scope (four production files), both delivered behaviors carry discriminating fail-before/pass-after regression evidence, the new pure function meets the T1 property-test obligation with four genuine CsCheck properties, and the reviewer's fresh toolchain and coverage runs reproduce the executor's numbers exactly (pooled 90.81% line / 80.62% branch; new matcher file 100.00% line / 89.58% branch). No Blocking or Major findings; the code review records one Minor follow-up (TimeProvider injection for the pre-existing wall-clock anchor in `CacheSchedulingCandidateSource`) and two Info observations. Remediation is not required. Recommendation: **Go for PR**.
+
+## Acceptance Criteria Check-off
+
+All seven criteria were already checked `[x]` by the executor in both authoritative source files (`spec.md`, `user-story.md`) and the `issue.md` mirror. Per the acceptance-criteria-tracking protocol, the reviewer verified each PASS verdict against the checked state; no new check-offs were needed and no criterion required unchecking. Criterion text was not modified.
+
+### Acceptance Criteria Status
+- Source: `docs/features/active/2026-07-02-ordinary-mail-candidates-103/spec.md`, `docs/features/active/2026-07-02-ordinary-mail-candidates-103/user-story.md` (mirror: `issue.md`)
+- Total AC items: 7
+- Checked off (delivered): 7
+- Remaining (unchecked): 0
+- Items remaining: none

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/issue.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/issue.md
@@ -1,0 +1,48 @@
+# ordinary-mail-candidates (Issue #103)
+
+- Date captured: 2026-07-02
+- Author: drmoisan
+- Status: Promoted -> docs/features/active/ordinary-mail-candidates/ (Issue #103)
+
+- Issue: #103
+- Issue URL: https://github.com/drmoisan/open-claw-bridge/issues/103
+- Last Updated: 2026-07-02
+- Work Mode: full-feature
+
+## Problem / Why
+
+The master specification defines two input classes (`docs/open-claw-approach.master.md` §2.2): formal meeting traffic and **ordinary scheduling mail** ("can we move this?", "what works next week?"). Today only the first class is handled: `CacheSchedulingCandidateSource.GetCandidateMessageIdsAsync` (`src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs`) selects only `item_kind = 'meeting'` messages, and `HostAdapterSchedulingService.GetEventForMessageAsync` does a direct event-by-id lookup returning null on a miss — there is no `calendarView`-window fallback with the subject/attendee-overlap matching heuristic the master specifies (§9.2 `chooseMostLikelyRelatedEvent`, §9.3 step 3). Ordinary scheduling threads are never triaged. Identified as gap F7 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`.
+
+## Proposed Behavior
+
+- Extend the candidate source so ordinary (non-meeting) messages become scheduling candidates alongside formal meeting traffic.
+- Add a pure, deterministic event-matching helper in `OpenClaw.Core.Agent` porting the master's §9.2 `chooseMostLikelyRelatedEvent`: tokenize the message subject (length >= 4 tokens), collect message participants, score candidate events by subject-token overlap (+2 per token) and attendee-email overlap (+3 per person), and return the best match only when the score is >= 4; ties resolve deterministically (stable ordering).
+- When the direct event-by-id lookup misses, the runtime queries a bounded `calendarView` window (default 14 days forward, matching §9.2) through the existing Graph-shaped surface and applies the matcher to select the most likely related event; no match means the triage proceeds with a message-only context (which the existing `TriageEngine` already supports — e.g. `IGNORE`/`HUMAN_APPROVAL` outcomes).
+- All scoring/selection logic is pure and unit-testable; only the window fetch touches the client seam.
+
+## Acceptance Criteria
+
+- [x] `CacheSchedulingCandidateSource.GetCandidateMessageIdsAsync` returns ordinary (`item_kind = 'mail'`) messages alongside meeting messages (repository kind `"all"`), preserving the existing lookback window, limit, and ordering; formal meeting-traffic handling is unchanged; covered by a new unit test against an in-memory SQLite `CoreCacheRepository`.
+- [x] A new pure static `RelatedEventMatcher` in `OpenClaw.Core.Agent` ports §9.2 `chooseMostLikelyRelatedEvent` exactly: distinct lowercase subject tokens (split on non-alphanumeric runs, length >= 4) score +2 per token also present in the event subject; distinct normalized participant emails (from, sender, to, cc) score +3 per email present in the event attendee set (required + optional + resource); the best event is returned only when its score >= 4; ties resolve deterministically by earliest `Start` (null last) then ordinal `Id`; unit tests cover subject-only, attendee-only, combined, sub-threshold, empty-input, and tie-break rows.
+- [x] CsCheck property/invariant tests cover the matcher: the result is null or scores >= 4; the selected event is invariant under permutation of the input event list; scoring is case-insensitive; duplicate tokens/emails do not double-count (set semantics).
+- [x] When `GetEventForMessageAsync` returns null, `SchedulingWorker.ProcessMessageAsync` fetches `ISchedulingService.GetCalendarViewAsync(now, now + CalendarViewFallbackDays)` and applies the matcher; `CalendarViewFallbackDays` is a new `AgentPolicyOptions` value defaulting to 14; `now` comes from the injected `TimeProvider` (no wall-clock APIs); a non-positive configured value skips the fallback; verified with mocked `ISchedulingService` and `FakeTimeProvider`.
+- [x] No-match (empty window, all scores < 4, or a failure envelope mapped to an empty window) falls through to message-only triage (`MeetingContextNormalizer.Normalize(mailboxUpn, message, null)`) without a new exception path; a matched event hydrates the context through the same `Normalize` call formal traffic uses.
+- [x] Widened candidates are re-listed every cycle (no candidate cursor exists); outbound proposal sends remain deduplicated across cycles by the #101 sent-action store with the unchanged key shape — verified by extending the existing dedupe tests with an ordinary-mail scenario.
+- [x] Full C# toolchain passes (CSharpier, analyzers, build, architecture, tests); coverage thresholds hold (line >= 85%, branch >= 75%) with changed lines covered; all touched files remain <= 500 lines.
+
+## Constraints & Risks
+
+- Widening the candidate set increases processed volume; the dedupe store (#101) and `SendEnabled` gate bound the blast radius. Verified during spec authoring: no candidate cursor exists — the source re-lists the lookback window every cycle for meeting traffic today, so widening changes volume, not reprocessing semantics (see spec.md, Design Decisions).
+- Matching is heuristic by design; the master mandates the deterministic decision come from code, which this preserves (fixed weights/threshold).
+- MSTest + FluentAssertions + Moq + CsCheck; no temp files; 500-line cap; pure logic in `OpenClaw.Core.Agent`, I/O in Runtime seam only.
+
+## Test Conditions to Consider
+
+- [ ] Unit: matcher scoring rows (subject-only, attendee-only, combined, sub-threshold, tie-break).
+- [ ] Unit: candidate source includes ordinary mail; excludes already-processed per existing cursor semantics.
+- [ ] Unit: runtime fallback path (miss -> window fetch -> match / no-match), mocked client.
+
+## Next Step
+
+- [x] Promote to GitHub issue (feature request template)
+- [x] Create active feature folder from the template

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/plan.2026-07-02T12-43.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/plan.2026-07-02T12-43.md
@@ -1,0 +1,112 @@
+# ordinary-mail-candidates - Plan
+
+- **Issue:** #103
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-07-02T12-43
+- **Status:** Draft
+- **Version:** 0.2
+- **Work Mode:** full-feature (per `issue.md` metadata)
+
+## Required References
+
+- General Coding Standards: `.claude/rules/general-code-change.md`
+- General Unit Test Policy: `.claude/rules/general-unit-test.md`
+- C# Standards: `.claude/rules/csharp.md`
+- Architecture Boundaries: `.claude/rules/architecture-boundaries.md`
+- Quality Tiers: `.claude/rules/quality-tiers.md`
+- Authoritative requirements: `docs/features/active/2026-07-02-ordinary-mail-candidates-103/spec.md` (7 acceptance criteria)
+
+**All work must comply with these policies; do not duplicate their content here.**
+
+## Conventions Used Throughout This Plan
+
+- `<FEATURE>` = `docs/features/active/2026-07-02-ordinary-mail-candidates-103`
+- `<ISO>` = the actual run timestamp in `yyyy-MM-ddTHH-mm` format at artifact creation time.
+- Evidence artifacts go under `<FEATURE>/evidence/<kind>/` only. Raw command intermediates (TRX, Cobertura XML, build logs) go under `artifacts/csharp/`. Writing evidence to `artifacts/baselines/`, `artifacts/qa/`, `artifacts/coverage/`, or `artifacts/evidence/` is a policy violation.
+- Every command-step evidence artifact MUST contain: `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (1-20 lines). Test-step artifacts MUST include numeric line and branch coverage in `Output Summary:`.
+- Toolchain commands (C#): `csharpier format .` / `csharpier check .` (global tool 1.3.0; not `dotnet csharpier` — no local tool manifest), `dotnet build OpenClaw.MailBridge.sln`, `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`.
+- Diff scope is confined to: `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs` (new), `src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs`, `src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs`, `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs`, and the test files named in Phases 1-4. No HostAdapter, MailBridge, or wire-contract changes.
+- Test stack: MSTest + FluentAssertions + Moq + CsCheck (established convention of `tests/OpenClaw.Core.Tests`); clock via injected `TimeProvider` / `FakeTimeProvider`; no temp files (in-memory shared-cache SQLite per `CoreCacheRepositoryMessageFieldsTests` convention); 500-line cap on all touched files.
+
+## Implementation Plan (Atomic Tasks)
+
+### Phase 0 — Compliance and Baseline Capture
+
+- [x] [P0-T1] Read repository policies in the required order — `CLAUDE.md`-loaded rules, `.claude/rules/general-code-change.md`, `.claude/rules/general-unit-test.md`, `.claude/rules/csharp.md`, `.claude/rules/architecture-boundaries.md`, `.claude/rules/quality-tiers.md` — and write `<FEATURE>/evidence/baseline/phase0-instructions-read.md` containing `Timestamp:`, `Policy Order:`, and the explicit list of files read.
+  - Acceptance: artifact exists at the named path with all three required fields populated.
+- [x] [P0-T2] Capture the formatting baseline by running `csharpier check .` from the repo root and writing `<FEATURE>/evidence/baseline/baseline-csharpier-check.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`.
+  - Acceptance: artifact exists with all four fields; `EXIT_CODE:` records the actual exit code (expected 0 on a clean tree).
+- [x] [P0-T3] Capture the build/lint/type baseline by running `dotnet build OpenClaw.MailBridge.sln` and writing `<FEATURE>/evidence/baseline/baseline-dotnet-build.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (warnings-as-errors count, analyzer status).
+  - Acceptance: artifact exists with all four fields; `EXIT_CODE: 0`.
+- [x] [P0-T4] Capture the test-and-coverage baseline by running `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"`, copying raw TRX/Cobertura outputs under `artifacts/csharp/`, and writing `<FEATURE>/evidence/baseline/baseline-dotnet-test.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, and an `Output Summary:` that includes pass/fail counts and numeric baseline line-coverage and branch-coverage percentages (no placeholders).
+  - Acceptance: artifact exists with all four fields; `Output Summary:` contains numeric line % and branch % values; raw coverage files are under `artifacts/csharp/`.
+
+### Phase 1 — Pure Matcher (RelatedEventMatcher)
+
+- [x] [P1-T1] Create `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs`: a pure static class porting master §9.2 `chooseMostLikelyRelatedEvent` per spec D1 — public API exactly `public static SchedulingEventDto? ChooseMostLikelyRelatedEvent(SchedulingMessageDto message, IReadOnlyList<SchedulingEventDto> events)`; `ArgumentNullException` on null arguments; subject tokenization via a `GeneratedRegex` (lowercase, split on `[^a-z0-9]+`, keep tokens length >= 4, distinct) following the `MeetingContextNormalizer.Helpers.cs` pattern; participant emails from `From`, `Sender`, `ToRecipients`, `CcRecipients` normalized via the existing `MeetingContextNormalizer.NormalizeEmail`/`EmailOf`, empties dropped, distinct; event attendee set = union of `RequiredAttendees` + `OptionalAttendees` + `ResourceAttendees` (organizer excluded); score +2 per shared subject token, +3 per shared participant email; return the best event only when score >= 4; tie-break among max-scoring qualifiers by earliest `Start` (null `Start` last) then ordinal `Id` (null treated as empty string). Also expose an `internal` overload or helper returning the selected event together with its score so the Phase 3 fallback can log the score without recomputing.
+  - Acceptance: file compiles under `dotnet build OpenClaw.MailBridge.sln` with zero warnings; file <= 500 lines; no I/O, clock, or randomness APIs referenced.
+- [x] [P1-T2] Create `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherTests.cs` (MSTest + FluentAssertions) covering, as individually named tests: subject-only match (two tokens, score 4, accepted), attendee-only match (two participants, score 6, accepted), combined token+participant (score 5, accepted), sub-threshold (score 3, returns null), exact-threshold (score 4, accepted), tie-break by earliest `Start` with null-`Start` sorting last, tie-break by ordinal `Id` when `Start` ties, empty event list returns null, null/short-token subject scores 0 from subject, case-insensitive token and email matching, organizer email not counted, and `ArgumentNullException` for null `message` and null `events`.
+  - Acceptance: file <= 500 lines; every listed scenario has a dedicated test; all tests in the file pass via `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~RelatedEventMatcherTests"`.
+- [x] [P1-T3] Create `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherPropertyTests.cs` (CsCheck, mirroring `MeetingContextNormalizerPropertyTests` conventions) with properties: (a) result is null or the selected event's score >= 4; (b) the selected event is invariant under permutation of the input event list; (c) scoring is case-insensitive (uppercasing subjects/emails does not change the selection); (d) duplicated subject tokens and duplicated participant/attendee emails do not change the score (set semantics).
+  - Acceptance: file <= 500 lines; all four properties present and passing via `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~RelatedEventMatcherPropertyTests"`.
+
+### Phase 2 — Candidate Widening (Test-First)
+
+- [x] [P2-T1] [expect-fail] Create `tests/OpenClaw.Core.Tests/Agent/Runtime/CacheSchedulingCandidateSourceTests.cs` (new file; none exists) using an in-memory shared-cache SQLite `CoreCacheRepository` (`Data Source=candidate-source-{Guid.NewGuid():N};Mode=Memory;Cache=Shared`, per `CoreCacheRepositoryMessageFieldsTests` convention; no temp files): seed one `item_kind = 'meeting'` row and one `item_kind = 'mail'` row inside the lookback window plus one row outside it; tests assert (a) both in-window bridge ids are returned (mail alongside meeting), (b) the lookback window excludes the stale row, (c) `Defaults.Limit` caps the result, (d) recency ordering is preserved. Run the file with `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~CacheSchedulingCandidateSourceTests"` and record the observed failure of the mail-inclusion test in `<FEATURE>/evidence/regression-testing/expect-fail-candidate-widening.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` naming the failing test(s).
+  - Acceptance: file compiles; the mail-inclusion assertion fails against the current `"meeting"` literal; evidence artifact exists with all four fields.
+- [x] [P2-T2] Update `src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs`: change the `ListMessagesAsync` kind literal from `"meeting"` to `"all"` and update the XML summary (currently "meeting-message identifiers") to describe the widened candidate set (meeting plus ordinary mail); make no other changes to lookback, limit, or ordering.
+  - Acceptance: diff touches only the kind literal and XML doc text in this file; file <= 500 lines.
+- [x] [P2-T3] Rerun `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~CacheSchedulingCandidateSourceTests"` and confirm all Phase 2 tests pass, including the previously failing mail-inclusion test.
+  - Acceptance: exit code 0 for the filtered run; zero failed tests.
+
+### Phase 3 — CalendarView Fallback (Option + Worker Pipeline)
+
+- [x] [P3-T1] [expect-fail] Create `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerFallbackTests.cs` (new file — `SchedulingWorkerTests.cs` is ~330 lines and adding fallback tests there risks the 500-line cap) with tests that compile against existing types only (mocked `ISchedulingService`, `FakeTimeProvider` pinned to a fixed instant, Moq, MSTest, FluentAssertions): (a) when `GetEventForMessageAsync` returns null, the worker calls `GetCalendarViewAsync(now, now + 14 days)` with bounds exactly equal to `FakeTimeProvider` now and now+14d (default option value); (b) a window event that clears the matcher threshold hydrates the meeting context — observable because the pipeline behaves as event-linked (assert via mock-verified downstream interaction, e.g. the send path receiving event-derived context under `SendEnabled = true`, following existing `SchedulingWorkerTests` observation patterns); (c) an empty window proceeds to message-only triage with no exception thrown. Run the file with `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerFallbackTests"` and record the failures in `<FEATURE>/evidence/regression-testing/expect-fail-worker-fallback.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` naming the failing tests.
+  - Acceptance: file compiles against the current production types; tests (a)-(c) fail (fallback not yet implemented); evidence artifact exists with all four fields; file <= 500 lines.
+- [x] [P3-T2] Add `public int CalendarViewFallbackDays { get; set; } = 14;` to `src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs` with XML docs citing master §9.2 (14-day forward window) and documenting that a non-positive value skips the fallback (opt-out).
+  - Acceptance: property present with default 14 and XML docs; file <= 500 lines; `dotnet build OpenClaw.MailBridge.sln` succeeds.
+- [x] [P3-T3] Update the existing worker test mocks to explicitly stub `GetCalendarViewAsync` returning an empty `IReadOnlyList<SchedulingEventDto>`: `ServiceReturningContext()` (and any per-test service mocks that reach the pipeline past hydration) in `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs`, and the service mocks in `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs`. Do not rely on Moq loose-mock default values (spec Constraints & Risks requires explicit stubs).
+  - Acceptance: every `Mock<ISchedulingService>` used by worker tests that can reach the fallback path has an explicit `GetCalendarViewAsync` setup; both files remain <= 500 lines. This task MUST complete before P3-T5's solution build/test run (build-order gate: the production change in P3-T4 alters which service methods existing tests exercise).
+- [x] [P3-T4] Implement the fallback in `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` inside `ProcessMessageAsync`, immediately after the `GetEventForMessageAsync` call: when the direct lookup returns null and `options.CalendarViewFallbackDays > 0`, compute `now = timeProvider.GetUtcNow()`, fetch `schedulingService.GetCalendarViewAsync(now, now.AddDays(options.CalendarViewFallbackDays), cancellationToken)`, and apply `RelatedEventMatcher` to select the related event (the matched event, or null, flows into the existing `MeetingContextNormalizer.Normalize(MailboxUpn(), message, meetingEvent)` call — no new exception path). Log `LogDebug` when the fallback is attempted (message id, window bounds), `LogInformation` on match (message id, event id, score via the internal matcher overload from P1-T1), `LogDebug` on no-match. Skip the fetch entirely when `CalendarViewFallbackDays <= 0`. No wall-clock APIs; I/O through `ISchedulingService` only.
+  - Acceptance: file <= 500 lines; `dotnet build OpenClaw.MailBridge.sln` succeeds with zero warnings; the fallback runs for any direct-lookup miss (not gated on `item_kind`).
+- [x] [P3-T5] Add the remaining fallback tests to `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerFallbackTests.cs` (these compile only after P3-T2): (d) `CalendarViewFallbackDays = 0` and `= -1` never call `GetCalendarViewAsync` (mock `Verify` never); (e) all window events scoring below 4 fall through to message-only triage; (f) a failure envelope mapped to an empty window (mock returning empty list, matching `HostAdapterSchedulingService` degradation) proceeds message-only without exception. Then run the full worker suite: `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorker"`.
+  - Acceptance: filtered run exits 0; the P3-T1 expect-fail tests now pass; file <= 500 lines.
+
+### Phase 4 — Dedupe Regression (Ordinary-Mail Scenario)
+
+- [x] [P4-T1] Extend `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` with an ordinary-mail scenario per AC-6: a plain-mail message (non-meeting `MeetingMessageType`) whose direct event lookup misses, with `SendEnabled = true`, processed across two scheduling cycles; assert the proposal reply is sent exactly once and the sent-action store is consulted/recorded with the unchanged #101 key shape `SentActionKey.Build(mailboxUpn, messageId, SentActionKey.ProposalReply)`.
+  - Acceptance: new test passes via `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerDedupeTests"`; file <= 500 lines; no changes to `SentActionKey` or the production send path.
+
+### Phase 5 — Final QA Loop and Coverage Comparison
+
+> Loop rule: if any task P5-T1 through P5-T4 fails or changes files, fix the cause and restart from P5-T1. Tasks P5-T1 through P5-T6 are unconditional; `SKIPPED` is not a valid outcome for any of them. Artifacts below record the final clean pass.
+
+- [x] [P5-T1] Run `csharpier format .` from the repo root and write `<FEATURE>/evidence/qa-gates/final-qa-csharpier-format.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` (files reformatted count; 0 on the final pass).
+  - Acceptance: artifact exists with all four fields; final pass reformats zero files.
+- [x] [P5-T2] Run `csharpier check .` from the repo root and write `<FEATURE>/evidence/qa-gates/final-qa-csharpier-check.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`.
+  - Acceptance: artifact exists with all four fields; `EXIT_CODE: 0`.
+- [x] [P5-T3] Run `dotnet build OpenClaw.MailBridge.sln` (analyzers + nullable as lint/type gate) and write `<FEATURE>/evidence/qa-gates/final-qa-dotnet-build.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:`.
+  - Acceptance: artifact exists with all four fields; `EXIT_CODE: 0`; zero warnings (warnings-as-errors).
+- [x] [P5-T4] Run `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage"` (architecture-boundary tests, unit tests, property tests, and dedupe tests all run in this suite), copy raw TRX/Cobertura outputs under `artifacts/csharp/`, and write `<FEATURE>/evidence/qa-gates/final-qa-dotnet-test.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, and an `Output Summary:` including pass/fail counts and numeric post-change line-coverage and branch-coverage percentages.
+  - Acceptance: artifact exists with all four fields; `EXIT_CODE: 0`; numeric coverage values recorded (no placeholders).
+- [x] [P5-T5] Create the coverage-comparison artifact `<FEATURE>/evidence/qa-gates/coverage-comparison.<ISO>.md` from the P0-T4 baseline and P5-T4 post-change Cobertura data, recording: baseline line/branch %, post-change line/branch %, per-file line/branch coverage for the changed production files (`src/OpenClaw.Core/Agent/RelatedEventMatcher.cs`, `src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs`, `src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs`, `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs`), and explicit verdicts: line >= 85%, branch >= 75%, and no coverage regression on changed lines.
+  - Acceptance: artifact exists with `Timestamp:` and all numeric values; every threshold verdict is PASS. If any required numeric value is unavailable or any threshold fails, the plan outcome is remediation-required, not PASS.
+- [x] [P5-T6] Verify scope and size caps: run `git diff --name-only main...HEAD` (or the branch base) and confirm the changed set is confined to the files enumerated in Conventions plus the test files from Phases 1-4 and feature-folder evidence/docs; verify every touched `.cs` file is <= 500 lines; write `<FEATURE>/evidence/qa-gates/final-qa-scope-and-caps.<ISO>.md` with `Timestamp:`, `Command:`, `EXIT_CODE:`, `Output Summary:` listing each touched file with its line count.
+  - Acceptance: artifact exists with all four fields; no out-of-scope production file appears in the diff; no touched file exceeds 500 lines.
+
+## Test Plan
+
+- Unit (new): `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherTests.cs` — scoring rows (subject-only, attendee-only, combined, sub-threshold, exact-threshold), tie-breaks (Start, then Id), empty/degenerate inputs, normalization, null-arg contracts (AC-2).
+- Property (new): `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherPropertyTests.cs` — CsCheck: null-or->=4, permutation invariance, case-insensitivity, set semantics (AC-3).
+- Unit (new): `tests/OpenClaw.Core.Tests/Agent/Runtime/CacheSchedulingCandidateSourceTests.cs` — in-memory shared-cache SQLite `CoreCacheRepository`; mail + meeting inclusion, lookback, limit, ordering (AC-1).
+- Unit (new): `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerFallbackTests.cs` — miss -> window fetch with `FakeTimeProvider` bounds, match hydrates context, no-match message-only, non-positive skip, empty-window degradation (AC-4, AC-5).
+- Regression (extended): `tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs` — ordinary-mail send dedupe across cycles, unchanged #101 key shape (AC-6).
+- Toolchain/coverage (AC-7): baseline artifacts `<FEATURE>/evidence/baseline/baseline-*.<ISO>.md`; final-QA artifacts `<FEATURE>/evidence/qa-gates/final-qa-*.<ISO>.md`; comparison artifact `<FEATURE>/evidence/qa-gates/coverage-comparison.<ISO>.md`; expect-fail evidence `<FEATURE>/evidence/regression-testing/expect-fail-*.<ISO>.md`; raw intermediates in `artifacts/csharp/`.
+
+## Open Questions / Notes
+
+- Test framework: `.claude/rules/csharp.md` names xUnit/NSubstitute, but `tests/OpenClaw.Core.Tests` is established on MSTest + Moq + FluentAssertions + CsCheck and the spec (Constraints & Risks) mandates that stack; this plan follows the repository's established convention.
+- Match-score logging: the spec's normative public API returns only `SchedulingEventDto?`; the score named in the spec's logging note is obtained via an internal matcher overload (P1-T1) rather than widening the public surface.
+- `CacheSchedulingCandidateSource` currently uses `DateTimeOffset.UtcNow` for the lookback anchor; this is pre-existing behavior outside the AC set and is intentionally not touched (diff-scope confinement). The new candidate-source tests must therefore seed rows relative to real now with generous margins rather than a fake clock.
+- No dependency changes: CsCheck 4.7.0, Moq 4.20.72, MSTest 3.6.4, FluentAssertions 6.12.0, `Microsoft.Extensions.TimeProvider.Testing` are already referenced.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/policy-audit.2026-07-02T13-36.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/policy-audit.2026-07-02T13-36.md
@@ -1,0 +1,464 @@
+# Policy Compliance Audit: ordinary-mail-candidates (#103)
+
+**Audit Date:** 2026-07-02
+**Code Under Test:** C# only. 4 production `.cs` files in `src/OpenClaw.Core` (`Agent/RelatedEventMatcher.cs` NEW, 191 lines, pure static matcher; `Agent/Contracts/AgentPolicyOptions.cs` adding `CalendarViewFallbackDays` default 14; `Agent/Runtime/CacheSchedulingCandidateSource.cs` kind literal `"meeting"` -> `"all"` plus doc update; `Agent/Runtime/SchedulingWorker.Pipeline.cs` adding the calendar-view fallback block and `ChooseRelatedEventFromWindowAsync`), 6 test `.cs` files (4 new: `RelatedEventMatcherTests.cs`, `RelatedEventMatcherPropertyTests.cs`, `Runtime/CacheSchedulingCandidateSourceTests.cs`, `Runtime/SchedulingWorkerFallbackTests.cs`; 2 modified: `Runtime/SchedulingWorkerTests.cs`, `Runtime/SchedulingWorkerDedupeTests.cs`). Plus feature scoping/evidence Markdown (feature folder for issue #103) and orchestrator agent-memory Markdown. No Python, PowerShell, TypeScript, Bash, or governed JSON files changed in the branch diff.
+
+**Scope:** Full feature branch `feature/ordinary-mail-candidates-103` @ `0f346d5e74a5543526ba8e642fe684b73475dba3` versus resolved base `main` @ merge-base `3dae644d98dcb564767002a51503e6b9944e4eab` (origin/main; the local `main` ref is stale per the caller inputs). Scope is feature-vs-base over the complete branch diff. Diff file breakdown (name-only): 10 `.cs`, 19 `.md` (29 files, +1934/-5). Work mode: `full-feature` (persisted marker `- Work Mode: full-feature` in `issue.md`); acceptance-criteria sources are `spec.md` and `user-story.md` (mirrored in `issue.md`).
+
+**Coverage Metrics by Language:**
+
+| Language | Files Changed | Tests | Test Result | Baseline Coverage | Post-Change Coverage | New Code Coverage |
+|----------|--------------|-------|-------------|-------------------|---------------------|-------------------|
+| C# | 4 production `.cs` + 6 test `.cs` | 736 (solution) / 284 (Core.Tests) | 731 pass, 0 fail, 5 env-gated skips | 90.63% line, 80.25% branch (pooled solution) | 90.81% line, 80.62% branch (pooled solution) | RelatedEventMatcher.cs (new) 100.00% line / 89.58% branch; CacheSchedulingCandidateSource.cs 100.00% line, no branch points, identical to baseline; SchedulingWorker.Pipeline.cs 100% of instrumented lines with the two partial branches pre-existing and untouched (async fallback body uninstrumented per pre-existing runsettings attribute exclusion, behaviorally covered by 7 fallback tests with fail-before evidence); AgentPolicyOptions.cs auto-properties uninstrumented at baseline and post-change alike, behaviorally covered |
+
+**Note:** Python, PowerShell, Bash, TypeScript, and governed-JSON rows are omitted because the branch diff contains no changed files in those languages. Coverage verdicts are therefore C#-only; no other language has changed files on the branch. The C# coverage verdict is an explicit PASS.
+
+### Coverage Evidence Checklist
+
+- C# baseline coverage artifact: `docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/baseline/baseline-dotnet-test.2026-07-02T13-02.md` (pooled 90.63% line / 80.25% branch; raw cobertura at `artifacts/csharp/baseline-2026-07-02T13-02/`)
+- C# post-change coverage artifact: `docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/final-qa-dotnet-test.2026-07-02T13-21.md` and `evidence/qa-gates/coverage-comparison.2026-07-02T13-21.md` (pooled 90.81% line / 80.62% branch)
+- Reviewer-regenerated cobertura (this audit, fresh `dotnet test` at branch head): `docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-review/{2300629f...,4f1a1449...,75d17a89...}/coverage.cobertura.xml`; independently parsed pooled 90.81% line (4298/4733) / 80.62% branch (990/1228), identical to executor evidence. Reviewer evidence: `docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-review.2026-07-02T13-36.md`
+- Per-language comparison summary: Section 1.2.1 below
+- TypeScript baseline coverage artifact: `N/A - out of scope`
+- TypeScript post-change coverage artifact: `N/A - out of scope`
+- PowerShell baseline coverage artifact: `N/A - out of scope`
+- PowerShell post-change coverage artifact: `N/A - out of scope`
+- Python / TypeScript / PowerShell coverage artifacts: `N/A - no changed files in those languages on the branch`
+
+**Non-negotiable verdict rule:** This audit includes numeric baseline and post-change coverage metrics for the only in-scope language (C#), plus per-changed-file line AND branch coverage re-measured by the reviewer from fresh cobertura. The C# coverage gate is met (pooled line 90.81% >= 85%, branch 80.62% >= 75%; the new matcher file is at 100.00% line / 89.58% branch; every instrumented changed line is covered; no regression — pooled coverage improved by +0.18pp line / +0.37pp branch and every changed file's instrumented figures equal or exceed baseline).
+
+---
+
+## Executive Summary
+
+This feature branch closes issue #103 (gap F7): ordinary scheduling mail is now triaged. Three coordinated changes: (a) `CacheSchedulingCandidateSource.GetCandidateMessageIdsAsync` widens the candidate predicate from `"meeting"` to `"all"` (meeting plus ordinary mail; lookback, limit, and recency ordering unchanged); (b) a new pure static `RelatedEventMatcher` in `OpenClaw.Core.Agent` ports master Section 9.2 `chooseMostLikelyRelatedEvent` (subject tokens length >= 4 at +2, participant emails at +3, accept threshold 4, deterministic tie-break by earliest `Start` null-last then ordinal `Id` null-as-empty); (c) `SchedulingWorker.ProcessMessageAsync` gains a calendar-view fallback — on a direct event-lookup miss with `CalendarViewFallbackDays > 0` it fetches `GetCalendarViewAsync(now, now + CalendarViewFallbackDays)` from the injected `TimeProvider` and applies the matcher, with no-match falling through to the existing message-only `Normalize(mailboxUpn, message, null)` call. No new exception paths; all I/O remains behind the `ISchedulingService` seam; the #101 sent-action dedupe store and `SendEnabled`/`CalendarWriteEnabled` kill switches bound side effects.
+
+The mandatory toolchain was independently re-run by the reviewer against the branch head `0f346d5` and passes in a single pass:
+- **Formatting:** `csharpier check .` (CSharpier 1.3.0) — "Checked 217 files", EXIT 0, no diffs.
+- **Lint + nullable type-check + analyzers:** `dotnet build OpenClaw.MailBridge.sln` — Build succeeded, 0 Warning(s), 0 Error(s) (AnalysisLevel=latest-all, AnalysisMode=All, TreatWarningsAsErrors=true per Directory.Build.props).
+- **Architecture-boundary tests:** NetArchTest suite runs inside `OpenClaw.Core.Tests` — included in the 284/284 pass.
+- **Tests + coverage:** full solution `dotnet test` with `--collect:"XPlat Code Coverage"` — 731 passed, 0 failed, 5 environment-gated skips (same skips as baseline); pooled coverage 90.81% line / 80.62% branch, above the uniform gates; T1 property-test obligation for the new pure function satisfied by `RelatedEventMatcherPropertyTests` (CsCheck, 4 properties, 1000 iterations each, seeded Fisher-Yates permutation).
+- **Regression evidence:** fail-before artifacts (EXIT 1) for both the candidate widening (2 discriminating tests failing pre-change) and the worker fallback (3 discriminating tests failing pre-change) are present under `evidence/regression-testing/`, with the final suite green.
+
+No Blocking findings. No material PARTIAL findings. Two informational/minor observations (async-body instrumentation scope — pre-existing runsettings behavior, same disposition as the accepted #99 audit; and the pre-existing `DateTimeOffset.UtcNow` anchor in `CacheSchedulingCandidateSource` that forces wall-clock-relative seeding in its new tests; Section 8 and the code review). Remediation is not required. The feature is recommended Go for PR.
+
+**Policy documents evaluated:**
+- `.claude/rules/general-code-change.md`
+- `.claude/rules/general-unit-test.md`
+- `.claude/rules/quality-tiers.md`
+- `.claude/rules/architecture-boundaries.md`
+- `.claude/rules/csharp.md`
+- `.claude/rules/ci-workflows.md` (not triggered — no workflow changes)
+- `.claude/rules/benchmark-baselines.md` (not triggered — no baseline changes)
+- `.claude/rules/tonality.md`
+
+**Language-specific policies evaluated:**
+- C#: `.claude/rules/csharp.md`
+- N/A Python / PowerShell / Bash / TypeScript / governed JSON (no changed files on the branch)
+
+**Temporary artifacts cleanup:**
+- No temporary or throwaway scripts were introduced by this feature; the diff is four production files, six test files, and documentation/evidence Markdown. The executor's raw cobertura intermediates under `artifacts/csharp/` are untracked (gitignored) and do not appear in the diff.
+
+---
+
+## Rejected Scope Narrowing
+
+None. The caller prompt instructed execution of the full `feature-review-workflow` contract, supplied the authoritative base branch (`main`), merge-base SHA (`3dae644`), the checked-out feature branch, and refreshed PR-context artifacts, and stated "Scope determination is your responsibility per your skill contract." No instruction attempted to narrow scope to a plan/task/phase subset, to a file subset, or to mark any in-scope language as out-of-scope or informational-only.
+
+Observation (not a narrowing instruction, recorded for completeness): the PR-context summary's "Changed files overview" reports "Core logic changes: 0 files" and categorizes the branch as docs/tooling only (16 files). That categorization is inaccurate; the authoritative `git diff 3dae644..0f346d5` contains 4 production C# files and 6 test C# files (29 files total, +1934/-5). This is the third consecutive review (#99, #101, #103) where the summary miscategorizes a C# branch as docs-only. The audit used the authoritative git diff file list, not the summary categorization. No scope was narrowed.
+
+---
+
+## Evidence Location Compliance
+
+The branch diff was scanned for evidence files written under the non-canonical roots `artifacts/baselines/`, `artifacts/baseline/`, `artifacts/qa/`, `artifacts/qa-gates/`, `artifacts/evidence/`, `artifacts/coverage/`, `artifacts/regression-testing/`, or `artifacts/post-change/`.
+
+- Command: `git diff --name-only 3dae644..HEAD | grep -E '^artifacts/'`
+- Result: **NONE.** No files under `artifacts/` are tracked in the diff at all. All feature evidence in the diff is written to the canonical `docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/<kind>/` locations (baseline, qa-gates, regression-testing).
+- Verdict: **PASS** — no evidence-location violations. No `EVIDENCE_LOCATION_OVERRIDE_REJECTED` events occurred during this review; the reviewer's own evidence was written to the canonical `evidence/qa-gates/` path.
+
+Note: the repository does not contain a `validate_evidence_locations.py` script (consistent with the prior #70, #80, #19, #18, #99, and #101 audits); the scan was performed by direct diff inspection. The executor's untracked raw cobertura copies under `artifacts/csharp/baseline-2026-07-02T13-02/` and `artifacts/csharp/final-2026-07-02T13-21/` are non-evidence coverage tooling intermediates at a path the feature-review skill itself designates for C# coverage; the canonical feature evidence lives under `evidence/baseline/` and `evidence/qa-gates/`.
+
+---
+
+## 1. General Unit Test Policy Compliance
+
+### 1.1 Core Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Independence** — Tests run in any order | PASS | Each matcher test builds its own DTOs; each candidate-source test creates a uniquely named in-memory shared-cache SQLite database (`candidate-source-{Guid}`); each fallback/dedupe/worker test builds a fresh Moq graph. 284/284 Core.Tests pass in a single reviewer run. |
+| **Isolation** — Each test targets single behavior | PASS | 14 matcher unit tests each pin one scoring/tie-break/guard rule; 4 candidate-source tests pin inclusion, lookback, limit, ordering separately; 7 fallback test cases pin window bounds, hydration, empty window, opt-out (x2), sub-threshold, failure degradation individually. |
+| **Fast Execution** | PASS | `OpenClaw.Core.Tests` completes 284 tests in ~1 s (reviewer run); property tests are in-memory CsCheck sampling; SQLite tests use in-memory shared cache. |
+| **Determinism** | PASS | Fallback tests use `FakeTimeProvider` pinned to a fixed `Now`; property tests use CsCheck's seeded sampling with the permutation shuffle driven by a generated seed through a local `Random(seed)` (reproducible); no sleeps, timers, network, or filesystem. The candidate-source tests anchor seed rows to `DateTimeOffset.UtcNow` because the production class reads the wall clock directly (pre-existing behavior, line unchanged by this branch); margins are generous (1-4h offsets against a 48h window, 100h for the stale row), so the tests are deterministic in practice. Recorded as a Minor follow-up in the code review. |
+| **Readability & Maintainability** | PASS | Descriptive snake-case scenario names (`Subject_only_match_with_two_shared_tokens_scores_four_and_is_accepted`, `RunCycle_NonPositiveFallbackDays_NeverFetchesCalendarView`), FluentAssertions with because-messages, XML doc summaries on every new test class citing the AC each covers. |
+
+### 1.2 Coverage and Scenarios
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Baseline Coverage Documented** | PASS | Baseline pooled: 90.63% line (4207/4642), 80.25% branch (947/1180). Source: `evidence/baseline/baseline-dotnet-test.2026-07-02T13-02.md`; independently re-parsed by the reviewer from `artifacts/csharp/baseline-2026-07-02T13-02/`. |
+| **No Coverage Regression** | PASS | Post-change pooled: 90.81% line, 80.62% branch (+0.18pp / +0.37pp). Per changed file: candidate source 100% -> 100% line; pipeline 20/20 line and 2/4 branch at baseline and post-change with the two partial conditions verified to be the same pre-existing `MailboxUpn`/`BuildProposalReply` ternaries (baseline lines 170/177 = post-change lines 233/240 after the +63-line shift). Independently confirmed from reviewer cobertura. |
+| **New Code Coverage** | PASS | `RelatedEventMatcher.cs` (new): 100.00% line (91/91) / 89.58% branch (43/48) — reviewer-parsed, line AND branch. The 5 uncovered condition arms (lines 180, 186, 189) are nullable-lifted compiler branches in the tie-break comparisons (`Start` lifted operators, `Id ?? string.Empty` null arms); above both gates. The new async fallback in `SchedulingWorker.Pipeline.cs` is uninstrumented per the pre-existing runsettings CompilerGenerated exclusion and is behaviorally verified by 7 fallback tests plus fail-before evidence (see Section 8). |
+| **Comprehensive Coverage** | PASS | Candidate widening (inclusion/lookback/limit/ordering), matcher scoring rows and tie-breaks, four CsCheck invariants, fallback window bounds/hydration/no-match/opt-out/failure degradation, and cross-cycle ordinary-mail dedupe are all exercised. |
+| **Positive Flows** | PASS | Mail-alongside-meeting inclusion; subject-only/attendee-only/combined/exact-threshold acceptance rows; window match hydrating the event context observable in the outbound reply subject. |
+| **Negative Flows** | PASS | Sub-threshold score returns null; `ArgumentNullException` for null message and null events; empty window and all-below-threshold fall through to message-only triage; stale rows excluded by lookback. |
+| **Edge Cases** | PASS | Exact threshold (score 4) accepted; score 3 rejected; null/short-token subjects; case-insensitive tokens and emails; organizer excluded from attendee scoring; tie-break earliest-Start with null-Start-last; tie-break ordinal-Id when Start ties; empty event list; limit cap; recency interleaving across kinds; non-positive fallback days (0 and -1). |
+| **Error Handling** | PASS | Failure-envelope-mapped-to-empty-window degradation proceeds without exception and the pipeline continues (mailbox settings consulted); null-arg guards pinned; no new exception paths introduced (verified in diff — no catch blocks added). |
+| **Concurrency** | N/A | No new concurrency surface; the fallback is a single awaited seam call inside the existing per-message pipeline. |
+| **State Transitions** | PASS | Cross-cycle dedupe state proven with a stateful `ISentActionStore` double: consult-before-send twice, record-once, key set exactly `[mailKey]` with the unchanged #101 key shape. |
+
+### 1.2.1 Per-Language Coverage Comparison
+
+- C#: Baseline: 90.63% line, 80.25% branch (pooled solution) -> Post-change: 90.81% line, 80.62% branch. Change: +0.18% line, +0.37% branch. New/changed-code coverage: RelatedEventMatcher.cs (new) 100.00% line / 89.58% branch reviewer-parsed; CacheSchedulingCandidateSource.cs 100.00% line identical to baseline; SchedulingWorker.Pipeline.cs 100% of instrumented lines with both partial branches pre-existing and untouched, new async fallback behaviorally covered by 7 tests with fail-before evidence; AgentPolicyOptions.cs auto-properties uninstrumented at baseline and post-change alike, defaults behaviorally covered; new test files excluded from measurement per policy. Disposition: PASS (line >= 85%, branch >= 75%, no regression on changed lines). Evidence: `evidence/baseline/baseline-dotnet-test.2026-07-02T13-02.md`, `evidence/qa-gates/final-qa-dotnet-test.2026-07-02T13-21.md`, `evidence/qa-gates/coverage-comparison.2026-07-02T13-21.md`, reviewer re-run `evidence/qa-gates/coverage-review.2026-07-02T13-36.md`.
+
+### 1.3 Test Structure and Diagnostics
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clear Failure Messages** | PASS | FluentAssertions because-clauses on every material assertion ("the widened candidate set is meeting plus ordinary mail within the window", "no other key shape may be recorded"); CsCheck prints the failing seed per suite convention; Moq `Verify` failures name the exact seam call and cardinality. |
+| **Arrange-Act-Assert Pattern** | PASS | All new tests carry explicit `// Arrange` / `// Act` / `// Assert` comments with AC anchors. |
+| **Document Intent** | PASS | XML docs on all four new test classes state the AC(s) covered, the no-temp-files SQLite strategy, and the wall-clock-anchor rationale where applicable. |
+
+### 1.4 External Dependencies and Environment
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Avoid External Dependencies** | PASS | No network, COM, or external process; repository tests use in-memory shared-cache SQLite (`Mode=Memory;Cache=Shared`, per the established `CoreCacheRepository*Tests` convention); all seams mocked with Moq. |
+| **Use Mocks/Stubs** | PASS | `ISchedulingService`, `ISchedulingCandidateSource`, and `ISentActionStore` mocked; window stubs are explicit (`ReturnsAsync(Array.Empty<SchedulingEventDto>())`) rather than Moq loose defaults, per the spec's stated risk mitigation. |
+| **Environment Stability** | PASS | No temporary files (in-memory SQLite only); no mutable global state; no environment variables read. |
+
+### 1.5 Policy Audit Requirement
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Pre-submission Review** | PASS | This audit serves as the required policy review. No outstanding items. |
+
+---
+
+## 2. General Code Change Policy Compliance
+
+### 2.1 Before Making Changes
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Clarify the objective** | PASS | Issue #103, `spec.md` v0.2 (six design decisions D1-D6 with verified code anchors), user-story scenarios, and the F7 gap-analysis reference define the change precisely. |
+| **Read existing change plans** | PASS | `evidence/baseline/phase0-instructions-read.md` records the policy-order read; `plan.2026-07-02T12-43.md` present. |
+| **Document the plan** | PASS | `plan.2026-07-02T12-43.md` with per-phase evidence under `evidence/**`; completed tasks recorded in the PR-context summary. |
+
+### 2.2 Design Principles
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Simplicity first** | PASS | The widening is a one-literal change; the matcher is one pure static class with fixed weights; the fallback is one guarded block plus one private method; no new types beyond the matcher, no new interfaces, no new dependencies. |
+| **Reusability** | PASS | Email normalization reuses the existing public `MeetingContextNormalizer.EmailOf`; tokenization follows the established `GeneratedRegex` pattern; the internal `ChooseMostLikelyRelatedEventWithScore` overload lets the pipeline log the score without recomputing. |
+| **Extensibility** | PASS | `CalendarViewFallbackDays` is an options-bag value with a documented default and opt-out; the matcher's public surface is the single spec-sanctioned method; the fallback sits behind the existing `ISchedulingService` seam so the Graph swap carries it unchanged. |
+| **Separation of concerns** | PASS | Scoring/selection is pure in `OpenClaw.Core.Agent`; the window fetch (I/O) is confined to the Runtime pipeline through the seam; per D3 the service adapter stays thin. |
+
+### 2.3 Module & File Structure
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Cohesive modules** | PASS | Pure logic in `Agent/`, orchestration in `Agent/Runtime/`, options in `Agent/Contracts/`; tests mirror the production layout exactly. |
+| **Under 500 lines** | PASS | `wc -l` (reviewer): RelatedEventMatcher.cs 191, AgentPolicyOptions.cs 95, CacheSchedulingCandidateSource.cs 29, SchedulingWorker.Pipeline.cs 258, RelatedEventMatcherTests.cs 257, RelatedEventMatcherPropertyTests.cs 273, CacheSchedulingCandidateSourceTests.cs 175, SchedulingWorkerFallbackTests.cs 312, SchedulingWorkerTests.cs 330, SchedulingWorkerDedupeTests.cs 364. All under the 500-line cap (max 364); matches executor evidence `evidence/qa-gates/final-qa-scope-and-caps.2026-07-02T13-21.md`. |
+| **Public vs internal** | PASS | The only public-surface additions are `RelatedEventMatcher.ChooseMostLikelyRelatedEvent` (spec-sanctioned) and the `CalendarViewFallbackDays` option; the with-score overload is `internal`; `ChooseRelatedEventFromWindowAsync` is `private`. |
+| **No circular dependencies** | PASS | No project-reference changes; NetArchTest boundary suite passes inside the 284/284 Core.Tests run. |
+
+### 2.4 Naming, Docs, and Comments
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Descriptive names** | PASS | `RelatedEventMatcher`, `ChooseMostLikelyRelatedEvent` (mirrors the master reference name), `CalendarViewFallbackDays`, `PrecedesInTieBreak`; named constants (`SubjectTokenWeight`, `ParticipantEmailWeight`, `AcceptThreshold`, `MinimumTokenLength`) instead of magic numbers. |
+| **Docs/docstrings** | PASS | XML docs on the matcher class, both entry points, and every private helper; the options doc cites master Section 9.2 and documents the opt-out; the candidate-source summary updated to describe the widened set (spec requirement). |
+| **Comment why, not what** | PASS | Comments explain the lowercase-before-regex contract, the organizer-exclusion rationale ("matching the master reference which scores event.attendees"), and the deliberate any-miss (not mail-only) fallback guard citing master Section 9.2/9.3. |
+
+### 2.5 After Making Changes — Toolchain Execution
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **1. Formatting** | PASS | Reviewer: `csharpier check .` — Checked 217 files, EXIT 0. Executor: `evidence/qa-gates/final-qa-csharpier-check.2026-07-02T13-21.md` EXIT 0. |
+| **2. Linting** | PASS | Reviewer: `dotnet build OpenClaw.MailBridge.sln` — 0 warnings, 0 errors (analyzers as errors). |
+| **3. Type checking** | PASS | Same build; nullable reference analysis runs as errors per Directory.Build.props; clean. |
+| **4. Architecture** | PASS | NetArchTest boundary tests pass within the full Core.Tests run (284/284). No COM, VSTO, or interop references added; all I/O remains behind the `ISchedulingService` seam (verified in diff — the pipeline gained no new dependency). |
+| **5. Testing** | PASS | Reviewer: full solution test run — 731 passed, 0 failed, 5 environment-gated skips (identical to baseline skips). Includes the T1 property-based tests for the new pure function. |
+| **6. Contract/schema checks** | N/A | No governed contract, DTO, route, or schema surface changed; `ISchedulingService` already carried `GetCalendarViewAsync` (interface byte-identical to base). |
+| **7. Integration tests** | N/A | No adapter/external-system boundary changed; the repository-level behavior is covered against a real in-memory SQLite `CoreCacheRepository`, and the pipeline behavior at the mocked `ISchedulingService` seam per spec. |
+| **Full toolchain loop** | PASS | Reviewer re-ran format -> build -> arch -> test+coverage in a single clean pass with no file mutations; executor evidence records the same single-pass Phase 5 loop (qa-gates set at 2026-07-02T13-21). |
+| **Explicit reporting** | PASS | Commands and results documented here, in Appendix B, and in `evidence/qa-gates/coverage-review.2026-07-02T13-36.md`. |
+
+### 2.6 Summarize and Document
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Summarize changes** | PASS | `spec.md` Implementation Strategy matches the delivered diff exactly (four production files, four new test files, two extended test files); the commit message describes the feature. |
+| **Design choices explained** | PASS | D1 (tie-break deviation from the reference, recorded deliberately with rationale), D2 (client path over Core-cache read, five evidence points), D3 (fallback placement), D4 (no cursor exists — verified), D5 (no memoization, simplicity-first), D6 (Prefer-header non-goal) all documented in spec.md. |
+| **Update supporting documents** | PASS | Acceptance criteria checked off in `spec.md`, `user-story.md`, and the `issue.md` mirror. |
+| **Provide next steps** | PASS | Spec Constraints & Risks records the accepted Local-MVP volume risk and the possible per-kind quota follow-up. |
+
+---
+
+## 3. Language-Specific Code Change Policy Compliance
+
+Only Section 3 C# applies. Python, PowerShell, Bash, TypeScript, and governed-JSON sections are omitted: no changed files in those categories on the branch.
+
+### Section 3-C#: C# Code Change Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Formatting — CSharpier** | PASS | `csharpier check .` EXIT 0 (reviewer, CSharpier 1.3.0 global; the repo tool-manifest restore mismatch is a pre-existing environment accommodation also recorded in the #70, #80, #19, #18, #99, and #101 audits). |
+| **Linting — .NET analyzers** | PASS | `dotnet build` clean: 0 warnings / 0 errors with AnalysisLevel=latest-all, AnalysisMode=All, TreatWarningsAsErrors=true. |
+| **Type Checking — Nullable** | PASS | Nullable enabled solution-wide; new code uses `ArgumentNullException.ThrowIfNull`, `is null`/`is not null` patterns, and explicit null-handling in the tie-break (`Id ?? string.Empty`, null-Start ordering). |
+| **Null-safety** | PASS | Matcher never throws for degenerate content (null subjects, empty attendee lists, null ids — pinned by tests); null-arg guards on both public inputs; options value is a non-nullable int with a documented non-positive opt-out. |
+| **Async / resource safety** | PASS | `await ... .ConfigureAwait(false)` throughout the new pipeline code; cancellation token forwarded to the seam; no fire-and-forget, no blocking waits, no `async void`. |
+| **Naming / file-scoped namespaces** | PASS | File-scoped namespaces; `Async` suffix on the new private method; PascalCase publics; `GeneratedRegex` partial-class pattern matches the existing `MeetingContextNormalizer.Helpers.cs` convention. |
+| **Exceptions fail-fast** | PASS | `ArgumentNullException.ThrowIfNull` at the pure entry point; no catch blocks added anywhere in production; failure degradation reuses the existing envelope-to-empty-list mapping and the existing per-message isolation guard. |
+| **No new suppressions** | PASS | The diff contains no pragma or suppression attributes and no banned-API additions (grep of the full C# diff for pragma, SuppressMessage, DateTime.Now, DateTime.UtcNow, Random.Shared, Thread.Sleep, Task.Delay returned zero added lines). The wall-clock read pre-existing in `CacheSchedulingCandidateSource` is unchanged (context line, not an addition) — see Section 8. |
+
+Note on test framework: `.claude/rules/csharp.md` names xUnit/NSubstitute, but the repository's actual convention is MSTest + FluentAssertions + Moq (all existing suites; divergence recorded in `.claude/agent-memory/prd-feature/project_test_framework_discrepancy.md`). The new and modified tests follow the established repo convention, consistent with the prior validated #70, #80, #19, #18, #99, and #101 audits. Pre-existing repo-wide divergence, not a finding against this branch.
+
+---
+
+## 4. Language-Specific Unit Test Policy Compliance
+
+Only C# tests changed. Python, PowerShell, and TypeScript sections are omitted.
+
+### Section 4-C#: C# Unit Test Policy Compliance
+
+| Requirement | Status | Evidence |
+|------------|--------|----------|
+| **Framework (repo convention: MSTest + FluentAssertions + Moq)** | PASS | `[TestClass]`/`[TestMethod]`/`[DataRow]`; FluentAssertions matchers; Moq `Setup`/`Verify`/`Capture.In` per suite convention. |
+| **Test file location** | PASS | All test changes under `tests/OpenClaw.Core.Tests/Agent/` and `tests/OpenClaw.Core.Tests/Agent/Runtime/`, mirroring `src/OpenClaw.Core/Agent/` and `src/OpenClaw.Core/Agent/Runtime/`. No colocation in the production tree. |
+| **Coverage expectation** | PASS | Pooled 90.81% line / 80.62% branch; new matcher file 100.00% / 89.58%; every instrumented changed line covered; no regression. |
+| **Property-based tests (T1 density)** | PASS | `OpenClaw.Core` is T1 (`quality-tiers.yml`); the new pure function (`ChooseMostLikelyRelatedEvent`) has four genuine CsCheck property tests (null-or-score>=4, permutation invariance via seeded Fisher-Yates, case-insensitivity, duplicate set semantics; 1000 iterations each; overlapping generator pools so both accept and reject branches are exercised). CsCheck 4.7.0 was already referenced by `OpenClaw.Core.Tests`; no new dependency. |
+| **Mutation testing** | N/A | Mutation testing runs in pre-merge/nightly pipelines per policy, not the per-commit loop (same disposition as the validated #80/#99 T1 audits). |
+| **Determinism (no sleeps, no wall clock)** | PASS | `FakeTimeProvider` pinned to a fixed epoch in all fallback/dedupe/worker tests; window bounds asserted as exact `Now`/`Now.AddDays(14)` values; no `Thread.Sleep`/`Task.Delay`/timers in the diff. The candidate-source tests' `DateTimeOffset.UtcNow` anchoring is forced by the production class's pre-existing wall-clock read (unchanged line); documented with generous margins and recorded as a Minor follow-up. |
+| **No temporary files** | PASS | In-memory shared-cache SQLite (`Data Source=candidate-source-{Guid:N};Mode=Memory;Cache=Shared`); zero filesystem artifacts. |
+| **Focused / isolated** | PASS | Fresh mock graph or fresh in-memory database per test; helper factories build per-test state only; explicit window stubs avoid reliance on Moq loose defaults. |
+
+---
+
+## 5. Test Coverage Detail
+
+### RelatedEventMatcherTests (14 new unit tests, new file)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `Subject_only_match_with_two_shared_tokens_scores_four_and_is_accepted` | Positive (subject-only, score 4) | PASS |
+| `Attendee_only_match_with_two_shared_participants_scores_six_and_is_accepted` | Positive (attendee-only, score 6) | PASS |
+| `Combined_token_and_participant_scores_five_and_is_accepted` | Positive (combined, score 5) | PASS |
+| `Single_participant_match_scores_three_and_returns_null` | Negative (sub-threshold, score 3) | PASS |
+| `Exact_threshold_score_of_four_is_accepted` | Boundary (exact threshold) | PASS |
+| `Tie_break_selects_earliest_start_and_null_start_sorts_last` | Determinism (Start tie-break) | PASS |
+| `Tie_break_selects_smallest_ordinal_id_when_start_ties` | Determinism (Id tie-break) | PASS |
+| `Empty_event_list_returns_null` | Edge (empty input) | PASS |
+| `Null_subject_contributes_zero_so_single_participant_stays_below_threshold` | Edge (null subject) | PASS |
+| `Short_tokens_are_ignored_so_single_participant_stays_below_threshold` | Edge (token length < 4) | PASS |
+| `Token_and_email_matching_is_case_insensitive` | Normalization | PASS |
+| `Organizer_email_is_not_counted_toward_the_score` | Reference fidelity | PASS |
+| `Null_message_throws_argument_null_exception` | Negative (null guard) | PASS |
+| `Null_events_throws_argument_null_exception` | Negative (null guard) | PASS |
+
+### RelatedEventMatcherPropertyTests (4 new CsCheck properties, new file)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `Result_is_null_or_the_selected_event_scores_at_least_four` | Property (threshold invariant, 1000 iters) | PASS |
+| `Selection_is_invariant_under_permutation_of_the_event_list` | Property (order independence, seeded Fisher-Yates) | PASS |
+| `Scoring_is_case_insensitive` | Property (case invariance) | PASS |
+| `Duplicated_tokens_and_emails_do_not_change_the_score` | Property (set semantics) | PASS |
+
+### CacheSchedulingCandidateSourceTests (4 new unit tests, new file; in-memory SQLite)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `GetCandidateMessageIds_returns_mail_alongside_meeting_within_window` | Positive (AC-1 widening; fail-before discriminator) | PASS |
+| `GetCandidateMessageIds_excludes_rows_older_than_the_lookback_window` | Behavior-preserving (lookback) | PASS |
+| `GetCandidateMessageIds_caps_the_result_at_the_configured_limit` | Behavior-preserving (limit) | PASS |
+| `GetCandidateMessageIds_preserves_recency_ordering_across_kinds` | Positive (ordering; fail-before discriminator) | PASS |
+
+### SchedulingWorkerFallbackTests (7 new test cases across 6 methods, new file)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `RunCycle_LookupMiss_FetchesCalendarViewFromNowToNowPlusFourteenDays` | Positive (window bounds from FakeTimeProvider; fail-before discriminator) | PASS |
+| `RunCycle_WindowEventClearsThreshold_HydratesEventContextIntoSendPath` | Positive (match hydration observable in reply subject; fail-before discriminator) | PASS |
+| `RunCycle_EmptyWindow_ProceedsMessageOnlyWithoutThrowing` | Negative (empty window; fail-before discriminator) | PASS |
+| `RunCycle_NonPositiveFallbackDays_NeverFetchesCalendarView(0)` / `(-1)` | Edge (documented opt-out, 2 DataRows) | PASS |
+| `RunCycle_AllWindowEventsBelowThreshold_FallsThroughToMessageOnly` | Negative (sub-threshold window) | PASS |
+| `RunCycle_FailureEnvelopeMappedToEmptyWindow_ProceedsWithoutException` | Error handling (degradation) | PASS |
+
+### SchedulingWorkerDedupeTests (1 new test; shared stubs extended) and SchedulingWorkerTests (shared stub extended)
+
+| Test Name | Scenario Type | Status |
+|-----------|--------------|--------|
+| `RunCycle_OrdinaryMailAcrossTwoCycles_SendsOnceWithUnchangedKeyShape` | State transitions (AC-6 cross-cycle dedupe, stateful store double, exact key-set assertion) | PASS |
+| Existing worker/dedupe suites (explicit empty-window stubs added) | Behavior-preserving | PASS |
+
+**Coverage:** `RelatedEventMatcher.cs` 100.00% line / 89.58% branch (new file, reviewer-parsed); `CacheSchedulingCandidateSource.cs` 100.00% line; `SchedulingWorker.Pipeline.cs` instrumented figures identical to baseline with the async fallback behaviorally covered. **Gap:** none attributable to this branch (the pipeline's two partial branches are pre-existing untouched ternaries; the matcher's five partial condition-arms are nullable-lifted compiler branches — an Info note in the code review suggests a null-Id tie-break row).
+
+**Fail-before / pass-after:** `evidence/regression-testing/expect-fail-candidate-widening.2026-07-02T13-11.md` (EXIT 1; 2 discriminating tests fail pre-change, 2 behavior-preserving tests pass) and `expect-fail-worker-fallback.2026-07-02T13-11.md` (EXIT 1; 3 fallback tests fail pre-change), followed by the green final suite (`final-qa-dotnet-test.2026-07-02T13-21.md` EXIT 0 and the reviewer's 731/731 re-run).
+
+---
+
+## 6. Test Execution Metrics
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Total Tests (solution, reviewer run) | 736 (731 passed, 5 env-gated skips) | PASS |
+| OpenClaw.Core.Tests | 284 passed / 284 | PASS |
+| Tests Failed | 0 | PASS |
+| Core.Tests Execution Time | ~1 s | PASS |
+| Pooled Code Coverage | 90.81% line, 80.62% branch | PASS |
+| New matcher file (T1, new code) | 100.00% line, 89.58% branch | PASS |
+| Net new tests vs baseline | +30 (14 matcher unit + 4 matcher property + 4 candidate-source + 7 fallback cases + 1 dedupe) | PASS |
+
+---
+
+## 7. Code Quality Checks
+
+| Check | Command | Result | Status |
+|-------|---------|--------|--------|
+| CSharpier format | `csharpier check .` (CSharpier 1.3.0, reviewer) | Checked 217 files, EXIT 0 | PASS |
+| .NET analyzers + nullable | `dotnet build OpenClaw.MailBridge.sln` | 0 warnings, 0 errors | PASS |
+| Architecture (NetArchTest) | Included in `dotnet test` Core.Tests run | 284/284 pass (boundary tests included) | PASS |
+| MSTest tests + coverage | `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory "docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-review"` | 731 passed, 0 failed, 5 skipped | PASS |
+
+**Notes:** The reviewer re-ran the full toolchain against branch head `0f346d5` on 2026-07-02. The 5 skips are the same environment-gated COM/publish tests skipped at baseline; none relate to this change.
+
+---
+
+## 8. Gaps and Exceptions
+
+### Identified Gaps
+
+**None Blocking.** Two observations, recorded (not policy violations on this branch):
+
+- **Async-body instrumentation exclusion (Informational).** The pre-existing `mailbridge.runsettings` coverlet setting `ExcludeByAttribute=CompilerGeneratedAttribute` excludes async state-machine bodies from instrumentation solution-wide. The new fallback code (`ChooseRelatedEventFromWindowAsync` and the fallback guard inside async `ProcessMessageAsync`) therefore contributes zero instrumented lines; per-line cobertura cannot attest the changed lines in `SchedulingWorker.Pipeline.cs`. Per the disposition accepted on the #99 review, the reviewer verified the new body behaviorally instead: 7 fallback test cases cover the guard both ways (miss-with-positive-days fetches; non-positive days never fetches; direct-hit paths in the pre-existing worker suites never fetch), the match and no-match arms, and the failure degradation — with fail-before evidence (EXIT 1, the 3 discriminating tests) proving the tests detect the absent implementation. The runsettings file is byte-identical to base on this branch; the setting is an attribute-level filter, not a production-path `exclude` entry of the kind the coverage-exclusion policy prohibits. The recommended runsettings follow-up remains open (also recorded on #99).
+- **Wall-clock anchor in `CacheSchedulingCandidateSource` (Minor, pre-existing).** The production class computes `sinceUtc` from `DateTimeOffset.UtcNow` directly (line unchanged by this branch — only the kind literal and doc comment changed). This forces the new tests to seed rows relative to real now instead of a `FakeTimeProvider`. The tests are deterministic in practice (1-4h offsets against a 48h window; the stale row at -100h), but the class should receive an injected `TimeProvider` per the csharp.md clock-seam rule. Recorded as a Minor follow-up recommendation in the code review; refactoring it was outside this feature's spec scope.
+
+### Approved Exceptions
+
+- **CSharpier invocation path:** the repo tool-manifest restore fails in this environment ("command csharpier ... package contains dotnet-csharpier"); the reviewer used the globally installed CSharpier 1.3.0, matching the accommodation recorded in the #70, #80, #19, #18, #99, and #101 audits. The format check ran to EXIT 0 over all 217 files.
+- **MCP template/validator tools unavailable:** the MCP tools `resolve_policy_audit_template_asset` and `validate_orchestration_artifacts` are not available in this review environment. The artifact structure was reproduced from the most recent validator-passing artifact set (issue #99 review, 2026-07-02) and the recorded validator requirements (exact headings, Coverage Evidence Checklist literals, single-line Section 1.2.1 comparison). Documented best-effort assumption per the workflow's fail-soft guidance.
+- **GitHub CLI unavailable:** `gh` is not installed, so issue cross-verification in the PR-context artifacts is author-asserted only. Does not affect any gate in this audit.
+
+### Removed/Skipped Tests
+
+- **None removed.** No existing test was deleted or weakened; the two modified test files gained explicit `GetCalendarViewAsync` empty-window stubs (a strengthening — the spec explicitly required explicit stubs over Moq loose defaults) and one new dedupe test. The 5 solution skips are pre-existing environment-gated COM/publish tests, unchanged.
+
+---
+
+## 9. Summary of Changes
+
+### Commits in This Branch (vs base `3dae644`)
+
+Branch `feature/ordinary-mail-candidates-103`, head `0f346d5e74a5543526ba8e642fe684b73475dba3` (single commit: "feat(core): triage ordinary scheduling mail with calendarView fallback matching"). Range: `3dae644d98dcb564767002a51503e6b9944e4eab..0f346d5e74a5543526ba8e642fe684b73475dba3`.
+
+### Files Modified (categories)
+
+1. **`src/OpenClaw.Core/Agent/RelatedEventMatcher.cs`** (NEW, 191 lines) — pure static Section 9.2 port: `GeneratedRegex` tokenizer, participant/attendee email sets via `MeetingContextNormalizer.EmailOf`, weighted scoring with named constants, threshold-4 acceptance, deterministic tie-break, internal with-score overload for logging.
+2. **`src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs`** (MODIFIED) — `CalendarViewFallbackDays` int property, default 14, XML doc citing master Section 9.2 and the non-positive opt-out.
+3. **`src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs`** (MODIFIED) — kind literal `"meeting"` -> `"all"`; XML summary updated to the widened candidate set.
+4. **`src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs`** (MODIFIED) — guarded fallback block after the direct lookup plus private `ChooseRelatedEventFromWindowAsync` (TimeProvider-derived window, seam fetch, matcher application, LogDebug/LogInformation per spec).
+5. **`tests/OpenClaw.Core.Tests/Agent/**`** — 4 new test files (matcher unit, matcher property, candidate source, worker fallback) and 2 extended files (explicit window stubs; ordinary-mail cross-cycle dedupe test).
+6. **`docs/features/active/2026-07-02-ordinary-mail-candidates-103/**`** (NEW, 16 files) — issue/spec/user-story/plan and canonical evidence (baseline, qa-gates, regression-testing).
+7. **`.claude/agent-memory/orchestrator/**`** (3 files) — orchestrator agent-memory bookkeeping; no code or policy content.
+
+---
+
+## 10. Compliance Verdict
+
+### Overall Status: FULLY COMPLIANT
+
+The C# change passes formatting, linting, nullable type-checking, architecture-boundary enforcement, the full unit-test suite, and the uniform coverage gates, all independently re-run by the reviewer at branch head. The T1 property-test obligation for the new pure function is satisfied with four genuine CsCheck properties. Fail-before/pass-after regression evidence is present and discriminates both delivered behaviors exactly. No evidence-location or file-size violations. No new suppressions or banned-API additions. The `modified-workflow-needs-green-run` rule does not fire (verified: no `.github/workflows/`, `scripts/benchmarks/`, or `.github/actions/` paths in the diff). The `benchmark-baselines` and `ci-workflows` rules are not triggered.
+
+**Fail-closed reminder:** All required baseline and post-change coverage metrics are present and independently re-verified; the audit is marked PASS because no required artifact, metric, or gate is missing or failing.
+
+---
+
+### Policy-by-Policy Summary
+
+#### General Code Change Policy (Section 2)
+- Before Making Changes: PASS (spec/plan/policy-order evidence present)
+- Design Principles: PASS (one-literal widening, one pure class, one guarded seam call)
+- Module & File Structure: PASS (all files under 500 lines, max 364)
+- Naming, Docs, Comments: PASS
+- Toolchain Execution: PASS (single clean pass, reviewer re-verified)
+- Summarize & Document: PASS
+
+#### Language-Specific Code Change Policy (Section 3) — C#
+- Tooling & Baseline: PASS
+- Design & Type-Safety: PASS
+- Error Handling: PASS (fail-fast null guards; no new catch blocks; documented degradation path)
+
+#### General Unit Test Policy (Section 1)
+- Core Principles: PASS
+- Coverage & Scenarios: PASS (90.81%/80.62% pooled; matcher 100%/89.58%; changed lines covered or behaviorally verified)
+- Test Structure: PASS
+- External Dependencies: PASS (Moq seams, in-memory SQLite, no temp files)
+- Policy Audit: PASS
+
+#### Language-Specific Unit Test Policy (Section 4) — C#
+- Framework & Location: PASS (MSTest + FluentAssertions + Moq repo convention; tests/ mirror)
+- Determinism: PASS (FakeTimeProvider throughout the pipeline tests; documented wall-clock accommodation for the pre-existing candidate-source anchor)
+- T1 obligations: PASS (four CsCheck property tests for the new pure function; mutation gate is pipeline-stage, not per-commit)
+
+---
+
+### Metrics Summary
+
+- 731/731 runnable solution tests passing (5 pre-existing environment-gated skips)
+- 90.81% pooled line coverage, 80.62% pooled branch coverage (gates: 85%/75%)
+- New T1 matcher file: 100.00% line / 89.58% branch (reviewer-parsed, line and branch)
+- No regression: pooled +0.18pp line / +0.37pp branch; every changed file's instrumented figures equal or exceed baseline
+- Build: 0 warnings / 0 errors (analyzers + nullable as errors)
+- All 10 touched `.cs` files under the 500-line cap (max 364)
+
+---
+
+### Recommendation
+
+**Ready for merge — Go.** All toolchain stages, coverage gates, regression evidence, and policy requirements pass against branch head `0f346d5`. No remediation inputs are required. Operational note (from spec, not a gate): widened candidates increase processed volume within `Defaults.Limit`; the accepted Local-MVP risk of mail crowding out meeting messages is documented with a per-kind quota as a possible follow-up, and all side effects remain behind `SendEnabled`/`CalendarWriteEnabled`.
+
+---
+
+## Appendix A: Test Inventory
+
+C# test changes in this feature (all in `tests/OpenClaw.Core.Tests/Agent/` and `tests/OpenClaw.Core.Tests/Agent/Runtime/`):
+
+1. `RelatedEventMatcherTests.cs` (NEW, 257 lines) — 14 unit tests: scoring rows (subject-only, attendee-only, combined, sub-threshold, exact-threshold), tie-breaks (earliest Start with null-last, ordinal Id), empty events, null/short subjects, case-insensitivity, organizer exclusion, null-arg guards.
+2. `RelatedEventMatcherPropertyTests.cs` (NEW, 273 lines) — 4 CsCheck properties (1000 iterations each): null-or-score>=4, permutation invariance (seeded Fisher-Yates), case-insensitivity, duplicate set semantics.
+3. `Runtime/CacheSchedulingCandidateSourceTests.cs` (NEW, 175 lines) — 4 tests against a real in-memory shared-cache SQLite `CoreCacheRepository`: mail-alongside-meeting inclusion, lookback exclusion, limit cap, recency ordering across kinds.
+4. `Runtime/SchedulingWorkerFallbackTests.cs` (NEW, 312 lines) — 7 test cases: window bounds from `FakeTimeProvider` (now to now+14d), match hydration observable in the outbound reply subject, empty-window message-only fall-through, non-positive opt-out (DataRows 0 and -1), sub-threshold fall-through, failure-envelope degradation.
+5. `Runtime/SchedulingWorkerDedupeTests.cs` (MODIFIED) — added `RunCycle_OrdinaryMailAcrossTwoCycles_SendsOnceWithUnchangedKeyShape` (stateful store double; consult-twice/record-once; exact key-set assertion) plus explicit empty-window stubs and a parameterizable `MeetingMessageType`.
+6. `Runtime/SchedulingWorkerTests.cs` (MODIFIED) — explicit `GetCalendarViewAsync` empty-window stub added to the shared service factory (spec-required explicitness; no assertions weakened).
+
+Reviewer run: `OpenClaw.Core.Tests` 284 passed, 0 failed; solution total 731 passed, 0 failed, 5 env-gated skipped.
+
+---
+
+## Appendix B: Toolchain Commands Reference (C#)
+
+```bash
+# Formatting (reviewer, CSharpier 1.3.0 global — repo tool-manifest accommodation)
+csharpier check .
+
+# Lint + nullable type-check + analyzers (as errors per Directory.Build.props)
+dotnet build OpenClaw.MailBridge.sln
+
+# Tests + coverage (full solution; reviewer results directory is the canonical evidence path)
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --collect:"XPlat Code Coverage" --results-directory "docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/qa-gates/coverage-review"
+
+# Regression subsets (executor fail-before evidence)
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~CacheSchedulingCandidateSourceTests"
+dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~SchedulingWorkerFallbackTests"
+
+# Evidence-location scan
+git diff --name-only 3dae644d98dcb564767002a51503e6b9944e4eab..HEAD | grep -E '^artifacts/'
+```
+
+---
+
+**Audit Completed By:** feature-review agent
+**Audit Date:** 2026-07-02
+**Policy Version:** Current (as of audit date)

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/spec.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/spec.md
@@ -1,0 +1,145 @@
+# ordinary-mail-candidates — Spec
+
+- **Issue:** #103
+- **Parent (optional):** none
+- **Owner:** drmoisan
+- **Last Updated:** 2026-07-02
+- **Status:** Draft
+- **Version:** 0.2
+
+## Overview
+
+The master specification defines two input classes (`docs/open-claw-approach.master.md` §2.2): formal meeting traffic and **ordinary scheduling mail** ("can we move this?", "what works next week?"). Today only the first class is handled: `CacheSchedulingCandidateSource.GetCandidateMessageIdsAsync` (`src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs`) selects only `item_kind = 'meeting'` messages, and `HostAdapterSchedulingService.GetEventForMessageAsync` does a direct event-by-id lookup returning null on a miss — there is no `calendarView`-window fallback with the subject/attendee-overlap matching heuristic the master specifies (§9.2 `chooseMostLikelyRelatedEvent`, §9.3 step 3). Ordinary scheduling threads are never triaged. Identified as gap F7 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`.
+
+This feature (a) widens the candidate source to ordinary mail, (b) ports the master's §9.2 `chooseMostLikelyRelatedEvent` as a pure matcher in `OpenClaw.Core.Agent`, and (c) adds a calendar-window fallback in the `SchedulingWorker` pipeline when the direct event lookup misses.
+
+## Behavior
+
+1. **Candidate widening.** `CacheSchedulingCandidateSource.GetCandidateMessageIdsAsync` calls `CoreCacheRepository.ListMessagesAsync("all", sinceUtc, limit)` instead of `"meeting"`. The repository predicate for `"all"` matches every cached message row regardless of `item_kind` (`src/OpenClaw.Core/CoreCacheRepository.Messages.cs` lines 31–33); the scanner writes only `'meeting'` and `'mail'` for messages (`src/OpenClaw.MailBridge/OutlookScanner.cs` line 391), so the widened set is exactly meeting messages plus ordinary mail. Lookback window (`Polling.MessageLookbackHours`), limit (`Defaults.Limit`), and recency ordering are unchanged.
+2. **Pure matcher.** A new pure static class `RelatedEventMatcher` in `OpenClaw.Core.Agent` ports §9.2 `chooseMostLikelyRelatedEvent` (see Design Decisions for the exact algorithm and tie-break rule).
+3. **Calendar-window fallback.** In `SchedulingWorker.ProcessMessageAsync` (`src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs`), when `GetEventForMessageAsync` returns null, the worker fetches `schedulingService.GetCalendarViewAsync(now, now + CalendarViewFallbackDays, ct)` with `now = timeProvider.GetUtcNow()` and applies `RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, windowEvents)`. The fallback runs for any direct-lookup miss — matching the master's `if (!event)` guard — not only for `item_kind = 'mail'` messages; meeting-message event linkage is itself deferred (#71–#76), so formal traffic benefits from the same fallback.
+4. **Downstream unchanged.** A matched event flows into `MeetingContextNormalizer.Normalize(mailboxUpn, message, matchedEvent)` — the identical call and shape used for a directly-linked event. No match yields `Normalize(mailboxUpn, message, null)`, the message-only context the pipeline already produces today; `TriageEngine.Triage` already handles that shape (empty subject+body → `IGNORE`; sensitivity defaults `"normal"`; event-derived flags default false — verified in `MeetingContextNormalizer.cs` lines 44–74 and `TriageEngine.cs`).
+5. **Failure degradation.** `HostAdapterSchedulingService.GetCalendarViewAsync` already maps a failure envelope to an empty list (`HostAdapterSchedulingService.cs` lines 54–63), so an unavailable window read degrades to no-match/message-only triage. Client exceptions propagate and are isolated per message by the existing `ProcessMessageSafelyAsync` guard (`SchedulingWorker.cs` lines 80–103). No new exception paths are introduced.
+
+## Inputs / Outputs
+
+- Inputs: cached message rows (Core SQLite cache, `messages` table) and calendar events served through the Graph-shaped `calendarView` surface (`GET /users/{id}/calendarView`), which the Local MVP backs with `list_calendar_window` over the MailBridge cache.
+- Outputs: unchanged pipeline outputs — triage/priority log lines and (when `SendEnabled`) proposal replies. New structured log lines for the fallback (attempted, matched event id, or no match).
+- Config keys and defaults:
+  - `OpenClaw:AgentPolicy:CalendarViewFallbackDays` (int, **default 14**, mirroring the 14-day forward window in master §9.2). A non-positive value skips the fallback entirely (documented opt-out; consistent with the options bag carrying no validators today).
+- Versioning / backward compatibility: no wire, schema, or public-contract changes. `ISchedulingService` is unchanged — `GetCalendarViewAsync` already exists on the interface (`src/OpenClaw.Core/Agent/Contracts/ISchedulingService.cs` lines 26–35, documented as "the calendar-view fallback").
+
+## API / CLI Surface
+
+No external API or CLI changes. Internal surface additions:
+
+```csharp
+namespace OpenClaw.Core.Agent;
+
+/// <summary>Pure port of master §9.2 chooseMostLikelyRelatedEvent.</summary>
+public static class RelatedEventMatcher
+{
+    public static SchedulingEventDto? ChooseMostLikelyRelatedEvent(
+        SchedulingMessageDto message,
+        IReadOnlyList<SchedulingEventDto> events
+    );
+}
+```
+
+- `AgentPolicyOptions` gains `public int CalendarViewFallbackDays { get; set; } = 14;`.
+- Contracts and validation: `ChooseMostLikelyRelatedEvent` throws `ArgumentNullException` for null arguments (matching `MeetingContextNormalizer.Normalize` and `TriageEngine.Triage` conventions); it never throws for empty/degenerate content (null subjects, empty attendee lists, null ids) and returns null when no event scores >= 4.
+
+## Data & State
+
+- No schema changes. The `messages` table already carries `item_kind` with values `'meeting'`/`'mail'`, and `ListMessagesAsync` already supports the `"all"` kind (used by `/messages` route validation in `Program.cs` lines 258–259).
+- Data transformations: window events arrive as `SchedulingEventDto` via the existing `SchedulingDtoMapper.MapEvent` path (attendee JSON parsed, emails preserved); the matcher normalizes emails with the existing public helpers `MeetingContextNormalizer.NormalizeEmail`/`EmailOf` (trim + lowercase) so message-side and event-side comparisons use identical normalization.
+- Invariants: the matcher is pure and order-independent (deterministic tie-break); the pipeline remains single I/O seam (`ISchedulingService`) only.
+- No migration or backfill.
+
+## Design Decisions
+
+### D1 — Matcher algorithm (exact §9.2 port) and tie-breaking
+
+- Message subject tokens: lowercase, split on runs of non-alphanumeric characters (`[^a-z0-9]+`), keep tokens of length >= 4, distinct (set semantics, as in the master's `Set`).
+- Message participants: normalized emails of `From`, `Sender`, all `ToRecipients`, all `CcRecipients`; empties dropped; distinct.
+- Event side: subject tokenized identically; attendee emails are the union of `RequiredAttendees`, `OptionalAttendees`, `ResourceAttendees` (the master scores `event.attendees`, which carries all three types; the organizer is intentionally **not** included, matching the reference).
+- Score: **+2** per message subject token present in the event token set; **+3** per participant email present in the event attendee set. Accept the best-scoring event only when the score is **>= 4** (so two subject tokens, or one token plus one participant, suffice; a single participant match does not).
+- Tie-break (deviation from the reference, recorded deliberately): the master's loop keeps the first event with a strictly greater score, making the result depend on input order. `CacheRepository.ListCalendarWindowAsync` ordering is an implementation detail of the bridge, so first-wins would couple the decision to storage ordering. Instead, among events sharing the maximum qualifying score, select the one with the earliest `Start` (null `Start` sorts last), then the smallest ordinal `Id` (null treated as empty string). This is strictly stronger determinism with identical accept/reject behavior.
+
+### D2 — Fallback event source: `ISchedulingService.GetCalendarViewAsync` (client path), not a direct Core-cache read
+
+Evidence-based choice of the live client path:
+
+1. The seam method already exists and was built for this purpose: `ISchedulingService.GetCalendarViewAsync` is documented "the calendar-view fallback" and implemented over `IHostAdapterClient.ListCalendarWindowAsync` (`HostAdapterSchedulingService.cs` lines 48–63; `IHostAdapterClient.cs` lines 71–87, route `GET /users/{id}/calendarView`).
+2. The pipeline's documented invariant is I/O through `ISchedulingService` only (`SchedulingWorker.Pipeline.cs` line 15). Reading `CoreCacheRepository` events directly from the pipeline would add a second data path and break the seam swap that carries the agent unchanged to Graph in Product Increment 1.
+3. Offline-friendliness is already satisfied: per the master's Local MVP mapping table, `calendarView` is served by `list_calendar_window` as "a bounded window over the cached events" — a local SQLite read in `OpenClaw.MailBridge/CacheRepository.cs`. The Core-cache alternative would not remove any network dependency that matters.
+4. No new availability dependency: `GetSchedulingMessageAsync` in the same per-message path already requires the adapter; if the adapter is down, hydration fails before the fallback is reached, and the per-message isolation in `ProcessMessageSafelyAsync` contains it.
+5. Less code: a Core-cache read would require a new `MailBridge.Contracts.Models.EventDto` → `SchedulingEventDto` mapping path and a pipeline dependency on the internal `CoreCacheRepository`; the client path reuses `SchedulingDtoMapper.MapEvent` as-is.
+
+### D3 — Fallback placement: `SchedulingWorker.ProcessMessageAsync`, not inside `HostAdapterSchedulingService.GetEventForMessageAsync`
+
+The matcher needs the hydrated message, a clock, and the window option. The worker already holds all three (`message`, injected `TimeProvider`, `AgentPolicyOptions`); the service holds none and would need re-hydration plus two new constructor dependencies. Placing the orchestration in the pipeline keeps `HostAdapterSchedulingService` a thin adapter and keeps the scoring pure in `OpenClaw.Core.Agent`.
+
+### D4 — Candidate widening predicate and reprocessing
+
+- New predicate: every cached message within `Polling.MessageLookbackHours`, up to `Defaults.Limit`, ordered by recency — implemented by switching the kind literal from `"meeting"` to `"all"`.
+- **Verified: no candidate cursor exists.** The only cursors in the codebase are polling-ingest bookmarks (for example `calendar_window_last_run_utc` in `CalendarPollingWorker.cs`). `CacheSchedulingCandidateSource` re-lists the window every cycle today, so meeting messages are already reprocessed each minute by design; the pipeline is deterministic-compute-plus-logs, and side effects are bounded by the #101 sent-action store (`SentActionKey.Build(mailboxUpn, messageId, ProposalReply)` consulted before send, recorded after — `SchedulingWorker.Pipeline.cs` lines 129–157) and the `SendEnabled`/`CalendarWriteEnabled` kill switches. Widening changes processed **volume**, not reprocessing semantics; no new cursor or option flag is required.
+- Volume bound: `Defaults.Limit` (default 100) messages per cycle. Risk: ordinary mail typically outnumbers meeting messages and both classes now compete for the same recency-ordered limit; accepted for the Local MVP and noted under Constraints & Risks.
+
+### D5 — Per-message window fetch (no memoization)
+
+The fallback issues one `GetCalendarViewAsync` call per unlinked message per cycle. Locally this is a named-pipe read over the MailBridge SQLite cache (cheap); per the repository's simplicity-first design rule, per-cycle memoization of the window is deferred until measurement shows it is needed.
+
+### D6 — `Prefer: outlook.body-content-type="text"` (master §9.3 step 3)
+
+Not applicable to the Local MVP wire: `SchedulingDtoMapper.MapEvent` maps `BodyContent`/`BodyContentType` to null and only `BodyPreview` (already plain text) is available, so deterministic code never sees HTML event bodies here. The `Prefer` header is a requirement on the future Graph-backed client in Product Increment 1 and is recorded as a non-goal for this feature.
+
+## Constraints & Risks
+
+- Widening the candidate set increases processed volume; the dedupe store (#101) and `SendEnabled` gate bound the blast radius. Verified: candidate cursoring does **not** exist — re-listing per cycle is the existing behavior for meeting traffic and is unchanged in kind (see D4).
+- With a shared `Defaults.Limit`, high mail volume can crowd meeting messages out of a cycle's candidate list (recency-ordered). Accepted for the Local MVP; a per-kind quota is a possible follow-up if observed.
+- Matching is heuristic by design; the master mandates the deterministic decision come from code, which this preserves (fixed weights/threshold, order-independent tie-break).
+- Existing worker tests stub `GetEventForMessageAsync` as null; after this change those paths invoke `GetCalendarViewAsync`, so the mocks must be extended (Moq loose mocks return empty task results for enumerable types, but the stubs will be made explicit rather than relying on default-value providers).
+- MSTest + FluentAssertions + Moq + CsCheck (all already referenced by `tests/OpenClaw.Core.Tests/OpenClaw.Core.Tests.csproj`); no temp files (in-memory shared-cache SQLite for repository tests, per `CoreCacheRepositoryGraphFieldsTests` convention); 500-line cap; pure logic in `OpenClaw.Core.Agent`, I/O in the Runtime seam only.
+
+## Implementation Strategy
+
+- Implementation scope (what changes, not sequencing):
+  - `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs` — **new** pure static class (D1). Reuses `MeetingContextNormalizer.NormalizeEmail`/`EmailOf`; tokenizer implemented with a `GeneratedRegex` following the `MeetingContextNormalizer.Helpers.cs` pattern.
+  - `src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs` — add `CalendarViewFallbackDays` (default 14) with XML docs citing master §9.2.
+  - `src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs` — kind literal `"meeting"` → `"all"`; update the XML summary (it currently says "meeting-message identifiers").
+  - `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` — fallback block after the `GetEventForMessageAsync` call (skip when `CalendarViewFallbackDays <= 0`); file is 195 lines today, remains well under 500.
+- New tests:
+  - `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherTests.cs` — scoring rows: subject-only, attendee-only, combined, sub-threshold (score 3), exact-threshold (score 4), tie-break (Start then Id), empty events, null/short subjects, case/normalization.
+  - `tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherPropertyTests.cs` — CsCheck properties per AC-3 (mirrors `MeetingContextNormalizerPropertyTests` conventions).
+  - `tests/OpenClaw.Core.Tests/Agent/Runtime/CacheSchedulingCandidateSourceTests.cs` — **new file** (none exists today): seed an in-memory shared-cache `CoreCacheRepository` with `meeting` and `mail` rows; assert both ids returned, lookback and limit respected.
+  - Update `SchedulingWorkerTests` (fallback: miss → window fetch → match hydrates context; miss → no match → message-only; `CalendarViewFallbackDays <= 0` skips the fetch; window bounds asserted against `FakeTimeProvider` now + 14 days) and `SchedulingWorkerDedupeTests` (ordinary-mail scenario).
+- Dependency changes: none (CsCheck 4.7.0, Moq 4.20.72, MSTest 3.6.4, FluentAssertions 6.12.0, `Microsoft.Extensions.TimeProvider.Testing` already referenced).
+- Logging: `LogDebug` when the fallback is attempted (message id, window bounds); `LogInformation` on match (message id, event id, score) and `LogDebug` on no-match — same `ILogger<SchedulingWorker>` patterns as the existing pipeline stages.
+- Rollout: no new kill switch; the fallback is compute-plus-logs like the rest of the pipeline, and all side effects remain behind `SendEnabled`/`CalendarWriteEnabled`. `CalendarViewFallbackDays <= 0` is the documented opt-out.
+
+## Acceptance Criteria
+
+- [x] `CacheSchedulingCandidateSource.GetCandidateMessageIdsAsync` returns ordinary (`item_kind = 'mail'`) messages alongside meeting messages (repository kind `"all"`), preserving the existing lookback window, limit, and ordering; formal meeting-traffic handling is unchanged; covered by a new unit test against an in-memory SQLite `CoreCacheRepository`.
+- [x] A new pure static `RelatedEventMatcher` in `OpenClaw.Core.Agent` ports §9.2 `chooseMostLikelyRelatedEvent` exactly: distinct lowercase subject tokens (split on non-alphanumeric runs, length >= 4) score +2 per token also present in the event subject; distinct normalized participant emails (from, sender, to, cc) score +3 per email present in the event attendee set (required + optional + resource); the best event is returned only when its score >= 4; ties resolve deterministically by earliest `Start` (null last) then ordinal `Id`; unit tests cover subject-only, attendee-only, combined, sub-threshold, empty-input, and tie-break rows.
+- [x] CsCheck property/invariant tests cover the matcher: the result is null or scores >= 4; the selected event is invariant under permutation of the input event list; scoring is case-insensitive; duplicate tokens/emails do not double-count (set semantics).
+- [x] When `GetEventForMessageAsync` returns null, `SchedulingWorker.ProcessMessageAsync` fetches `ISchedulingService.GetCalendarViewAsync(now, now + CalendarViewFallbackDays)` and applies the matcher; `CalendarViewFallbackDays` is a new `AgentPolicyOptions` value defaulting to 14; `now` comes from the injected `TimeProvider` (no wall-clock APIs); a non-positive configured value skips the fallback; verified with mocked `ISchedulingService` and `FakeTimeProvider`.
+- [x] No-match (empty window, all scores < 4, or a failure envelope mapped to an empty window) falls through to message-only triage (`MeetingContextNormalizer.Normalize(mailboxUpn, message, null)`) without a new exception path; a matched event hydrates the context through the same `Normalize` call formal traffic uses.
+- [x] Widened candidates are re-listed every cycle (no candidate cursor exists); outbound proposal sends remain deduplicated across cycles by the #101 sent-action store with the unchanged key shape — verified by extending the existing dedupe tests with an ordinary-mail scenario.
+- [x] Full C# toolchain passes (CSharpier, analyzers, build, architecture, tests); coverage thresholds hold (line >= 85%, branch >= 75%) with changed lines covered; all touched files remain <= 500 lines.
+
+## Definition of Done
+
+- [ ] Acceptance criteria documented and mapped to tests or demos
+- [ ] Behavior matches acceptance criteria in all documented environments
+- [ ] Tests updated/added (unit/integration as applicable)
+- [ ] Edge cases and error handling covered by tests
+- [ ] Docs updated (README, docs/features/active/... links)
+- [ ] Telemetry/logging added or updated (if applicable)
+- [ ] Toolchain pass completed (format → lint → type-check → test)
+
+## Seeded Test Conditions (from potential)
+
+- [ ] Unit: matcher scoring rows (subject-only, attendee-only, combined, sub-threshold, tie-break).
+- [ ] Unit: candidate source includes ordinary mail; excludes nothing new — re-listing per cycle is the existing (cursor-less) behavior, bounded by lookback and limit.
+- [ ] Unit: runtime fallback path (miss -> window fetch -> match / no-match), mocked client.

--- a/docs/features/active/2026-07-02-ordinary-mail-candidates-103/user-story.md
+++ b/docs/features/active/2026-07-02-ordinary-mail-candidates-103/user-story.md
@@ -1,0 +1,60 @@
+# `ordinary-mail-candidates` — User Story
+
+- Issue: #103
+- Owner: drmoisan
+- Status: Draft
+- Last Updated: 2026-07-02
+
+## Story Statement
+
+- As a mailbox owner, I want ordinary scheduling emails ("can we move this?", "what works next week?") to be triaged by the assistant, so that reschedule requests sent as plain mail are handled instead of being handled only when they arrive as formal meeting invites.
+- As a mailbox owner, I want the assistant to connect a plain email to the calendar event it is talking about, so that its decisions use the real meeting context — attendees, recurrence, sensitivity, and protected status — rather than the email text alone.
+- As a mailbox owner, I want scheduling mail that matches no calendar event to still be triaged safely from the message alone, so that the assistant neither errors out nor acts on the wrong meeting.
+
+## Problem / Why
+
+The master specification defines two input classes (`docs/open-claw-approach.master.md` §2.2): formal meeting traffic and **ordinary scheduling mail** ("can we move this?", "what works next week?"). Today only the first class is handled: `CacheSchedulingCandidateSource.GetCandidateMessageIdsAsync` (`src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs`) selects only `item_kind = 'meeting'` messages, and `HostAdapterSchedulingService.GetEventForMessageAsync` does a direct event-by-id lookup returning null on a miss — there is no `calendarView`-window fallback with the subject/attendee-overlap matching heuristic the master specifies (§9.2 `chooseMostLikelyRelatedEvent`, §9.3 step 3). Ordinary scheduling threads are never triaged. Identified as gap F7 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`.
+
+From the mailbox owner's perspective the effect is simple: most real-world rescheduling conversations happen in plain email, and the assistant currently ignores every one of them.
+
+## Personas & Scenarios
+
+- Persona: **The mailbox owner** (an executive or manager whose calendar the assistant coordinates)
+  - Receives a steady stream of scheduling-related plain email alongside formal invites.
+  - Cares that reschedule requests are noticed promptly and answered consistently, without personally re-reading every thread.
+  - Constraint: trusts the assistant only if it is deterministic and conservative — it must never confuse one meeting with another, act on private meetings, or send anything while the send kill switch is off.
+  - Frustration today: a colleague's "can we push Thursday's budget review?" email produces no assistant activity at all, while the same request sent as a formal proposal would be triaged.
+
+- Scenario: **Reschedule request as plain mail, matching event found**
+  - A direct report emails the owner: subject "Budget review Thursday", body "Can we move this to later in the week?". It is ordinary mail — no invite attached, no linked event.
+  - On the next scheduling cycle the assistant now includes this message as a candidate (previously it was filtered out as non-meeting mail).
+  - The direct event lookup misses, so the assistant reads the next 14 days of the calendar and scores each event: the "Budget Review" event shares two long subject tokens with the message and the sender is a required attendee, comfortably clearing the acceptance threshold.
+  - The assistant hydrates the meeting context from that event — exactly as it would for a formal invite — then runs the standard triage, priority, and slot-proposal pipeline. With sends enabled, the requester receives a proposal reply; with sends disabled, the decision is computed and logged only.
+  - Obstacle handled deterministically: if two events tie on score, the assistant always picks the same one (earliest start, then id), so repeated cycles never flip-flop.
+
+- Scenario: **Scheduling mail with no matching event**
+  - A partner emails "what works next week for a first sync?" — there is no existing calendar event to match, so the calendar-window search finds nothing above the threshold.
+  - The assistant proceeds with message-only context: triage still classifies the item (for example `HUMAN_APPROVAL` for an external sender), and nothing errors or silently stalls.
+  - Outcome the owner expects: no wrong-meeting guesses — a below-threshold match is treated as no match.
+
+- Scenario: **Adapter hiccup during the calendar read**
+  - The calendar-window read fails or returns nothing. The assistant degrades to message-only triage for that message and continues the cycle; one bad item never halts the loop.
+
+## Acceptance Criteria
+
+- [x] `CacheSchedulingCandidateSource.GetCandidateMessageIdsAsync` returns ordinary (`item_kind = 'mail'`) messages alongside meeting messages (repository kind `"all"`), preserving the existing lookback window, limit, and ordering; formal meeting-traffic handling is unchanged; covered by a new unit test against an in-memory SQLite `CoreCacheRepository`.
+- [x] A new pure static `RelatedEventMatcher` in `OpenClaw.Core.Agent` ports §9.2 `chooseMostLikelyRelatedEvent` exactly: distinct lowercase subject tokens (split on non-alphanumeric runs, length >= 4) score +2 per token also present in the event subject; distinct normalized participant emails (from, sender, to, cc) score +3 per email present in the event attendee set (required + optional + resource); the best event is returned only when its score >= 4; ties resolve deterministically by earliest `Start` (null last) then ordinal `Id`; unit tests cover subject-only, attendee-only, combined, sub-threshold, empty-input, and tie-break rows.
+- [x] CsCheck property/invariant tests cover the matcher: the result is null or scores >= 4; the selected event is invariant under permutation of the input event list; scoring is case-insensitive; duplicate tokens/emails do not double-count (set semantics).
+- [x] When `GetEventForMessageAsync` returns null, `SchedulingWorker.ProcessMessageAsync` fetches `ISchedulingService.GetCalendarViewAsync(now, now + CalendarViewFallbackDays)` and applies the matcher; `CalendarViewFallbackDays` is a new `AgentPolicyOptions` value defaulting to 14; `now` comes from the injected `TimeProvider` (no wall-clock APIs); a non-positive configured value skips the fallback; verified with mocked `ISchedulingService` and `FakeTimeProvider`.
+- [x] No-match (empty window, all scores < 4, or a failure envelope mapped to an empty window) falls through to message-only triage (`MeetingContextNormalizer.Normalize(mailboxUpn, message, null)`) without a new exception path; a matched event hydrates the context through the same `Normalize` call formal traffic uses.
+- [x] Widened candidates are re-listed every cycle (no candidate cursor exists); outbound proposal sends remain deduplicated across cycles by the #101 sent-action store with the unchanged key shape — verified by extending the existing dedupe tests with an ordinary-mail scenario.
+- [x] Full C# toolchain passes (CSharpier, analyzers, build, architecture, tests); coverage thresholds hold (line >= 85%, branch >= 75%) with changed lines covered; all touched files remain <= 500 lines.
+
+## Non-Goals
+
+- No natural-language or model-based matching; the matcher is the fixed-weight, fixed-threshold deterministic heuristic from master §9.2. "Timing clues" mentioned in §2.2 are not scored — the §9.2 reference implementation scores subject and participants only, and this feature ports it exactly.
+- No calendar writes and no changes to the send path, kill switches, or the #101 dedupe key shape.
+- No `Prefer: outlook.body-content-type="text"` header work: the Local MVP event surface already returns plain-text previews only; the header is a Product Increment 1 (Graph client) concern.
+- No message-to-event linkage for formal traffic (deferred bridge work #71–#76) — the fallback compensates for misses but does not implement linkage.
+- No candidate cursor, backpressure, or per-kind quota redesign; re-listing the lookback window each cycle remains the candidate model.
+- No changes to the Graph-shaped HostAdapter surface or MailBridge RPC methods (`list_calendar_window` is consumed as-is).

--- a/src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs
+++ b/src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs
@@ -69,6 +69,16 @@ public sealed class AgentPolicyOptions
     /// </summary>
     public IReadOnlyList<string> PreferredDays { get; set; } = Array.Empty<string>();
 
+    // --- Calendar-view fallback (master Section 9.2) ---
+
+    /// <summary>
+    /// The forward calendar-view window, in days, fetched when the direct
+    /// event-for-message lookup misses (master Section 9.2 uses a 14-day forward
+    /// window). Default 14. A non-positive value skips the fallback entirely
+    /// (documented opt-out).
+    /// </summary>
+    public int CalendarViewFallbackDays { get; set; } = 14;
+
     // --- Kill switches (master Section 7.5) ---
 
     /// <summary>

--- a/src/OpenClaw.Core/Agent/RelatedEventMatcher.cs
+++ b/src/OpenClaw.Core/Agent/RelatedEventMatcher.cs
@@ -1,0 +1,191 @@
+using System.Text.RegularExpressions;
+
+namespace OpenClaw.Core.Agent;
+
+/// <summary>
+/// Pure port of master Section 9.2 <c>chooseMostLikelyRelatedEvent</c>. Scores each
+/// candidate event against the message by shared subject tokens (+2 each) and shared
+/// participant emails (+3 each), returning the best event only when its score is at
+/// least 4. Ties among max-scoring qualifiers resolve deterministically by earliest
+/// <see cref="SchedulingEventDto.Start"/> (null last), then smallest ordinal
+/// <see cref="SchedulingEventDto.Id"/> (null treated as empty).
+/// </summary>
+public static partial class RelatedEventMatcher
+{
+    private const int SubjectTokenWeight = 2;
+    private const int ParticipantEmailWeight = 3;
+    private const int AcceptThreshold = 4;
+    private const int MinimumTokenLength = 4;
+
+    // Master Section 9.2 tokenizes subjects by lowercasing and splitting on runs of
+    // non-alphanumeric characters; inputs are lowercased before this regex applies.
+    [GeneratedRegex("[^a-z0-9]+")]
+    private static partial Regex NonAlphanumericRunRegex();
+
+    /// <summary>
+    /// Selects the calendar event most likely related to <paramref name="message"/>,
+    /// or null when no event scores at least 4.
+    /// </summary>
+    /// <param name="message">The hydrated scheduling message.</param>
+    /// <param name="events">The candidate calendar-window events.</param>
+    /// <returns>The best-scoring event with score &gt;= 4, or null.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="message"/> or <paramref name="events"/> is null.
+    /// </exception>
+    public static SchedulingEventDto? ChooseMostLikelyRelatedEvent(
+        SchedulingMessageDto message,
+        IReadOnlyList<SchedulingEventDto> events
+    ) => ChooseMostLikelyRelatedEventWithScore(message, events).Event;
+
+    /// <summary>
+    /// Selects the most likely related event together with its score so callers can
+    /// log the score without recomputing. Returns (null, 0) when no event qualifies.
+    /// </summary>
+    internal static (SchedulingEventDto? Event, int Score) ChooseMostLikelyRelatedEventWithScore(
+        SchedulingMessageDto message,
+        IReadOnlyList<SchedulingEventDto> events
+    )
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        ArgumentNullException.ThrowIfNull(events);
+
+        var messageTokens = TokenizeSubject(message.Subject);
+        var participantEmails = CollectParticipantEmails(message);
+
+        SchedulingEventDto? best = null;
+        var bestScore = 0;
+        foreach (var candidate in events)
+        {
+            var score = ScoreEvent(messageTokens, participantEmails, candidate);
+            if (score < AcceptThreshold)
+            {
+                continue;
+            }
+
+            if (
+                best is null
+                || score > bestScore
+                || (score == bestScore && PrecedesInTieBreak(candidate, best))
+            )
+            {
+                best = candidate;
+                bestScore = score;
+            }
+        }
+
+        return best is null ? (null, 0) : (best, bestScore);
+    }
+
+    private static int ScoreEvent(
+        HashSet<string> messageTokens,
+        HashSet<string> participantEmails,
+        SchedulingEventDto candidate
+    )
+    {
+        var eventTokens = TokenizeSubject(candidate.Subject);
+        var attendeeEmails = CollectAttendeeEmails(candidate);
+        var sharedTokens = messageTokens.Count(eventTokens.Contains);
+        var sharedParticipants = participantEmails.Count(attendeeEmails.Contains);
+        return (sharedTokens * SubjectTokenWeight) + (sharedParticipants * ParticipantEmailWeight);
+    }
+
+    /// <summary>
+    /// Lowercases the subject, splits on runs of non-alphanumeric characters, and keeps
+    /// distinct tokens of length at least 4 (master Section 9.2 set semantics).
+    /// </summary>
+    private static HashSet<string> TokenizeSubject(string? subject)
+    {
+        var tokens = new HashSet<string>(StringComparer.Ordinal);
+        if (string.IsNullOrEmpty(subject))
+        {
+            return tokens;
+        }
+
+        var lowered = subject.ToLowerInvariant();
+        foreach (var token in NonAlphanumericRunRegex().Split(lowered))
+        {
+            if (token.Length >= MinimumTokenLength)
+            {
+                tokens.Add(token);
+            }
+        }
+
+        return tokens;
+    }
+
+    /// <summary>
+    /// Collects the distinct normalized emails of From, Sender, To, and Cc, dropping
+    /// empties, using the same normalization as <see cref="MeetingContextNormalizer"/>.
+    /// </summary>
+    private static HashSet<string> CollectParticipantEmails(SchedulingMessageDto message)
+    {
+        var emails = new HashSet<string>(StringComparer.Ordinal);
+        AddNonEmpty(emails, MeetingContextNormalizer.EmailOf(message.From));
+        AddNonEmpty(emails, MeetingContextNormalizer.EmailOf(message.Sender));
+        AddAttendeeEmails(emails, message.ToRecipients);
+        AddAttendeeEmails(emails, message.CcRecipients);
+        return emails;
+    }
+
+    /// <summary>
+    /// Collects the distinct normalized attendee emails of an event as the union of
+    /// required, optional, and resource attendees. The organizer is intentionally
+    /// excluded, matching the master reference which scores <c>event.attendees</c>.
+    /// </summary>
+    private static HashSet<string> CollectAttendeeEmails(SchedulingEventDto candidate)
+    {
+        var emails = new HashSet<string>(StringComparer.Ordinal);
+        AddAttendeeEmails(emails, candidate.RequiredAttendees);
+        AddAttendeeEmails(emails, candidate.OptionalAttendees);
+        AddAttendeeEmails(emails, candidate.ResourceAttendees);
+        return emails;
+    }
+
+    private static void AddAttendeeEmails(
+        HashSet<string> emails,
+        IReadOnlyList<AttendeeDto> attendees
+    )
+    {
+        foreach (var attendee in attendees)
+        {
+            AddNonEmpty(emails, MeetingContextNormalizer.EmailOf(attendee));
+        }
+    }
+
+    private static void AddNonEmpty(HashSet<string> emails, string email)
+    {
+        if (email.Length > 0)
+        {
+            emails.Add(email);
+        }
+    }
+
+    /// <summary>
+    /// Deterministic tie-break among equal-scoring qualifiers: earliest
+    /// <see cref="SchedulingEventDto.Start"/> wins (null sorts last); when Start ties,
+    /// the smallest ordinal <see cref="SchedulingEventDto.Id"/> wins (null as empty).
+    /// </summary>
+    private static bool PrecedesInTieBreak(SchedulingEventDto candidate, SchedulingEventDto current)
+    {
+        if (candidate.Start is not null && current.Start is null)
+        {
+            return true;
+        }
+
+        if (candidate.Start is null && current.Start is not null)
+        {
+            return false;
+        }
+
+        if (
+            candidate.Start is not null
+            && current.Start is not null
+            && candidate.Start != current.Start
+        )
+        {
+            return candidate.Start < current.Start;
+        }
+
+        return string.CompareOrdinal(candidate.Id ?? string.Empty, current.Id ?? string.Empty) < 0;
+    }
+}

--- a/src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs
+++ b/src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs
@@ -4,8 +4,9 @@ namespace OpenClaw.Core.Agent.Runtime;
 
 /// <summary>
 /// Repository-backed <see cref="ISchedulingCandidateSource"/> that supplies recent
-/// meeting-message identifiers from the local cache populated by the existing polling
-/// workers (OR-3). Part of the runtime seam.
+/// message identifiers — meeting messages plus ordinary mail (#103 candidate
+/// widening) — from the local cache populated by the existing polling workers
+/// (OR-3). Part of the runtime seam.
 /// </summary>
 internal sealed class CacheSchedulingCandidateSource(
     CoreCacheRepository repository,
@@ -21,7 +22,7 @@ internal sealed class CacheSchedulingCandidateSource(
     {
         var sinceUtc = DateTimeOffset.UtcNow.AddHours(-options.Polling.MessageLookbackHours);
         var messages = await repository
-            .ListMessagesAsync("meeting", sinceUtc, options.Defaults.Limit)
+            .ListMessagesAsync("all", sinceUtc, options.Defaults.Limit)
             .ConfigureAwait(false);
         return messages.Select(message => message.BridgeId).ToList();
     }

--- a/src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs
+++ b/src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs
@@ -26,6 +26,18 @@ public sealed partial class SchedulingWorker
             .GetEventForMessageAsync(messageId, cancellationToken)
             .ConfigureAwait(false);
 
+        // Calendar-view fallback (#103, master Section 9.2/9.3 step 3): any direct-lookup
+        // miss consults the forward window; a non-positive window opts out entirely.
+        if (meetingEvent is null && options.CalendarViewFallbackDays > 0)
+        {
+            meetingEvent = await ChooseRelatedEventFromWindowAsync(
+                    messageId,
+                    message,
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+        }
+
         // Normalize (D1).
         var context = MeetingContextNormalizer.Normalize(MailboxUpn(), message, meetingEvent);
 
@@ -57,6 +69,57 @@ public sealed partial class SchedulingWorker
 
         await ProposeAndActAsync(messageId, context, priority, cancellationToken)
             .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Fetches the forward calendar window from the injected clock and applies the pure
+    /// <see cref="RelatedEventMatcher"/> to select the most likely related event. Returns
+    /// null when nothing clears the threshold, which flows into the same message-only
+    /// Normalize call the pipeline already uses (no new exception path). I/O goes
+    /// through the <see cref="ISchedulingService"/> seam only.
+    /// </summary>
+    private async Task<SchedulingEventDto?> ChooseRelatedEventFromWindowAsync(
+        string messageId,
+        SchedulingMessageDto message,
+        CancellationToken cancellationToken
+    )
+    {
+        var windowStart = timeProvider.GetUtcNow();
+        var windowEnd = windowStart.AddDays(options.CalendarViewFallbackDays);
+        logger.LogDebug(
+            "Direct event lookup missed for message {MessageId}; attempting calendar-view "
+                + "fallback over {WindowStart:o}..{WindowEnd:o}.",
+            messageId,
+            windowStart,
+            windowEnd
+        );
+
+        var windowEvents = await schedulingService
+            .GetCalendarViewAsync(windowStart, windowEnd, cancellationToken)
+            .ConfigureAwait(false);
+        var (matched, score) = RelatedEventMatcher.ChooseMostLikelyRelatedEventWithScore(
+            message,
+            windowEvents
+        );
+        if (matched is null)
+        {
+            logger.LogDebug(
+                "No calendar-view event matched message {MessageId}; proceeding message-only.",
+                messageId
+            );
+        }
+        else
+        {
+            logger.LogInformation(
+                "Calendar-view fallback matched message {MessageId} to event {EventId} "
+                    + "with score {Score}.",
+                messageId,
+                matched.Id,
+                score
+            );
+        }
+
+        return matched;
     }
 
     private async Task ProposeAndActAsync(

--- a/tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherPropertyTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherPropertyTests.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CsCheck;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.Core.Agent;
+
+namespace OpenClaw.Core.Tests.Agent;
+
+/// <summary>
+/// Property-based tests for the pure Section 9.2 matcher port (AC-3): the result is
+/// null or scores at least 4; the selection is invariant under permutation of the
+/// event list; scoring is case-insensitive; duplicates do not double-count.
+/// </summary>
+[TestClass]
+public sealed class RelatedEventMatcherPropertyTests
+{
+    // Small overlapping pools so generated messages and events frequently share
+    // tokens/emails and both accept and reject branches are exercised.
+    private static readonly Gen<string> GenSubject = Gen.OneOfConst(
+            "budget",
+            "review",
+            "planning",
+            "sync",
+            "standup",
+            "fix",
+            "re",
+            "it"
+        )
+        .List[0, 4]
+        .Select(tokens => string.Join(' ', tokens));
+
+    private static readonly Gen<AttendeeDto> GenAttendee = Gen.OneOfConst(
+            "alice@contoso.com",
+            "bob@contoso.com",
+            "carol@contoso.com",
+            "dave@contoso.com",
+            string.Empty
+        )
+        .Select(email => new AttendeeDto(Name: string.Empty, Email: email));
+
+    private static readonly Gen<IReadOnlyList<AttendeeDto>> GenAttendees = GenAttendee
+        .List[0, 3]
+        .Select(list => (IReadOnlyList<AttendeeDto>)list);
+
+    private static readonly Gen<SchedulingMessageDto> GenMessage = Gen.Select(
+        GenSubject,
+        GenAttendee,
+        GenAttendees,
+        GenAttendees,
+        (subject, from, to, cc) =>
+            new SchedulingMessageDto(
+                Id: "msg",
+                Subject: subject,
+                BodyPreview: null,
+                BodyContent: null,
+                BodyContentType: null,
+                From: from,
+                Sender: null,
+                ToRecipients: to,
+                CcRecipients: cc,
+                ConversationId: "conv",
+                ReceivedDateTime: null,
+                MeetingMessageType: null,
+                Importance: null
+            )
+    );
+
+    private static readonly Gen<SchedulingEventDto> GenEvent = Gen.Select(
+        Gen.String[Gen.Char['a', 'z'], 1, 6],
+        GenSubject,
+        GenAttendees,
+        GenAttendees,
+        Gen.DateTimeOffset.Nullable(),
+        (id, subject, required, optional, start) =>
+            new SchedulingEventDto(
+                Id: id,
+                ICalUId: null,
+                SeriesMasterId: null,
+                Subject: subject,
+                BodyPreview: null,
+                BodyContent: null,
+                BodyContentType: null,
+                Organizer: new AttendeeDto("O", "organizer@contoso.com"),
+                RequiredAttendees: required,
+                OptionalAttendees: optional,
+                ResourceAttendees: Array.Empty<AttendeeDto>(),
+                Categories: Array.Empty<string>(),
+                IsOrganizer: false,
+                IsOnlineMeeting: false,
+                AllowNewTimeProposals: true,
+                Sensitivity: "normal",
+                Start: start,
+                StartTimeZone: null,
+                End: null,
+                EndTimeZone: null,
+                LastModifiedDateTime: null,
+                Type: null
+            )
+    );
+
+    private static readonly Gen<IReadOnlyList<SchedulingEventDto>> GenEvents = GenEvent
+        .List[0, 6]
+        .Select(list => (IReadOnlyList<SchedulingEventDto>)list);
+
+    [TestMethod]
+    public void Result_is_null_or_the_selected_event_scores_at_least_four()
+    {
+        Gen.Select(GenMessage, GenEvents)
+            .Sample(
+                tuple =>
+                {
+                    var (message, events) = tuple;
+
+                    var (selected, score) =
+                        RelatedEventMatcher.ChooseMostLikelyRelatedEventWithScore(message, events);
+
+                    if (selected is null)
+                    {
+                        score.Should().Be(0, "no qualifying event reports score 0");
+                    }
+                    else
+                    {
+                        score
+                            .Should()
+                            .BeGreaterThanOrEqualTo(4, "accepted events must clear the threshold");
+                        events.Should().Contain(selected);
+                    }
+                },
+                iter: 1000
+            );
+    }
+
+    [TestMethod]
+    public void Selection_is_invariant_under_permutation_of_the_event_list()
+    {
+        Gen.Select(GenMessage, GenEvents, Gen.Int)
+            .Sample(
+                tuple =>
+                {
+                    var (message, events, seed) = tuple;
+                    var shuffled = FisherYates(events, seed);
+
+                    var original = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(
+                        message,
+                        events
+                    );
+                    var permuted = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(
+                        message,
+                        shuffled
+                    );
+
+                    permuted
+                        .Should()
+                        .BeSameAs(original, "the deterministic tie-break is order-independent");
+                },
+                iter: 1000
+            );
+    }
+
+    [TestMethod]
+    public void Scoring_is_case_insensitive()
+    {
+        Gen.Select(GenMessage, GenEvents)
+            .Sample(
+                tuple =>
+                {
+                    var (message, events) = tuple;
+                    var upperMessage = message with
+                    {
+                        Subject = message.Subject?.ToUpperInvariant(),
+                        From = Upper(message.From),
+                        Sender = Upper(message.Sender),
+                        ToRecipients = Upper(message.ToRecipients),
+                        CcRecipients = Upper(message.CcRecipients),
+                    };
+
+                    var original = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(
+                        message,
+                        events
+                    );
+                    var uppercased = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(
+                        upperMessage,
+                        events
+                    );
+
+                    uppercased
+                        .Should()
+                        .BeSameAs(
+                            original,
+                            "uppercasing subjects and emails must not change the selection"
+                        );
+                },
+                iter: 1000
+            );
+    }
+
+    [TestMethod]
+    public void Duplicated_tokens_and_emails_do_not_change_the_score()
+    {
+        Gen.Select(GenMessage, GenEvents)
+            .Sample(
+                tuple =>
+                {
+                    var (message, events) = tuple;
+                    var duplicatedMessage = message with
+                    {
+                        Subject = message.Subject is null
+                            ? null
+                            : message.Subject + " " + message.Subject,
+                        ToRecipients = Doubled(message.ToRecipients),
+                        CcRecipients = Doubled(message.CcRecipients),
+                    };
+                    var duplicatedEvents =
+                        (IReadOnlyList<SchedulingEventDto>)
+                            events
+                                .Select(candidate =>
+                                    candidate with
+                                    {
+                                        Subject = candidate.Subject is null
+                                            ? null
+                                            : candidate.Subject + " " + candidate.Subject,
+                                        RequiredAttendees = Doubled(candidate.RequiredAttendees),
+                                        OptionalAttendees = Doubled(candidate.OptionalAttendees),
+                                    }
+                                )
+                                .ToList();
+
+                    var (original, originalScore) =
+                        RelatedEventMatcher.ChooseMostLikelyRelatedEventWithScore(message, events);
+                    var (duplicated, duplicatedScore) =
+                        RelatedEventMatcher.ChooseMostLikelyRelatedEventWithScore(
+                            duplicatedMessage,
+                            duplicatedEvents
+                        );
+
+                    duplicatedScore
+                        .Should()
+                        .Be(originalScore, "duplicated tokens and emails must not double-count");
+                    (duplicated?.Id)
+                        .Should()
+                        .Be(original?.Id, "set semantics preserve the selection");
+                },
+                iter: 1000
+            );
+    }
+
+    private static IReadOnlyList<SchedulingEventDto> FisherYates(
+        IReadOnlyList<SchedulingEventDto> events,
+        int seed
+    )
+    {
+        var random = new Random(seed);
+        var array = events.ToArray();
+        for (var i = array.Length - 1; i > 0; i--)
+        {
+            var j = random.Next(i + 1);
+            (array[i], array[j]) = (array[j], array[i]);
+        }
+
+        return array;
+    }
+
+    private static AttendeeDto? Upper(AttendeeDto? attendee) =>
+        attendee is null ? null : attendee with { Email = attendee.Email.ToUpperInvariant() };
+
+    private static IReadOnlyList<AttendeeDto> Upper(IReadOnlyList<AttendeeDto> attendees) =>
+        attendees.Select(attendee => Upper(attendee)!).ToList();
+
+    private static IReadOnlyList<AttendeeDto> Doubled(IReadOnlyList<AttendeeDto> attendees) =>
+        attendees.Concat(attendees).ToList();
+}

--- a/tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/RelatedEventMatcherTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.Core.Agent;
+
+namespace OpenClaw.Core.Tests.Agent;
+
+/// <summary>
+/// Unit tests for the pure Section 9.2 matcher port (AC-2): scoring rows, threshold,
+/// deterministic tie-breaks, degenerate inputs, normalization, and null-arg contracts.
+/// </summary>
+[TestClass]
+public sealed class RelatedEventMatcherTests
+{
+    private static SchedulingMessageDto Message(
+        string? subject = null,
+        AttendeeDto? from = null,
+        AttendeeDto? sender = null,
+        IReadOnlyList<AttendeeDto>? to = null,
+        IReadOnlyList<AttendeeDto>? cc = null
+    ) =>
+        new(
+            Id: "msg-1",
+            Subject: subject,
+            BodyPreview: null,
+            BodyContent: null,
+            BodyContentType: null,
+            From: from,
+            Sender: sender,
+            ToRecipients: to ?? Array.Empty<AttendeeDto>(),
+            CcRecipients: cc ?? Array.Empty<AttendeeDto>(),
+            ConversationId: "conv-1",
+            ReceivedDateTime: new DateTimeOffset(2026, 6, 9, 10, 0, 0, TimeSpan.Zero),
+            MeetingMessageType: null,
+            Importance: null
+        );
+
+    private static SchedulingEventDto Event(
+        string? id = "evt-1",
+        string? subject = null,
+        AttendeeDto? organizer = null,
+        IReadOnlyList<AttendeeDto>? required = null,
+        IReadOnlyList<AttendeeDto>? optional = null,
+        IReadOnlyList<AttendeeDto>? resource = null,
+        DateTimeOffset? start = null
+    ) =>
+        new(
+            Id: id,
+            ICalUId: null,
+            SeriesMasterId: null,
+            Subject: subject,
+            BodyPreview: null,
+            BodyContent: null,
+            BodyContentType: null,
+            Organizer: organizer,
+            RequiredAttendees: required ?? Array.Empty<AttendeeDto>(),
+            OptionalAttendees: optional ?? Array.Empty<AttendeeDto>(),
+            ResourceAttendees: resource ?? Array.Empty<AttendeeDto>(),
+            Categories: Array.Empty<string>(),
+            IsOrganizer: false,
+            IsOnlineMeeting: false,
+            AllowNewTimeProposals: true,
+            Sensitivity: "normal",
+            Start: start,
+            StartTimeZone: null,
+            End: start is null ? null : start.Value.AddHours(1),
+            EndTimeZone: null,
+            LastModifiedDateTime: null,
+            Type: null
+        );
+
+    private static AttendeeDto Attendee(string email) => new(Name: string.Empty, Email: email);
+
+    [TestMethod]
+    public void Subject_only_match_with_two_shared_tokens_scores_four_and_is_accepted()
+    {
+        var message = Message(subject: "budget review");
+        var candidate = Event(subject: "Quarterly budget review sync");
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result.Should().BeSameAs(candidate, "two shared subject tokens score 2 + 2 = 4");
+    }
+
+    [TestMethod]
+    public void Attendee_only_match_with_two_shared_participants_scores_six_and_is_accepted()
+    {
+        var message = Message(
+            from: Attendee("alice@contoso.com"),
+            to: [Attendee("bob@contoso.com")]
+        );
+        var candidate = Event(
+            required: [Attendee("alice@contoso.com")],
+            optional: [Attendee("bob@contoso.com")]
+        );
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result.Should().BeSameAs(candidate, "two shared participant emails score 3 + 3 = 6");
+    }
+
+    [TestMethod]
+    public void Combined_token_and_participant_scores_five_and_is_accepted()
+    {
+        var message = Message(subject: "standup", from: Attendee("alice@contoso.com"));
+        var candidate = Event(subject: "Team standup", required: [Attendee("alice@contoso.com")]);
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result.Should().BeSameAs(candidate, "one token (2) plus one participant (3) scores 5");
+    }
+
+    [TestMethod]
+    public void Single_participant_match_scores_three_and_returns_null()
+    {
+        var message = Message(from: Attendee("alice@contoso.com"));
+        var candidate = Event(required: [Attendee("alice@contoso.com")]);
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result.Should().BeNull("a single participant match scores 3, below the threshold of 4");
+    }
+
+    [TestMethod]
+    public void Exact_threshold_score_of_four_is_accepted()
+    {
+        var message = Message(subject: "planning session");
+        var candidate = Event(subject: "planning session");
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result.Should().BeSameAs(candidate, "the threshold is inclusive: score >= 4 accepts");
+    }
+
+    [TestMethod]
+    public void Tie_break_selects_earliest_start_and_null_start_sorts_last()
+    {
+        var message = Message(subject: "budget review");
+        var later = Event(
+            id: "evt-later",
+            subject: "budget review",
+            start: new DateTimeOffset(2026, 7, 10, 9, 0, 0, TimeSpan.Zero)
+        );
+        var earlier = Event(
+            id: "evt-earlier",
+            subject: "budget review",
+            start: new DateTimeOffset(2026, 7, 3, 9, 0, 0, TimeSpan.Zero)
+        );
+        var nullStart = Event(id: "evt-null-start", subject: "budget review", start: null);
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(
+            message,
+            [nullStart, later, earlier]
+        );
+
+        result.Should().BeSameAs(earlier, "the earliest Start wins and null Start sorts last");
+    }
+
+    [TestMethod]
+    public void Tie_break_selects_smallest_ordinal_id_when_start_ties()
+    {
+        var message = Message(subject: "budget review");
+        var start = new DateTimeOffset(2026, 7, 3, 9, 0, 0, TimeSpan.Zero);
+        var idB = Event(id: "evt-b", subject: "budget review", start: start);
+        var idA = Event(id: "evt-a", subject: "budget review", start: start);
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [idB, idA]);
+
+        result.Should().BeSameAs(idA, "when Start ties the smallest ordinal Id wins");
+    }
+
+    [TestMethod]
+    public void Empty_event_list_returns_null()
+    {
+        var message = Message(subject: "budget review");
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(
+            message,
+            Array.Empty<SchedulingEventDto>()
+        );
+
+        result.Should().BeNull("there is no candidate to select");
+    }
+
+    [TestMethod]
+    public void Null_subject_contributes_zero_so_single_participant_stays_below_threshold()
+    {
+        var message = Message(subject: null, from: Attendee("alice@contoso.com"));
+        var candidate = Event(subject: "budget review", required: [Attendee("alice@contoso.com")]);
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result
+            .Should()
+            .BeNull("a null subject yields no tokens, leaving only 3 from the participant");
+    }
+
+    [TestMethod]
+    public void Short_tokens_are_ignored_so_single_participant_stays_below_threshold()
+    {
+        var message = Message(subject: "re: fix it now", from: Attendee("alice@contoso.com"));
+        var candidate = Event(subject: "re: fix it now", required: [Attendee("alice@contoso.com")]);
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result.Should().BeNull("tokens shorter than 4 characters score nothing");
+    }
+
+    [TestMethod]
+    public void Token_and_email_matching_is_case_insensitive()
+    {
+        var message = Message(subject: "BUDGET Review", from: Attendee("ALICE@Contoso.COM"));
+        var candidate = Event(subject: "budget review", required: [Attendee("alice@contoso.com")]);
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result.Should().BeSameAs(candidate, "tokens and emails are compared case-insensitively");
+    }
+
+    [TestMethod]
+    public void Organizer_email_is_not_counted_toward_the_score()
+    {
+        var message = Message(
+            from: Attendee("alice@contoso.com"),
+            to: [Attendee("bob@contoso.com")]
+        );
+        var candidate = Event(
+            organizer: Attendee("alice@contoso.com"),
+            required: [Attendee("bob@contoso.com")]
+        );
+
+        var result = RelatedEventMatcher.ChooseMostLikelyRelatedEvent(message, [candidate]);
+
+        result.Should().BeNull("the organizer is excluded, so only one participant (3) matches");
+    }
+
+    [TestMethod]
+    public void Null_message_throws_argument_null_exception()
+    {
+        var act = () =>
+            RelatedEventMatcher.ChooseMostLikelyRelatedEvent(
+                null!,
+                Array.Empty<SchedulingEventDto>()
+            );
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("message");
+    }
+
+    [TestMethod]
+    public void Null_events_throws_argument_null_exception()
+    {
+        var act = () => RelatedEventMatcher.ChooseMostLikelyRelatedEvent(Message(), null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("events");
+    }
+}

--- a/tests/OpenClaw.Core.Tests/Agent/Runtime/CacheSchedulingCandidateSourceTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/Runtime/CacheSchedulingCandidateSourceTests.cs
@@ -1,0 +1,175 @@
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenClaw.Core;
+using OpenClaw.Core.Agent.Runtime;
+using OpenClaw.MailBridge.Contracts.Models;
+
+namespace OpenClaw.Core.Tests.Agent.Runtime;
+
+/// <summary>
+/// Unit tests for the widened candidate source (#103 AC-1): ordinary
+/// (<c>item_kind = 'mail'</c>) messages are candidates alongside meeting messages,
+/// while the lookback window, limit, and recency ordering are unchanged. Uses
+/// in-memory shared-cache SQLite so no temp files are created. Rows are seeded
+/// relative to real now with generous margins because the candidate source anchors
+/// its lookback to <see cref="DateTimeOffset.UtcNow"/> (pre-existing behavior).
+/// </summary>
+[TestClass]
+public sealed class CacheSchedulingCandidateSourceTests
+{
+    private static readonly BridgeStatusDto ReadyBridge = new(
+        BridgeState.ready.ToString(),
+        BridgeMode.enhanced.ToString(),
+        true,
+        false,
+        null,
+        null,
+        null
+    );
+
+    private static MessageDto BuildMessage(
+        string bridgeId,
+        string itemKind,
+        DateTimeOffset receivedUtc
+    ) =>
+        new(
+            BridgeId: bridgeId,
+            ItemKind: itemKind,
+            Subject: "Candidate row",
+            ReceivedUtc: receivedUtc,
+            SentUtc: receivedUtc.AddMinutes(-5),
+            Importance: 1,
+            Sensitivity: 0,
+            Unread: true,
+            HasAttachments: false,
+            MessageClass: itemKind == "meeting" ? "IPM.Schedule.Meeting.Request" : "IPM.Note",
+            SenderName: "Sender",
+            SenderEmail: "sender@contoso.com",
+            ToJson: null,
+            CcJson: null,
+            BodyPreview: null,
+            ProtectedFieldsAvailable: true,
+            IsRedacted: false,
+            SenderEmailResolved: null,
+            FromEmailAddress: null,
+            ConversationId: null,
+            MeetingMessageType: null
+        );
+
+    private static async Task<CoreCacheRepository> CreateRepositoryAsync(
+        params MessageDto[] messages
+    )
+    {
+        var repository = new CoreCacheRepository(
+            $"Data Source=candidate-source-{Guid.NewGuid():N};Mode=Memory;Cache=Shared"
+        );
+        await repository.InitializeAsync();
+        await repository.UpsertMessagesAsync(messages, ReadyBridge, "req-1", DateTimeOffset.UtcNow);
+        return repository;
+    }
+
+    private static CacheSchedulingCandidateSource CreateSource(
+        CoreCacheRepository repository,
+        int limit = 100,
+        int lookbackHours = 48
+    ) =>
+        new(
+            repository,
+            Options.Create(
+                new OpenClawOptions
+                {
+                    Polling = new PollingOptions { MessageLookbackHours = lookbackHours },
+                    Defaults = new DefaultOptions { Limit = limit },
+                }
+            )
+        );
+
+    [TestMethod]
+    public async Task GetCandidateMessageIds_returns_mail_alongside_meeting_within_window()
+    {
+        // Arrange: one meeting row and one ordinary mail row inside the lookback window.
+        var now = DateTimeOffset.UtcNow;
+        using var repository = await CreateRepositoryAsync(
+            BuildMessage("meeting-in-window", "meeting", now.AddHours(-1)),
+            BuildMessage("mail-in-window", "mail", now.AddHours(-2)),
+            BuildMessage("meeting-stale", "meeting", now.AddHours(-100))
+        );
+        var source = CreateSource(repository);
+
+        // Act
+        var ids = await source.GetCandidateMessageIdsAsync(CancellationToken.None);
+
+        // Assert: ordinary mail is a candidate alongside meeting traffic.
+        ids.Should()
+            .BeEquivalentTo(
+                ["meeting-in-window", "mail-in-window"],
+                "the widened candidate set is meeting plus ordinary mail within the window"
+            );
+    }
+
+    [TestMethod]
+    public async Task GetCandidateMessageIds_excludes_rows_older_than_the_lookback_window()
+    {
+        // Arrange: one in-window meeting row and one stale meeting row (lookback 48h).
+        var now = DateTimeOffset.UtcNow;
+        using var repository = await CreateRepositoryAsync(
+            BuildMessage("meeting-in-window", "meeting", now.AddHours(-1)),
+            BuildMessage("meeting-stale", "meeting", now.AddHours(-100))
+        );
+        var source = CreateSource(repository);
+
+        // Act
+        var ids = await source.GetCandidateMessageIdsAsync(CancellationToken.None);
+
+        // Assert
+        ids.Should().BeEquivalentTo(["meeting-in-window"], "the lookback window is unchanged");
+    }
+
+    [TestMethod]
+    public async Task GetCandidateMessageIds_caps_the_result_at_the_configured_limit()
+    {
+        // Arrange: three in-window meeting rows with a limit of two.
+        var now = DateTimeOffset.UtcNow;
+        using var repository = await CreateRepositoryAsync(
+            BuildMessage("meeting-newest", "meeting", now.AddHours(-1)),
+            BuildMessage("meeting-middle", "meeting", now.AddHours(-2)),
+            BuildMessage("meeting-oldest", "meeting", now.AddHours(-3))
+        );
+        var source = CreateSource(repository, limit: 2);
+
+        // Act
+        var ids = await source.GetCandidateMessageIdsAsync(CancellationToken.None);
+
+        // Assert: the two most recent rows survive the cap.
+        ids.Should()
+            .Equal(
+                ["meeting-newest", "meeting-middle"],
+                "Defaults.Limit caps the recency-ordered result"
+            );
+    }
+
+    [TestMethod]
+    public async Task GetCandidateMessageIds_preserves_recency_ordering_across_kinds()
+    {
+        // Arrange: interleaved meeting and mail rows, all inside the window.
+        var now = DateTimeOffset.UtcNow;
+        using var repository = await CreateRepositoryAsync(
+            BuildMessage("meeting-1h", "meeting", now.AddHours(-1)),
+            BuildMessage("mail-2h", "mail", now.AddHours(-2)),
+            BuildMessage("meeting-3h", "meeting", now.AddHours(-3)),
+            BuildMessage("mail-4h", "mail", now.AddHours(-4))
+        );
+        var source = CreateSource(repository);
+
+        // Act
+        var ids = await source.GetCandidateMessageIdsAsync(CancellationToken.None);
+
+        // Assert: newest-first ordering interleaves both kinds.
+        ids.Should()
+            .Equal(
+                ["meeting-1h", "mail-2h", "meeting-3h", "mail-4h"],
+                "recency ordering is preserved across meeting and mail rows"
+            );
+    }
+}

--- a/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerDedupeTests.cs
@@ -43,7 +43,10 @@ public sealed class SchedulingWorkerDedupeTests
             PreferredDays = Array.Empty<string>(),
         };
 
-    private static SchedulingMessageDto Message(string id) =>
+    private static SchedulingMessageDto Message(
+        string id,
+        string? meetingMessageType = "meetingRequest"
+    ) =>
         new(
             Id: id,
             Subject: "Project sync",
@@ -56,7 +59,7 @@ public sealed class SchedulingWorkerDedupeTests
             CcRecipients: Array.Empty<AttendeeDto>(),
             ConversationId: "conv-1",
             ReceivedDateTime: Now,
-            MeetingMessageType: "meetingRequest",
+            MeetingMessageType: meetingMessageType,
             Importance: "normal"
         );
 
@@ -73,6 +76,17 @@ public sealed class SchedulingWorkerDedupeTests
                 .ReturnsAsync((SchedulingEventDto?)null);
         }
 
+        // Explicit stub (spec #103 Constraints & Risks): the calendar-view fallback runs
+        // on every direct-lookup miss, so the empty window is stated, not a Moq default.
+        service
+            .Setup(s =>
+                s.GetCalendarViewAsync(
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(Array.Empty<SchedulingEventDto>());
         service
             .Setup(s => s.GetMailboxSettingsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(
@@ -292,5 +306,59 @@ public sealed class SchedulingWorkerDedupeTests
             s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()),
             Times.Once
         );
+    }
+
+    [TestMethod]
+    public async Task RunCycle_OrdinaryMailAcrossTwoCycles_SendsOnceWithUnchangedKeyShape()
+    {
+        // Arrange (#103 AC-6): a plain-mail candidate (non-meeting MeetingMessageType)
+        // whose direct event lookup misses, re-listed across two scheduling cycles. A
+        // stateful store double proves consult-before-send and record-after-send with
+        // the unchanged #101 key shape.
+        var mailKey = SentActionKey.Build(
+            "owner@contoso.com",
+            "mail-1",
+            SentActionKey.ProposalReply
+        );
+        var service = ServiceReturningContext("mail-1");
+        service
+            .Setup(s => s.GetSchedulingMessageAsync("mail-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Message("mail-1", meetingMessageType: null));
+        service
+            .Setup(s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var recordedKeys = new HashSet<string>(StringComparer.Ordinal);
+        var store = new Mock<ISentActionStore>();
+        store
+            .Setup(s => s.IsRecordedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string key, CancellationToken _) => recordedKeys.Contains(key));
+        store
+            .Setup(s =>
+                s.RecordAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .Callback((string key, DateTimeOffset _, CancellationToken _) => recordedKeys.Add(key))
+            .Returns(Task.CompletedTask);
+        var worker = Worker(service, store.Object, CandidateSource("mail-1"), Options(true));
+
+        // Act: the cursor-less candidate source re-lists the same message every cycle.
+        await worker.RunSchedulingCycleAsync(CancellationToken.None);
+        await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert: exactly one outbound proposal; the store is consulted each cycle and
+        // recorded once, always under the unchanged #101 key shape.
+        service.Verify(
+            s => s.SendMailAsync(It.IsAny<SendMailRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+        store.Verify(
+            s => s.IsRecordedAsync(mailKey, It.IsAny<CancellationToken>()),
+            Times.Exactly(2)
+        );
+        store.Verify(s => s.RecordAsync(mailKey, Now, It.IsAny<CancellationToken>()), Times.Once);
+        recordedKeys.Should().Equal([mailKey], "no other key shape may be recorded");
     }
 }

--- a/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerFallbackTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerFallbackTests.cs
@@ -1,0 +1,312 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using OpenClaw.Core.Agent;
+using OpenClaw.Core.Agent.Runtime;
+using OpenClaw.HostAdapter.Contracts;
+using SendMailRequest = OpenClaw.Core.Agent.SendMailRequest;
+
+namespace OpenClaw.Core.Tests.Agent.Runtime;
+
+/// <summary>
+/// Unit tests for the calendar-view fallback in the <see cref="SchedulingWorker"/>
+/// pipeline (#103 AC-4, AC-5): a direct event-lookup miss fetches the forward calendar
+/// window from the injected <see cref="TimeProvider"/> now, a matcher hit hydrates the
+/// event context through the same Normalize call formal traffic uses, a no-match or
+/// empty window falls through to message-only triage, and a non-positive
+/// <c>CalendarViewFallbackDays</c> skips the fetch entirely.
+/// </summary>
+[TestClass]
+public sealed class SchedulingWorkerFallbackTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 6, 8, 8, 0, 0, TimeSpan.Zero);
+
+    private static AgentPolicyOptions Options(
+        bool sendEnabled = false,
+        int calendarViewFallbackDays = 14
+    ) =>
+        new()
+        {
+            InternalDomains = new[] { "contoso.com" },
+            InternalDomain = "contoso.com",
+            SendEnabled = sendEnabled,
+            CalendarViewFallbackDays = calendarViewFallbackDays,
+            CalendarWriteEnabled = false,
+            NoMeetingBlocks = Array.Empty<string>(),
+            MinNoticeMinutes = 0,
+            PreferredDays = Array.Empty<string>(),
+        };
+
+    private static SchedulingMessageDto Message(string id = "msg-1") =>
+        new(
+            Id: id,
+            Subject: "Project sync",
+            BodyPreview: "Can we move this?",
+            BodyContent: null,
+            BodyContentType: null,
+            From: new AttendeeDto("Colleague", "colleague@contoso.com"),
+            Sender: new AttendeeDto("Colleague", "colleague@contoso.com"),
+            ToRecipients: Array.Empty<AttendeeDto>(),
+            CcRecipients: Array.Empty<AttendeeDto>(),
+            ConversationId: "conv-1",
+            ReceivedDateTime: Now,
+            MeetingMessageType: null,
+            Importance: "normal"
+        );
+
+    private static SchedulingEventDto WindowEvent(string? subject, string id = "evt-1") =>
+        new(
+            Id: id,
+            ICalUId: "ical-1",
+            SeriesMasterId: null,
+            Subject: subject,
+            BodyPreview: null,
+            BodyContent: null,
+            BodyContentType: null,
+            Organizer: new AttendeeDto("Organizer", "organizer@contoso.com"),
+            RequiredAttendees: Array.Empty<AttendeeDto>(),
+            OptionalAttendees: Array.Empty<AttendeeDto>(),
+            ResourceAttendees: Array.Empty<AttendeeDto>(),
+            Categories: Array.Empty<string>(),
+            IsOrganizer: false,
+            IsOnlineMeeting: false,
+            AllowNewTimeProposals: true,
+            Sensitivity: "normal",
+            Start: Now.AddDays(2),
+            StartTimeZone: null,
+            End: Now.AddDays(2).AddHours(1),
+            EndTimeZone: null,
+            LastModifiedDateTime: null,
+            Type: null
+        );
+
+    /// <summary>
+    /// Builds a service mock whose direct event lookup misses and whose calendar-view
+    /// fallback returns the given window (explicit stub — never Moq loose defaults).
+    /// </summary>
+    private static Mock<ISchedulingService> ServiceWithLookupMiss(
+        IReadOnlyList<SchedulingEventDto> windowEvents
+    )
+    {
+        var service = new Mock<ISchedulingService>();
+        service
+            .Setup(s => s.GetSchedulingMessageAsync("msg-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Message());
+        service
+            .Setup(s => s.GetEventForMessageAsync("msg-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SchedulingEventDto?)null);
+        service
+            .Setup(s =>
+                s.GetCalendarViewAsync(
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(windowEvents);
+        service
+            .Setup(s => s.GetMailboxSettingsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new MailboxSettingsDto(
+                    "UTC",
+                    new[]
+                    {
+                        DayOfWeek.Monday,
+                        DayOfWeek.Tuesday,
+                        DayOfWeek.Wednesday,
+                        DayOfWeek.Thursday,
+                        DayOfWeek.Friday,
+                    },
+                    new TimeOnly(9, 0),
+                    new TimeOnly(17, 0)
+                )
+            );
+        service
+            .Setup(s =>
+                s.GetFreeBusyAsync(
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(
+                new FreeBusyScheduleDto("owner@contoso.com", Array.Empty<BusyIntervalDto>())
+            );
+        return service;
+    }
+
+    private static Mock<ISchedulingCandidateSource> CandidateSource(params string[] ids)
+    {
+        var source = new Mock<ISchedulingCandidateSource>();
+        source
+            .Setup(s => s.GetCandidateMessageIdsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ids);
+        return source;
+    }
+
+    private static SchedulingWorker Worker(
+        Mock<ISchedulingService> service,
+        AgentPolicyOptions options
+    )
+    {
+        var sentActionStore = new Mock<ISentActionStore>();
+        sentActionStore
+            .Setup(s => s.IsRecordedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        return new(
+            service.Object,
+            sentActionStore.Object,
+            CandidateSource("msg-1").Object,
+            Microsoft.Extensions.Options.Options.Create(options),
+            new FakeTimeProvider(Now),
+            NullLogger<SchedulingWorker>.Instance
+        );
+    }
+
+    [TestMethod]
+    public async Task RunCycle_LookupMiss_FetchesCalendarViewFromNowToNowPlusFourteenDays()
+    {
+        // Arrange: direct lookup misses; the default fallback window is 14 days.
+        var service = ServiceWithLookupMiss(Array.Empty<SchedulingEventDto>());
+        var worker = Worker(service, Options());
+
+        // Act
+        await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert: window bounds come from the injected TimeProvider, not wall clock.
+        service.Verify(
+            s => s.GetCalendarViewAsync(Now, Now.AddDays(14), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+
+    [TestMethod]
+    public async Task RunCycle_WindowEventClearsThreshold_HydratesEventContextIntoSendPath()
+    {
+        // Arrange: the window event shares two subject tokens with the message
+        // ("project", "sync" -> score 4), so the matcher accepts it. Normalize prefers
+        // the event subject, which is observable in the outbound reply subject.
+        var matched = WindowEvent(subject: "Project sync planning");
+        var service = ServiceWithLookupMiss([matched]);
+        var captured = new List<SendMailRequest>();
+        service
+            .Setup(s => s.SendMailAsync(Capture.In(captured), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var worker = Worker(service, Options(sendEnabled: true));
+
+        // Act
+        await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert: the pipeline behaved event-linked — the reply subject carries the
+        // matched event's subject through MeetingContextNormalizer.Normalize.
+        captured
+            .Should()
+            .ContainSingle()
+            .Which.Subject.Should()
+            .Be("Re: Project sync planning", "a matched window event hydrates the context");
+    }
+
+    [TestMethod]
+    public async Task RunCycle_EmptyWindow_ProceedsMessageOnlyWithoutThrowing()
+    {
+        // Arrange: the fallback window is empty; triage must proceed message-only.
+        var service = ServiceWithLookupMiss(Array.Empty<SchedulingEventDto>());
+        var captured = new List<SendMailRequest>();
+        service
+            .Setup(s => s.SendMailAsync(Capture.In(captured), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var worker = Worker(service, Options(sendEnabled: true));
+
+        // Act
+        var act = async () => await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert: no exception, the window was consulted, and the reply subject is the
+        // message subject (message-only context).
+        await act.Should().NotThrowAsync("an empty window degrades to message-only triage");
+        service.Verify(
+            s =>
+                s.GetCalendarViewAsync(
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+        captured
+            .Should()
+            .ContainSingle()
+            .Which.Subject.Should()
+            .Be("Re: Project sync", "message-only triage uses the message subject");
+    }
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(-1)]
+    public async Task RunCycle_NonPositiveFallbackDays_NeverFetchesCalendarView(int days)
+    {
+        // Arrange: the documented opt-out — a non-positive window skips the fetch.
+        var service = ServiceWithLookupMiss(Array.Empty<SchedulingEventDto>());
+        var worker = Worker(service, Options(calendarViewFallbackDays: days));
+
+        // Act
+        await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert
+        service.Verify(
+            s =>
+                s.GetCalendarViewAsync(
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    [TestMethod]
+    public async Task RunCycle_AllWindowEventsBelowThreshold_FallsThroughToMessageOnly()
+    {
+        // Arrange: one shared token ("sync" -> score 2) stays below the threshold of 4,
+        // so the matcher rejects every window event.
+        var belowThreshold = WindowEvent(subject: "Design sync");
+        var service = ServiceWithLookupMiss([belowThreshold]);
+        var captured = new List<SendMailRequest>();
+        service
+            .Setup(s => s.SendMailAsync(Capture.In(captured), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var worker = Worker(service, Options(sendEnabled: true));
+
+        // Act
+        await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert: the reply subject is message-derived, proving message-only triage.
+        captured
+            .Should()
+            .ContainSingle()
+            .Which.Subject.Should()
+            .Be("Re: Project sync", "sub-threshold window events must not hydrate the context");
+    }
+
+    [TestMethod]
+    public async Task RunCycle_FailureEnvelopeMappedToEmptyWindow_ProceedsWithoutException()
+    {
+        // Arrange: HostAdapterSchedulingService maps a failure envelope to an empty
+        // list; the pipeline must degrade to message-only triage without throwing.
+        var service = ServiceWithLookupMiss(Array.Empty<SchedulingEventDto>());
+        var worker = Worker(service, Options());
+
+        // Act
+        var act = async () => await worker.RunSchedulingCycleAsync(CancellationToken.None);
+
+        // Assert: no exception and the deterministic pipeline continued past the
+        // fallback (mailbox settings are consulted by the proposal stage).
+        await act.Should().NotThrowAsync("an unavailable window read degrades to no-match");
+        service.Verify(s => s.GetMailboxSettingsAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs
+++ b/tests/OpenClaw.Core.Tests/Agent/Runtime/SchedulingWorkerTests.cs
@@ -80,6 +80,17 @@ public sealed class SchedulingWorkerTests
         service
             .Setup(s => s.GetEventForMessageAsync("msg-1", It.IsAny<CancellationToken>()))
             .ReturnsAsync((SchedulingEventDto?)null);
+        // Explicit stub (spec #103 Constraints & Risks): the calendar-view fallback runs
+        // on every direct-lookup miss, so the empty window is stated, not a Moq default.
+        service
+            .Setup(s =>
+                s.GetCalendarViewAsync(
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<DateTimeOffset>(),
+                    It.IsAny<CancellationToken>()
+                )
+            )
+            .ReturnsAsync(Array.Empty<SchedulingEventDto>());
         service
             .Setup(s => s.GetMailboxSettingsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(MailboxSettings());


### PR DESCRIPTION
## Summary

- Ordinary scheduling mail ("can we move this?", "what works next week?") is now triaged, not just formal meeting invitations — implementing the master specification's second input class (`docs/open-claw-approach.master.md` §2.2).
- `CacheSchedulingCandidateSource` widens from meeting-only to all cached messages.
- New pure `RelatedEventMatcher` ports the master's §9.2 `chooseMostLikelyRelatedEvent` heuristic exactly: +2 per subject token (>= 4 chars), +3 per participant email overlap, accept only at score >= 4, with deterministic order-independent tie-breaking (earliest `Start`, then ordinal `Id`).
- On an event-by-id miss, `SchedulingWorker` fetches a bounded calendarView window (`AgentPolicyOptions.CalendarViewFallbackDays`, default 14 days; non-positive disables) and applies the matcher; no-match proceeds with message-only triage as before.
- 30 new tests (matcher unit + CsCheck property, candidate widening, worker fallback, ordinary-mail dedupe regression); 731 total passing; pooled coverage 90.81% line / 80.62% branch.

## Why

Only formal meeting traffic reached the deterministic triage engine; regular scheduling threads were never selected as candidates, and the runtime had no `calendarView` fallback with the subject/attendee-overlap matching the master mandates (§9.2, §9.3 step 3). Tracked as gap F7 in `docs/research/2026-07-01-open-claw-vision-gap-analysis.md`; issue #103.

## What Changed

**Production (`OpenClaw.Core` only; pure logic in Agent, I/O in Runtime)**
- `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs` (new) — pure scorer/selector reusing `MeetingContextNormalizer` email helpers.
- `src/OpenClaw.Core/Agent/Runtime/CacheSchedulingCandidateSource.cs` — kind literal `"meeting"` → `"all"` (repository already supported it).
- `src/OpenClaw.Core/Agent/Contracts/AgentPolicyOptions.cs` — `CalendarViewFallbackDays` (default 14).
- `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` — fallback: miss → `GetCalendarViewAsync(now, now + fallbackDays)` → matcher → hydrated or message-only context.

**Tests**
- `RelatedEventMatcherTests` (14) + `RelatedEventMatcherPropertyTests` (4, CsCheck).
- `CacheSchedulingCandidateSourceTests` (new, in-memory shared-cache SQLite; fail-before observed).
- `SchedulingWorkerFallbackTests` (7; fail-before observed) and an ordinary-mail dedupe regression in `SchedulingWorkerDedupeTests`.

**Docs / evidence**
- `docs/features/active/2026-07-02-ordinary-mail-candidates-103/` — issue/spec/user-story, plan, baseline/regression/QA-gate evidence, audit artifacts (all pass the MCP orchestration-artifact validator).

## Architecture / How It Fits Together

The fallback stays behind the existing seams: the worker calls `ISchedulingService.GetCalendarViewAsync` (locally served from the MailBridge cache through the Graph-shaped adapter — the same surface Product Increment 1 replaces with Microsoft Graph), and all scoring/selection is pure and host-neutral, so the logic carries to PI-1 unchanged.

## Verification

**Completed** (evidence under `docs/features/active/2026-07-02-ordinary-mail-candidates-103/evidence/`):
- Two expect-fail evidence sets (candidate widening EXIT 1; worker fallback EXIT 1), both passing after implementation.
- Final toolchain single pass: format clean (217 files), build 0 warnings / 0 errors, 731 passed / 0 failed / 5 pre-existing environment-gated skips.
- Coverage: pooled 90.81% line / 80.62% branch (no regression); `RelatedEventMatcher.cs` 100% line / 89.58% branch; T1 property-test gate satisfied.
- Independent feature review at branch head: zero blocking findings, Go; audit artifacts MCP-validated.

**Recommended**:
- `dotnet test OpenClaw.MailBridge.sln --settings mailbridge.runsettings --filter "FullyQualifiedName~RelatedEventMatcher|FullyQualifiedName~SchedulingWorkerFallback|FullyQualifiedName~CacheSchedulingCandidateSource"`

## Backward Compatibility / Migration Notes

- No wire-contract, HostAdapter, MailBridge, or schema changes. Formal meeting-traffic handling is unchanged.
- Behavior change: more messages are processed per cycle (ordinary mail included); the #101 dedupe store and the default-off `SendEnabled` gate bound the effect.

## Risks and Mitigations

- Heuristic matching: fixed deterministic weights/threshold per the master's requirement that decisions come from code; sub-threshold matches fall through to message-only triage rather than guessing.
- Volume increase: bounded by the existing lookback window, dedupe store, and kill switches.

## Review Guide

1. `src/OpenClaw.Core/Agent/RelatedEventMatcher.cs`
2. `src/OpenClaw.Core/Agent/Runtime/SchedulingWorker.Pipeline.cs` (fallback placement)
3. `CacheSchedulingCandidateSource.cs` + `AgentPolicyOptions.cs` (one-line-scale changes)
4. Test suites; docs/evidence are mechanical.

## Follow-ups

- Minor: inject `TimeProvider` into `CacheSchedulingCandidateSource` (pre-existing `DateTimeOffset.UtcNow` anchor).
- Program continues per `docs/research/2026-07-01-open-claw-vision-gap-analysis.md` (next: F8 recurring 1:1 move-history persistence).

## GitHub Auto-close

- Closes #103
